### PR TITLE
Removing starter tag from 3scale template

### DIFF
--- a/official.yaml
+++ b/official.yaml
@@ -490,11 +490,9 @@ data:
       - location: https://raw.githubusercontent.com/3scale/3scale-amp-openshift-templates/master/apicast-gateway/apicast.yml
         docs: https://access.redhat.com/documentation/en-us/red_hat_3scale/2.saas/html/deployment_options/apicast-openshift
         tags:
-          - online-starter
           - online-professional
     imagestreams:
       - location: https://raw.githubusercontent.com/3scale/3scale-amp-openshift-templates/master/3scale-image-streams.yml
         docs: https://access.redhat.com/documentation/en-us/red_hat_3scale/2.saas/html/deployment_options/apicast-openshift
         tags:
-          - online-starter
           - online-professional


### PR DESCRIPTION
As for today, the 3scale resources consumption is not suitable for starter users.

We are working on lowering the resources consumption, but meanwhile we have decided to remove it from the starter templates.

`make import` and `make verify` has been executed:

```bash
Diffing current official directory against freshly generated official directory
SUCCESS: Generated official directory up to date.
Diffing current community directory against freshly generated community directory
SUCCESS: Generated community directory up to date.
```

Thanks!