### PR TITLE
Add Fuse entries to Online starter plan

### DIFF
--- a/official.yaml
+++ b/official.yaml
@@ -661,20 +661,24 @@ data:
       - location: https://raw.githubusercontent.com/jboss-fuse/application-templates/GA/quickstarts/spring-boot-camel-template.json
         docs: https://access.redhat.com/documentation/en-us/red_hat_fuse/7.0/html/fuse_on_openshift_guide/
         tags:
+          - online-starter
           - online-professional
       - location: https://raw.githubusercontent.com/jboss-fuse/application-templates/GA/quickstarts/spring-boot-camel-xml-template.json
         docs: https://access.redhat.com/documentation/en-us/red_hat_fuse/7.0/html/fuse_on_openshift_guide/
         tags:
+          - online-starter
           - online-professional
       - location: https://raw.githubusercontent.com/jboss-fuse/application-templates/GA/fis-console-namespace-template.json
         docs: https://access.redhat.com/documentation/en-us/red_hat_fuse/7.0/html/managing_fuse/
         tags:
+          - online-starter
           - online-professional
     imagestreams:
       - location: https://raw.githubusercontent.com/jboss-fuse/application-templates/GA/fis-image-streams.json
         docs: https://access.redhat.com/documentation/en-us/red_hat_fuse/7.0/html/fuse_on_openshift_guide/
         suffix: rhel7
         tags:
+          - online-starter
           - online-professional
   dotnet:
     templates:


### PR DESCRIPTION
This PR is meant to make the Fuse entries available in the OpenShift catalog for the Online Starter plan.

Please let me know if there is any additional change to make.