### PR TITLE
Add custom tags and allow the script to filter items based on tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ verify:
 #
 # Example:
 #   make import
+#   make import TAGS=online-starter,online-professional
 import:
-	python import_content.py
+	python import_content.py -t ${TAGS}
 .PHONY: import

--- a/README.md
+++ b/README.md
@@ -52,15 +52,15 @@ Community templates and image streams are **not** provided or supported by Red H
 
 ### Running the Script
 
-    $ make import
-    
+    $ make import TAGS=<tag>,...
+
 ## Verifying Your Updates
 
     $ make verify
-    
+
 The `make verify` command runs the following checks:
  - verifies YAML syntax
- - verifies the Python script *(using pylint)* 
+ - verifies the Python script *(using pylint)*
  - verifies that make import has been run
 
 ## Contributing
@@ -89,11 +89,19 @@ That's it!  Your pull request will be reviewed by a member of the OpenShift Team
             regex: # (optional) matched against ['metadata']['name'] in the json file
             suffix: # (optional) suffix for the file that is created ex: ruby-<suffix>.json
             docs: # (optional) web address of the documentation for this image-stream
+            # Custom tags for OpenShift are added below if needed
+            openshift: # (optional) flag for OpenShift
+                - online-starter # (optional) flag for OpenShift Online Starter
+                - online-professional # (optional) flag for OpenShift Online Professional
         templates: # (optional) list of templates to process into the above folder
           - location: # (required) github url to a template or folder of templates in json format
             regex: # (optional) matched against ['metadata']['name'] in the json file
             suffix: # (optional) suffix for the file that is created ex: ruby-<suffix>.json
             docs: # (optional) web address of the documentation for this template
+            # Custom tags for OpenShift are added below if needed
+            openshift: # (optional) flag for OpenShift
+                - online-starter # (optional) flag for OpenShift Online Starter
+                - online-professional # (optional) flag for OpenShift Online Professional
 
 #### Variables
 
@@ -112,6 +120,8 @@ Listings in the **official.yaml** file will be created in a sub folder of the  *
 #### folder_name
 
 The **folder_name** is a sub folder which represents a logical grouping for a set of templates or image-streams in the top level **official** or **community** folders.
+
+For custom tags option, templates are imported into <tag>/templates/ directory while imagestreams are imported into <tag>/imagestreams/
 
 #### location
 

--- a/community.yaml
+++ b/community.yaml
@@ -3,6 +3,9 @@ data:
     templates:
       - location: https://raw.githubusercontent.com/luciddreamz/laravel-ex/master/openshift/templates/laravel-mysql.json
         docs: https://github.com/luciddreamz/laravel-ex/blob/master/readme.md
+        openshift:
+          - online-starter
+          - online-professional
       - location: https://raw.githubusercontent.com/luciddreamz/laravel-ex/master/openshift/templates/laravel-postgresql.json
         docs: https://github.com/luciddreamz/laravel-ex/blob/master/readme.md
       - location: https://raw.githubusercontent.com/luciddreamz/laravel-ex/master/openshift/templates/laravel-sqlite.json
@@ -27,6 +30,9 @@ data:
         docs: https://github.com/openshift-s2i/s2i-wildfly/blob/master/README.md
         regex: wildfly
         suffix: centos7
+        openshift:
+          - online-starter
+          - online-professional
   infinispan:
     imagestreams:
       - location: https://raw.githubusercontent.com/infinispan/infinispan-openshift-templates/master/imagestreams/infinispan-centos7.json

--- a/official.yaml
+++ b/official.yaml
@@ -1,5 +1,5 @@
 variables:
-  xpaas_version: ose-v1.3.5
+  xpaas_version: ose-v1.3.6
 data:
   ruby:
     imagestreams:
@@ -7,18 +7,27 @@ data:
         docs: https://github.com/sclorg/s2i-ruby-container/blob/master/README.md
         regex: ruby
         suffix: rhel7
+        openshift:
+          - online-starter
+          - online-professional
   rails:
     templates:
       - location: https://raw.githubusercontent.com/openshift/rails-ex/master/openshift/templates/rails-postgresql.json
         docs: https://github.com/openshift/rails-ex/blob/master/README.md
       - location: https://raw.githubusercontent.com/openshift/rails-ex/master/openshift/templates/rails-postgresql-persistent.json
         docs: https://github.com/openshift/rails-ex/blob/master/README.md
+        openshift:
+          - online-starter
+          - online-professional
   python:
     imagestreams:
       - location: https://raw.githubusercontent.com/openshift/origin/master/examples/image-streams/image-streams-rhel7.json
         docs: https://github.com/sclorg/s2i-python-container/blob/master/README.md
         regex: python
         suffix: rhel7
+        openshift:
+          - online-starter
+          - online-professional
   django:
     templates:
       - location: https://raw.githubusercontent.com/openshift/django-ex/master/openshift/templates/django.json
@@ -27,6 +36,9 @@ data:
         docs: https://github.com/openshift/django-ex/blob/master/README.md
       - location: https://raw.githubusercontent.com/openshift/django-ex/master/openshift/templates/django-postgresql-persistent.json
         docs: https://github.com/openshift/django-ex/blob/master/README.md
+        openshift:
+          - online-starter
+          - online-professional
   nodejs:
     templates:
       - location: https://raw.githubusercontent.com/openshift/nodejs-ex/master/openshift/templates/nodejs.json
@@ -35,17 +47,26 @@ data:
         docs: https://github.com/openshift/nodejs-ex/blob/master/README.md
       - location: https://raw.githubusercontent.com/openshift/nodejs-ex/master/openshift/templates/nodejs-mongodb-persistent.json
         docs: https://github.com/openshift/nodejs-ex/blob/master/README.md
+        openshift:
+          - online-starter
+          - online-professional
     imagestreams:
       - location: https://raw.githubusercontent.com/openshift/origin/master/examples/image-streams/image-streams-rhel7.json
         docs: https://github.com/sclorg/s2i-nodejs-container/blob/master/README.md
         regex: nodejs
         suffix: rhel7
+        openshift:
+          - online-starter
+          - online-professional
   perl:
     imagestreams:
       - location: https://raw.githubusercontent.com/openshift/origin/master/examples/image-streams/image-streams-rhel7.json
         docs: https://github.com/sclorg/s2i-perl-container/blob/master/README.md
         regex: perl
         suffix: rhel7
+        openshift:
+          - online-starter
+          - online-professional
   dancer:
     templates:
       - location: https://raw.githubusercontent.com/openshift/dancer-ex/master/openshift/templates/dancer.json
@@ -54,12 +75,18 @@ data:
         docs: https://github.com/openshift/dancer-ex/blob/master/README.md
       - location: https://raw.githubusercontent.com/openshift/dancer-ex/master/openshift/templates/dancer-mysql-persistent.json
         docs: https://github.com/openshift/dancer-ex/blob/master/README.md
+        openshift:
+          - online-starter
+          - online-professional
   php:
     imagestreams:
       - location: https://raw.githubusercontent.com/openshift/origin/master/examples/image-streams/image-streams-rhel7.json
         docs: https://github.com/sclorg/s2i-php-container/blob/master/README.md
         regex: php
         suffix: rhel7
+        openshift:
+          - online-starter
+          - online-professional
   cakephp:
     templates:
       - location: https://raw.githubusercontent.com/openshift/cakephp-ex/master/openshift/templates/cakephp.json
@@ -68,61 +95,114 @@ data:
         docs: https://github.com/openshift/cakephp-ex/blob/master/README.md
       - location: https://raw.githubusercontent.com/openshift/cakephp-ex/master/openshift/templates/cakephp-mysql-persistent.json
         docs: https://github.com/openshift/cakephp-ex/blob/master/README.md
+        openshift:
+          - online-starter
+          - online-professional
+  jenkins:
+    templates:
+      - location: https://raw.githubusercontent.com/openshift/origin/master/examples/jenkins/jenkins-ephemeral-template.json
+        docs: https://github.com/openshift/origin/blob/master/examples/jenkins/README.md
+      - location: https://raw.githubusercontent.com/openshift/origin/master/examples/jenkins/jenkins-persistent-template.json
+        docs: https://github.com/openshift/origin/blob/master/examples/jenkins/README.md
+        openshift:
+          - online-starter
+          - online-professional
+    imagestreams:
+      - location: https://raw.githubusercontent.com/openshift/origin/master/examples/image-streams/image-streams-rhel7.json
+        docs: https://github.com/openshift/origin/blob/master/examples/jenkins/README.md
+        regex: jenkins
+        suffix: rhel7
+        openshift:
+          - online-starter
+          - online-professional
   mariadb:
     templates:
       - location: https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/mariadb-ephemeral-template.json
         docs: https://github.com/openshift/origin/blob/master/examples/db-templates/README.md
       - location: https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/mariadb-persistent-template.json
         docs: https://github.com/openshift/origin/blob/master/examples/db-templates/README.md
+        openshift:
+          - online-starter
+          - online-professional
     imagestreams:
       - location: https://raw.githubusercontent.com/openshift/origin/master/examples/image-streams/image-streams-rhel7.json
         docs: https://github.com/sclorg/mariadb-container/blob/master/README.md
         regex: mariadb
         suffix: rhel7
+        openshift:
+          - online-starter
+          - online-professional
   mongodb:
     templates:
       - location: https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/mongodb-ephemeral-template.json
         docs: https://github.com/openshift/origin/blob/master/examples/db-templates/README.md
       - location: https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/mongodb-persistent-template.json
         docs: https://github.com/openshift/origin/blob/master/examples/db-templates/README.md
+        openshift:
+          - online-starter
+          - online-professional
     imagestreams:
       - location: https://raw.githubusercontent.com/openshift/origin/master/examples/image-streams/image-streams-rhel7.json
         docs: https://github.com/sclorg/mongodb-container/blob/master/README.md
         regex: mongodb
         suffix: rhel7
+        openshift:
+          - online-starter
+          - online-professional
   mysql:
     templates:
       - location: https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/mysql-ephemeral-template.json
         docs: https://github.com/openshift/origin/blob/master/examples/db-templates/README.md
       - location: https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/mysql-persistent-template.json
         docs: https://github.com/openshift/origin/blob/master/examples/db-templates/README.md
+        openshift:
+          - online-starter
+          - online-professional
     imagestreams:
       - location: https://raw.githubusercontent.com/openshift/origin/master/examples/image-streams/image-streams-rhel7.json
         docs: https://github.com/sclorg/mysql-container/blob/master/README.md
         regex: mysql
         suffix: rhel7
+        openshift:
+          - online-starter
+          - online-professional
   postgresql:
     templates:
       - location: https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/postgresql-ephemeral-template.json
         docs: https://github.com/openshift/origin/blob/master/examples/db-templates/README.md
       - location: https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/postgresql-persistent-template.json
         docs: https://github.com/openshift/origin/blob/master/examples/db-templates/README.md
+        openshift:
+          - online-starter
+          - online-professional
     imagestreams:
       - location: https://raw.githubusercontent.com/openshift/origin/master/examples/image-streams/image-streams-rhel7.json
         docs: https://github.com/sclorg/postgresql-container/blob/master/README.md
         regex: postgresql
         suffix: rhel7
+        openshift:
+          - online-starter
+          - online-professional
   redis:
     templates:
       - location: https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/redis-ephemeral-template.json
         docs: https://github.com/openshift/origin/blob/master/examples/db-templates/README.md
+        openshift:
+          - online-starter
+          - online-professional
       - location: https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/redis-persistent-template.json
         docs: https://github.com/openshift/origin/blob/master/examples/db-templates/README.md
+        openshift:
+          - online-starter
+          - online-professional
     imagestreams:
       - location: https://raw.githubusercontent.com/openshift/origin/master/examples/image-streams/image-streams-rhel7.json
         docs: https://github.com/sclorg/redis-container/blob/master/README.md
         regex: redis
         suffix: rhel7
+        openshift:
+          - online-starter
+          - online-professional
   amq:
     templates:
       - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{xpaas_version}/amq/amq62-basic.json
@@ -235,12 +315,26 @@ data:
         docs: https://github.com/jboss-openshift/application-templates/blob/{xpaas_version}/docs/eap/eap70-postgresql-s2i.adoc
       - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{xpaas_version}/eap/eap70-sso-s2i.json
         docs: https://github.com/jboss-openshift/application-templates/blob/{xpaas_version}/docs/eap/eap70-sso-s2i.adoc
-
     imagestreams:
       - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{xpaas_version}/jboss-image-streams.json
         docs: https://access.redhat.com/documentation/en/red-hat-jboss-middleware-for-openshift/3/paged/red-hat-jboss-enterprise-application-platform-for-openshift/
         regex: jboss-eap
         suffix: rhel7
+  java:
+    templates:
+      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{xpaas_version}/openjdk/openjdk18-web-basic-s2i.json
+        docs: https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/paged/red_hat_java_s2i_for_openshift/
+        openshift:
+          - online-starter
+          - online-professional
+    imagestreams:
+      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{xpaas_version}/jboss-image-streams.json
+        docs: https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/paged/red_hat_java_s2i_for_openshift/
+        regex: redhat-openjdk18
+        suffix: rhel7
+        openshift:
+          - online-starter
+          - online-professional
   processserver:
     templates:
       - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{xpaas_version}/processserver/processserver63-amq-mysql-persistent-s2i.json
@@ -303,6 +397,9 @@ data:
         docs: https://github.com/jboss-openshift/application-templates/blob/{xpaas_version}/docs/webserver/jws30-tomcat7-postgresql-s2i.adoc
       - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{xpaas_version}/webserver/jws30-tomcat8-basic-s2i.json
         docs: https://github.com/jboss-openshift/application-templates/blob/{xpaas_version}/docs/webserver/jws30-tomcat8-basic-s2i.adoc
+        openshift:
+          - online-starter
+          - online-professional
       - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{xpaas_version}/webserver/jws30-tomcat8-https-s2i.json
         docs: https://github.com/jboss-openshift/application-templates/blob/{xpaas_version}/docs/webserver/jws30-tomcat8-https-s2i.adoc
       - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{xpaas_version}/webserver/jws30-tomcat8-mongodb-persistent-s2i.json
@@ -322,6 +419,9 @@ data:
         docs: https://access.redhat.com/documentation/en/red-hat-jboss-middleware-for-openshift/3/paged/red-hat-jboss-web-server-for-openshift/
         regex: jboss-webserver
         suffix: rhel7
+        openshift:
+          - online-starter
+          - online-professional
   fis:
     templates:
       - location: https://raw.githubusercontent.com/jboss-fuse/application-templates/master/quickstarts/karaf2-camel-amq-template.json
@@ -359,6 +459,9 @@ data:
       - location: https://raw.githubusercontent.com/redhat-developer/s2i-dotnetcore/master/dotnet_imagestreams.json
         docs: https://github.com/redhat-developer/s2i-dotnetcore/blob/master/README.md
         suffix: rhel7
+        openshift:
+          - online-starter
+          - online-professional
   3scale:
     templates:
       - location: https://raw.githubusercontent.com/openshift/openshift-ansible/master/roles/openshift_examples/files/examples/v1.5/quickstart-templates/apicast-gateway-template.yml


### PR DESCRIPTION
The new tags for online-starter and online-professional are added to selected
templates and imagestreams. The script is modified to accept the custom tags via
flag '-t' or '--tags' and custom tags are concatenated but separated by comma.

If custom tags are provided, all templates and imagestreams will be imported under
the folder with the name of the tag(s) and under /templates or /imagestreams
respectively. There are not further sub-directori(es).

The index.json and README.rd are also added into the folder(s) to provide further
information in case users need to locate the file(s) or source(s).

The script is now able to detect file collision and will append index numer to
file name to avoid file overwritten issue.

Updated the README to reflect new Online tags for YAML files and further details.

Signed-off-by: Vu Dinh <vdinh@redhat.com>