### PR TITLE
Revert "Removing starter tag from 3scale template"

### DIFF
--- a/official.yaml
+++ b/official.yaml
@@ -557,9 +557,11 @@ data:
       - location: https://raw.githubusercontent.com/3scale/3scale-amp-openshift-templates/master/apicast-gateway/apicast.yml
         docs: https://access.redhat.com/documentation/en-us/red_hat_3scale/2.saas/html/deployment_options/apicast-openshift
         tags:
+          - online-starter
           - online-professional
     imagestreams:
       - location: https://raw.githubusercontent.com/3scale/3scale-amp-openshift-templates/master/3scale-image-streams.yml
         docs: https://access.redhat.com/documentation/en-us/red_hat_3scale/2.saas/html/deployment_options/apicast-openshift
         tags:
+          - online-starter
           - online-professional

--- a/official/3scale/imagestreams/apicast-gateway.json
+++ b/official/3scale/imagestreams/apicast-gateway.json
@@ -11,7 +11,7 @@
         "tags": [
             {
                 "annotations": {
-                    "description": "3scale's APIcast API Gateway is an OpenResty application which consists of two parts:  Nginx configuration and Lua files.\n\nWARNING: By selecting this tag, your application  will automatically update to use the latest version of Httpd available on OpenShift,  including major versions updates.",
+                    "description": "3scale's APIcast API Gateway is an OpenResty application which consists of two parts: Nginx configuration and Lua files.\n\nWARNING: By selecting this tag, your application  will automatically update to use the latest version of 3scale available on OpenShift, including major versions updates.",
                     "iconClass": "icon-3scale",
                     "openshift.io/display-name": "3scale APIcast API Gateway (latest)",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
@@ -19,24 +19,24 @@
                 },
                 "from": {
                     "kind": "ImageStreamTag",
-                    "name": "1.4-2"
+                    "name": "2.1.0.GA"
                 },
                 "name": "latest"
             },
             {
                 "annotations": {
-                    "description": "3scale's APIcast is an NGINX based API gateway used to integrate your internal and external  API services with 3scale\u2019s API Management Platform. It supports OpenID connect to integrate  with external Identity Providers such as Red Hat Single Sign On, for API traffic authentication.",
+                    "description": "3scale's APIcast is an NGINX based API gateway used to integrate your internal and external API services with 3scale's API Management Platform. It supports OpenID connect to integrate with external Identity Providers such as Red Hat Single Sign On, for API traffic authentication.",
                     "iconClass": "icon-3scale",
                     "openshift.io/display-name": "3scale APIcast API Gateway (latest)",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
                     "tags": "api,gateway,3scale",
-                    "version": "1.4-2"
+                    "version": "2.1.0.GA"
                 },
                 "from": {
                     "kind": "DockerImage",
                     "name": "registry.access.redhat.com/3scale-amp21/apicast-gateway:1.4-2"
                 },
-                "name": "1.4-2"
+                "name": "2.1.0.GA"
             }
         ]
     }

--- a/official/3scale/templates/3scale-gateway.json
+++ b/official/3scale/templates/3scale-gateway.json
@@ -3,7 +3,7 @@
     "kind": "Template",
     "metadata": {
         "annotations": {
-            "description": "3scale's APIcast is an NGINX based API gateway used to integrate your internal and external  API services with 3scale\u2019s API Management Platform. It supports OpenID connect to integrate  with external Identity Providers such as Red Hat Single Sign On, for API traffic authentication ",
+            "description": "3scale's APIcast is an NGINX based API gateway used to integrate your internal and external  API services with 3scale's API Management Platform. It supports OpenID connect to integrate  with external Identity Providers such as Red Hat Single Sign On, for API traffic authentication ",
             "iconClass": "icon-3scale",
             "openshift.io/display-name": "3scale APIcast API Gateway",
             "openshift.io/documentation-url": "https://access.redhat.com/documentation/en-us/red_hat_3scale/2.saas/html/deployment_options/apicast-openshift",
@@ -20,7 +20,7 @@
                 "name": "${APICAST_NAME}"
             },
             "spec": {
-                "replicas": 2,
+                "replicas": 1,
                 "selector": {
                     "deploymentconfig": "${APICAST_NAME}"
                 },
@@ -95,7 +95,7 @@
                                         "value": "${OPENSSL_VERIFY}"
                                     }
                                 ],
-                                "image": "3scale-amp21/apicast-gateway:1.4-2",
+                                "image": "apicast-gateway:${AMP_RELEASE}",
                                 "imagePullPolicy": "Always",
                                 "livenessProbe": {
                                     "httpGet": {
@@ -115,7 +115,17 @@
                                     {
                                         "containerPort": 8090,
                                         "name": "management",
-                                        "protocol": "TCP"
+                                        "protocol": "TCP",
+                                        "resources": {
+                                            "limits": {
+                                                "cpu": "1",
+                                                "memory": "128Mi"
+                                            },
+                                            "requests": {
+                                                "cpu": "500m",
+                                                "memory": "64Mi"
+                                            }
+                                        }
                                     }
                                 ],
                                 "readinessProbe": {
@@ -169,7 +179,7 @@
             "description": "AMP release tag.",
             "name": "AMP_RELEASE",
             "required": true,
-            "value": "2.1.0-CR2-redhat-1"
+            "value": "2.0.1.GA"
         },
         {
             "description": "Name of the secret containing the THREESCALE_PORTAL_ENDPOINT with the access-token or provider key",

--- a/official/index.json
+++ b/official/index.json
@@ -10,7 +10,7 @@
         ],
         "templates": [
             {
-                "description": "3scale's APIcast is an NGINX based API gateway used to integrate your internal and external  API services with 3scale\u2019s API Management Platform. It supports OpenID connect to integrate  with external Identity Providers such as Red Hat Single Sign On, for API traffic authentication ",
+                "description": "3scale's APIcast is an NGINX based API gateway used to integrate your internal and external  API services with 3scale's API Management Platform. It supports OpenID connect to integrate  with external Identity Providers such as Red Hat Single Sign On, for API traffic authentication ",
                 "docs": "https://access.redhat.com/documentation/en-us/red_hat_3scale/2.saas/html/deployment_options/apicast-openshift",
                 "name": "3scale-gateway",
                 "path": "official/3scale/templates/3scale-gateway.json",


### PR DESCRIPTION
We have amended the resources requirements from APIcast Gateway and now it should be suitable for starters users. 

`make import` and `make verify` has been executed:

```bash
Diffing current official directory against freshly generated official directory
SUCCESS: Generated official directory up to date.
Diffing current community directory against freshly generated community directory
SUCCESS: Generated community directory up to date.
```

Thanks!