### PR TITLE
Per request from RH-SSO PM tag RH-SSO sso71-https.json application template

### DIFF
--- a/official.yaml
+++ b/official.yaml
@@ -409,6 +409,9 @@ data:
     templates:
       - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{xpaas_version}/sso/sso71-https.json
         docs: https://github.com/jboss-openshift/application-templates/blob/{xpaas_version}/docs/sso/sso71-https.adoc
+        tags:
+          - online-starter
+          - online-professional
       - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{xpaas_version}/sso/sso71-mysql-persistent.json
         docs: https://github.com/jboss-openshift/application-templates/blob/{xpaas_version}/docs/sso/sso71-mysql-persistent.adoc
       - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{xpaas_version}/sso/sso71-mysql.json


### PR DESCRIPTION
as available for both OpenShift Online Starter and OpenShift Online Professional <br/>

The [prerequisite advisory](https://access.redhat.com/errata/RHEA-2018:0222) has been released already, this one is ready for review.

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com> <br/>

@bparees PTAL<br/>

Thank you, Jan