### PR TITLE
chore: update community.yml with new bucharest-gold imagestream

### DIFF
--- a/community.yaml
+++ b/community.yaml
@@ -62,7 +62,7 @@ data:
         docs: https://github.com/sclorg/s2i-nodejs-container/blob/master/README.md
         regex: nodejs
         suffix: centos7
-      - location: https://raw.githubusercontent.com/bucharest-gold/centos7-s2i-nodejs/master/image-stream.yml
+      - location: https://raw.githubusercontent.com/bucharest-gold/centos7-s2i-nodejs/master/imagestreams/nodejs-centos7.yml
         docs: https://github.com/bucharest-gold/centos7-s2i-nodejs/blob/master/README.md
         suffix: bucharest-gold
   perl:


### PR DESCRIPTION
As part of the work that went into https://github.com/openshift/library/pull/78 the location of the community imagestream file has changed. 