### PR TITLE
update amq templates so only version 6.3 (basic & ssl) is available on OSO

### DIFF
--- a/official.yaml
+++ b/official.yaml
@@ -216,8 +216,6 @@ data:
     templates:
       - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{xpaas_version}/amq/amq62-basic.json
         docs: https://github.com/jboss-openshift/application-templates/blob/{xpaas_version}/docs/amq/amq62-basic.adoc
-        tags:
-          - online-professional
       - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{xpaas_version}/amq/amq62-persistent-ssl.json
         docs: https://github.com/jboss-openshift/application-templates/blob/{xpaas_version}/docs/amq/amq62-persistent-ssl.adoc
       - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{xpaas_version}/amq/amq62-persistent.json
@@ -226,6 +224,8 @@ data:
         docs: https://github.com/jboss-openshift/application-templates/blob/{xpaas_version}/docs/amq/amq62-ssl.adoc
       - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{xpaas_version}/amq/amq63-basic.json
         docs: https://github.com/jboss-openshift/application-templates/blob/{xpaas_version}/docs/amq/amq63-basic.adoc
+        tags:
+          - online-professional
       - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{xpaas_version}/amq/amq63-persistent-ssl.json
         docs: https://github.com/jboss-openshift/application-templates/blob/{xpaas_version}/docs/amq/amq63-persistent-ssl.adoc
       - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{xpaas_version}/amq/amq63-persistent.json


### PR DESCRIPTION
Openshift Online Pro should only have the basic & ssl template available for version 6.3
https://issues.jboss.org/browse/ENTMQ-2176

Removed the basic 6.2 template from OSO, and added the 6.3
