### PR TITLE
update for latest Java S2I image and templates

### DIFF
--- a/official.yaml
+++ b/official.yaml
@@ -1,5 +1,6 @@
 variables:
   xpaas_version: ose-v1.4.8-1
+  openjdk_version: ose-v1.4.14
   amq_version: ose-v1.4.12
   rhsso_version: ose-v1.4.11
   webserver_version: ose-v1.4.11
@@ -440,15 +441,14 @@ data:
           - online-professional
   java:
     templates:
-      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{xpaas_version}/openjdk/openjdk18-web-basic-s2i.json
+      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{openjdk_version}/openjdk/openjdk18-web-basic-s2i.json
         docs: https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/paged/red_hat_java_s2i_for_openshift/
         tags:
           - online-starter
           - online-professional
     imagestreams:
-      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{xpaas_version}/jboss-image-streams.json
+      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{openjdk_version}/openjdk/openjdk18-image-stream.json
         docs: https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/paged/red_hat_java_s2i_for_openshift/
-        regex: redhat-openjdk18
         suffix: rhel7
         tags:
           - online-starter

--- a/official/README.md
+++ b/official/README.md
@@ -461,12 +461,16 @@ Path: official/httpd/templates/httpd-example.json
 # java
 ## imagestreams
 ### redhat-openjdk18-openshift
-Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/jboss-image-streams.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/jboss-image-streams.json )  
+Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/openjdk/openjdk18-image-stream.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/openjdk/openjdk18-image-stream.json )  
 Docs: [https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/paged/red_hat_java_s2i_for_openshift/](https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/paged/red_hat_java_s2i_for_openshift/)  
 Path: official/java/imagestreams/redhat-openjdk18-openshift-rhel7.json  
+### java
+Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/openjdk/openjdk18-image-stream.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/openjdk/openjdk18-image-stream.json )  
+Docs: [https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/paged/red_hat_java_s2i_for_openshift/](https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/paged/red_hat_java_s2i_for_openshift/)  
+Path: official/java/imagestreams/java-rhel7.json  
 ## templates
 ### openjdk18-web-basic-s2i
-Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/openjdk/openjdk18-web-basic-s2i.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/openjdk/openjdk18-web-basic-s2i.json )  
+Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/openjdk/openjdk18-web-basic-s2i.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/openjdk/openjdk18-web-basic-s2i.json )  
 Docs: [https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/paged/red_hat_java_s2i_for_openshift/](https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/paged/red_hat_java_s2i_for_openshift/)  
 Path: official/java/templates/openjdk18-web-basic-s2i.json  
 # jenkins

--- a/official/index.json
+++ b/official/index.json
@@ -794,7 +794,13 @@
                 "docs": "https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/paged/red_hat_java_s2i_for_openshift/",
                 "name": "redhat-openjdk18-openshift",
                 "path": "official/java/imagestreams/redhat-openjdk18-openshift-rhel7.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/jboss-image-streams.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/openjdk/openjdk18-image-stream.json"
+            },
+            {
+                "docs": "https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/paged/red_hat_java_s2i_for_openshift/",
+                "name": "java",
+                "path": "official/java/imagestreams/java-rhel7.json",
+                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/openjdk/openjdk18-image-stream.json"
             }
         ],
         "templates": [
@@ -803,7 +809,7 @@
                 "docs": "https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/paged/red_hat_java_s2i_for_openshift/",
                 "name": "openjdk18-web-basic-s2i",
                 "path": "official/java/templates/openjdk18-web-basic-s2i.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/openjdk/openjdk18-web-basic-s2i.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/openjdk/openjdk18-web-basic-s2i.json"
             }
         ]
     },

--- a/official/java/imagestreams/java-rhel7.json
+++ b/official/java/imagestreams/java-rhel7.json
@@ -1,0 +1,53 @@
+{
+    "apiVersion": "v1",
+    "kind": "ImageStream",
+    "labels": {
+        "xpaas": "1.4.14"
+    },
+    "metadata": {
+        "annotations": {
+            "openshift.io/display-name": "Red Hat OpenJDK 8",
+            "openshift.io/provider-display-name": "Red Hat, Inc.",
+            "version": "1.4.14"
+        },
+        "name": "java"
+    },
+    "spec": {
+        "tags": [
+            {
+                "annotations": {
+                    "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                    "iconClass": "icon-rh-openjdk",
+                    "openshift.io/display-name": "Red Hat OpenJDK 8",
+                    "sampleContextDir": "undertow-servlet",
+                    "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                    "supports": "java:8,java",
+                    "tags": "builder,java,openjdk",
+                    "version": "8"
+                },
+                "from": {
+                    "kind": "DockerImage",
+                    "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:latest"
+                },
+                "name": "8"
+            },
+            {
+                "annotations": {
+                    "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                    "iconClass": "icon-rh-openjdk",
+                    "openshift.io/display-name": "Red Hat OpenJDK 8",
+                    "sampleContextDir": "undertow-servlet",
+                    "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                    "supports": "java:8,java",
+                    "tags": "builder,java,openjdk",
+                    "version": "latest"
+                },
+                "from": {
+                    "kind": "ImageStreamTag",
+                    "name": "java:8"
+                },
+                "name": "latest"
+            }
+        ]
+    }
+}

--- a/official/java/imagestreams/redhat-openjdk18-openshift-rhel7.json
+++ b/official/java/imagestreams/redhat-openjdk18-openshift-rhel7.json
@@ -2,13 +2,13 @@
     "apiVersion": "v1",
     "kind": "ImageStream",
     "labels": {
-        "xpaas": "1.4.8"
+        "xpaas": "1.4.14"
     },
     "metadata": {
         "annotations": {
             "openshift.io/display-name": "Red Hat OpenJDK 8",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "version": "1.4.8"
+            "version": "1.4.14"
         },
         "name": "redhat-openjdk18-openshift"
     },
@@ -39,7 +39,7 @@
                     "sampleContextDir": "undertow-servlet",
                     "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
                     "supports": "java:8",
-                    "tags": "builder,java,openjdk",
+                    "tags": "builder,java,openjdk,hidden",
                     "version": "1.1"
                 },
                 "from": {
@@ -56,7 +56,7 @@
                     "sampleContextDir": "undertow-servlet",
                     "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
                     "supports": "java:8",
-                    "tags": "builder,java,openjdk",
+                    "tags": "builder,java,openjdk,hidden",
                     "version": "1.2"
                 },
                 "from": {
@@ -64,6 +64,40 @@
                     "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.2"
                 },
                 "name": "1.2"
+            },
+            {
+                "annotations": {
+                    "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                    "iconClass": "icon-rh-openjdk",
+                    "openshift.io/display-name": "Red Hat OpenJDK 8",
+                    "sampleContextDir": "undertow-servlet",
+                    "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                    "supports": "java:8",
+                    "tags": "builder,java,openjdk,hidden",
+                    "version": "1.3"
+                },
+                "from": {
+                    "kind": "DockerImage",
+                    "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.3"
+                },
+                "name": "1.3"
+            },
+            {
+                "annotations": {
+                    "description": "Build and run Java applications using Maven and OpenJDK 8.",
+                    "iconClass": "icon-rh-openjdk",
+                    "openshift.io/display-name": "Red Hat OpenJDK 8",
+                    "sampleContextDir": "undertow-servlet",
+                    "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts",
+                    "supports": "java:8",
+                    "tags": "builder,java,openjdk,hidden",
+                    "version": "1.4"
+                },
+                "from": {
+                    "kind": "DockerImage",
+                    "name": "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.4"
+                },
+                "name": "1.4"
             }
         ]
     }

--- a/official/java/templates/openjdk18-web-basic-s2i.json
+++ b/official/java/templates/openjdk18-web-basic-s2i.json
@@ -3,7 +3,7 @@
     "kind": "Template",
     "labels": {
         "template": "openjdk18-web-basic-s2i",
-        "xpaas": "1.4.8"
+        "xpaas": "1.4.14"
     },
     "message": "A new java application has been created in your project.",
     "metadata": {
@@ -16,7 +16,7 @@
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/",
             "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat OpenJDK Java 8 based application.",
             "template.openshift.io/support-url": "https://access.redhat.com",
-            "version": "1.4.8"
+            "version": "1.4.14"
         },
         "name": "openjdk18-web-basic-s2i"
     },
@@ -104,7 +104,7 @@
                         "forcePull": true,
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "redhat-openjdk18-openshift:1.2",
+                            "name": "java:8",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}"
                         }
                     },


### PR DESCRIPTION
openjdk18-openshift:1.4 should be available in the RHCC early next week.

Signed-off-by: rcernich <rcernich@redhat.com>