### PR TITLE
meta: change nodejs runtime to use rhoar-nodejs

### DIFF
--- a/community.yaml
+++ b/community.yaml
@@ -62,7 +62,7 @@ data:
         docs: https://github.com/sclorg/s2i-nodejs-container/blob/master/README.md
         regex: nodejs
         suffix: centos7
-      - location: https://raw.githubusercontent.com/bucharest-gold/centos7-s2i-nodejs/master/image-stream.yml
+      - location: https://raw.githubusercontent.com/bucharest-gold/centos7-s2i-nodejs/master/imagestreams/nodejs-centos7.yml
         docs: https://github.com/bucharest-gold/centos7-s2i-nodejs/blob/master/README.md
         suffix: bucharest-gold
   perl:

--- a/official.yaml
+++ b/official.yaml
@@ -43,18 +43,14 @@ data:
   nodejs:
     templates:
       - location: https://raw.githubusercontent.com/sclorg/nodejs-ex/master/openshift/templates/nodejs.json
-        docs: https://github.com/sclorg/nodejs-ex/blob/master/README.md
-      - location: https://raw.githubusercontent.com/sclorg/nodejs-ex/master/openshift/templates/nodejs-mongodb.json
-        docs: https://github.com/sclorg/nodejs-ex/blob/master/README.md
-      - location: https://raw.githubusercontent.com/sclorg/nodejs-ex/master/openshift/templates/nodejs-mongodb-persistent.json
-        docs: https://github.com/sclorg/nodejs-ex/blob/master/README.md
+        docs: https://appdev.openshift.io/docs/nodejs-runtime.html
         tags:
           - online-starter
           - online-professional
     imagestreams:
-      - location: https://raw.githubusercontent.com/sclorg/s2i-nodejs-container/master/imagestreams/nodejs-rhel7.json
-        docs: https://github.com/sclorg/s2i-nodejs-container/blob/master/README.md
-        regex: nodejs
+      - location: https://raw.githubusercontent.com/bucharest-gold/centos7-s2i-nodejs/master/imagestreams/nodejs-rhel7.yml
+        docs: https://github.com/bucharest-gold/centos7-s2i-nodejs/blob/master/README.md
+        regex: rhoar-nodejs
         suffix: rhel7
         tags:
           - online-starter


### PR DESCRIPTION
This removes a couple of the example templates. These templates could be modified if necessary, and restored.

I have validated both the image stream and the template using openshift online starter.