### PR TITLE
Update Data Grid image streams/templates for registry switch

### DIFF
--- a/official.yaml
+++ b/official.yaml
@@ -8,6 +8,9 @@ variables:
   ips_ds_version: ose-v1.4.16
   rhdm_version: 7.0.1.GA
   rhpam_version: 7.0.2.GA
+  jdg_version: ose-v1.4.16
+  datagrid_version: 1.1.1
+  cacheservice_version: 1.0.TP
 data:
   ruby:
     imagestreams:
@@ -308,8 +311,8 @@ data:
           - online-professional
   datagrid:
     templates:
-      - location: https://raw.githubusercontent.com/jboss-container-images/datagrid-7-image/datagrid-services-dev/templates/caching-service.json
-        docs: https://github.com/jboss-container-images/datagrid-7-image/blob/datagrid-services-dev/documentation/cache-service.asciidoc
+      - location: https://raw.githubusercontent.com/jboss-container-images/datagrid-7-image/{cacheservice_version}/templates/caching-service.json
+        docs: https://github.com/jboss-container-images/datagrid-7-image/blob/{cacheservice_version}/documentation/cache-service.asciidoc
         tags:
           - ocp
           - online-professional
@@ -325,64 +328,71 @@ data:
         docs: https://github.com/jboss-openshift/application-templates/blob/{xpaas_version}/docs/datagrid/datagrid65-postgresql-persistent.adoc
       - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{xpaas_version}/datagrid/datagrid65-postgresql.json
         docs: https://github.com/jboss-openshift/application-templates/blob/{xpaas_version}/docs/datagrid/datagrid65-postgresql.adoc
-      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{xpaas_version}/datagrid/datagrid71-basic.json
-        docs: https://github.com/jboss-openshift/application-templates/blob/{xpaas_version}/docs/datagrid/datagrid71-basic.adoc
+      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{jdg_version}/datagrid/datagrid71-basic.json
+        docs: https://github.com/jboss-openshift/application-templates/blob/{jdg_version}/docs/datagrid/datagrid71-basic.adoc
         tags:
           - ocp
           - online-professional
-      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{xpaas_version}/datagrid/datagrid71-https.json
-        docs: https://github.com/jboss-openshift/application-templates/blob/{xpaas_version}/docs/datagrid/datagrid71-https.adoc
+      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{jdg_version}/datagrid/datagrid71-https.json
+        docs: https://github.com/jboss-openshift/application-templates/blob/{jdg_version}/docs/datagrid/datagrid71-https.adoc
         tags:
           - ocp
           - online-professional
-      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{xpaas_version}/datagrid/datagrid71-mysql-persistent.json
-        docs: https://github.com/jboss-openshift/application-templates/blob/{xpaas_version}/docs/datagrid/datagrid71-mysql-persistent.adoc
+      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{jdg_version}/datagrid/datagrid71-mysql-persistent.json
+        docs: https://github.com/jboss-openshift/application-templates/blob/{jdg_version}/docs/datagrid/datagrid71-mysql-persistent.adoc
         tags:
           - ocp
           - online-professional
-      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{xpaas_version}/datagrid/datagrid71-mysql.json
-        docs: https://github.com/jboss-openshift/application-templates/blob/{xpaas_version}/docs/datagrid/datagrid71-mysql.adoc
-      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{xpaas_version}/datagrid/datagrid71-postgresql-persistent.json
-        docs: https://github.com/jboss-openshift/application-templates/blob/{xpaas_version}/docs/datagrid/datagrid71-postgresql-persistent.adoc
+      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{jdg_version}/datagrid/datagrid71-mysql.json
+        docs: https://github.com/jboss-openshift/application-templates/blob/{jdg_version}/docs/datagrid/datagrid71-mysql.adoc
+      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{jdg_version}/datagrid/datagrid71-postgresql-persistent.json
+        docs: https://github.com/jboss-openshift/application-templates/blob/{jdg_version}/docs/datagrid/datagrid71-postgresql-persistent.adoc
         tags:
           - ocp
           - online-professional
-      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{xpaas_version}/datagrid/datagrid71-postgresql.json
-        docs: https://github.com/jboss-openshift/application-templates/blob/{xpaas_version}/docs/datagrid/datagrid71-postgresql.adoc
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/datagrid72/templates/datagrid72-basic.json
-        docs: https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/datagrid72-dev/docs/datagrid72-basic.adoc
+      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{jdg_version}/datagrid/datagrid71-postgresql.json
+        docs: https://github.com/jboss-openshift/application-templates/blob/{jdg_version}/docs/datagrid/datagrid71-postgresql.adoc
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/{datagrid_version}/templates/datagrid72-basic.json
+        docs: https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/{datagrid_version}/docs/datagrid72-basic.adoc
         tags:
           - ocp
           - online-professional
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/datagrid72/templates/datagrid72-https.json
-        docs: https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/datagrid72-dev/docs/datagrid72-https.adoc
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/{datagrid_version}/templates/datagrid72-https.json
+        docs: https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/{datagrid_version}/docs/datagrid72-https.adoc
         tags:
           - ocp
           - online-professional
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/datagrid72/templates/datagrid72-mysql-persistent.json
-        docs: https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/datagrid72-dev/docs/datagrid72-mysql-persistent.adoc
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/{datagrid_version}/templates/datagrid72-mysql-persistent.json
+        docs: https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/{datagrid_version}/docs/datagrid72-mysql-persistent.adoc
         tags:
           - ocp
           - online-professional
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/datagrid72/templates/datagrid72-mysql.json
-        docs: https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/datagrid72-dev/docs/datagrid72-mysql.adoc
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/datagrid72/templates/datagrid72-postgresql-persistent.json
-        docs: https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/datagrid72-dev/docs/datagrid72-postgresql-persistent.adoc
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/{datagrid_version}/templates/datagrid72-mysql.json
+        docs: https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/{datagrid_version}/docs/datagrid72-mysql.adoc
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/{datagrid_version}/templates/datagrid72-postgresql-persistent.json
+        docs: https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/{datagrid_version}/docs/datagrid72-postgresql-persistent.adoc
         tags:
           - ocp
           - online-professional
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/datagrid72/templates/datagrid72-postgresql.json
-        docs: https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/datagrid72-dev/docs/datagrid72-postgresql.adoc
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/{datagrid_version}/templates/datagrid72-postgresql.json
+        docs: https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/{datagrid_version}/docs/datagrid72-postgresql.adoc
     imagestreams:
-      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{xpaas_version}/jboss-image-streams.json
-        docs: https://access.redhat.com/documentation/en/red-hat-jboss-middleware-for-openshift/3/paged/red-hat-jboss-data-grid-for-openshift/
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/{jdg_version}/templates/deprecated/datagrid65-image-stream.json
+        docs: https://access.redhat.com/documentation/en-us/red_hat_jboss_data_grid/6.5/html/data_grid_for_openshift/
         regex: jboss-datagrid
         suffix: rhel7
         tags:
           - ocp
           - online-professional
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/datagrid72/templates/datagrid72-image-stream.json
-        docs: https://access.redhat.com/documentation/en/red-hat-jboss-middleware-for-openshift/3/paged/red-hat-jboss-data-grid-for-openshift/
+      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{jdg_version}/datagrid/datagrid71-image-stream.json
+        docs: https://access.redhat.com/documentation/en-us/red_hat_jboss_data_grid/7.1/html/data_grid_for_openshift/
+        regex: jboss-datagrid
+        suffix: rhel7
+        tags:
+          - ocp
+          - online-professional
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/{datagrid_version}/templates/datagrid72-image-stream.json
+        docs: https://access.redhat.com/documentation/en-us/red_hat_jboss_data_grid/7.2/html/data_grid_for_openshift/
         regex: jboss-datagrid
         suffix: rhel7
         tags:

--- a/official/README.md
+++ b/official/README.md
@@ -67,29 +67,29 @@ Path: official/dancer/templates/dancer-mysql-persistent.json
 # datagrid
 ## imagestreams
 ### jboss-datagrid65-openshift
-Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/jboss-image-streams.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/jboss-image-streams.json )  
-Docs: [https://access.redhat.com/documentation/en/red-hat-jboss-middleware-for-openshift/3/paged/red-hat-jboss-data-grid-for-openshift/](https://access.redhat.com/documentation/en/red-hat-jboss-middleware-for-openshift/3/paged/red-hat-jboss-data-grid-for-openshift/)  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/ose-v1.4.16/templates/deprecated/datagrid65-image-stream.json](https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/ose-v1.4.16/templates/deprecated/datagrid65-image-stream.json )  
+Docs: [https://access.redhat.com/documentation/en-us/red_hat_jboss_data_grid/6.5/html/data_grid_for_openshift/](https://access.redhat.com/documentation/en-us/red_hat_jboss_data_grid/6.5/html/data_grid_for_openshift/)  
 Path: official/datagrid/imagestreams/jboss-datagrid65-openshift-rhel7.json  
-### jboss-datagrid71-openshift
-Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/jboss-image-streams.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/jboss-image-streams.json )  
-Docs: [https://access.redhat.com/documentation/en/red-hat-jboss-middleware-for-openshift/3/paged/red-hat-jboss-data-grid-for-openshift/](https://access.redhat.com/documentation/en/red-hat-jboss-middleware-for-openshift/3/paged/red-hat-jboss-data-grid-for-openshift/)  
-Path: official/datagrid/imagestreams/jboss-datagrid71-openshift-rhel7.json  
 ### jboss-datagrid65-client-openshift
-Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/jboss-image-streams.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/jboss-image-streams.json )  
-Docs: [https://access.redhat.com/documentation/en/red-hat-jboss-middleware-for-openshift/3/paged/red-hat-jboss-data-grid-for-openshift/](https://access.redhat.com/documentation/en/red-hat-jboss-middleware-for-openshift/3/paged/red-hat-jboss-data-grid-for-openshift/)  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/ose-v1.4.16/templates/deprecated/datagrid65-image-stream.json](https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/ose-v1.4.16/templates/deprecated/datagrid65-image-stream.json )  
+Docs: [https://access.redhat.com/documentation/en-us/red_hat_jboss_data_grid/6.5/html/data_grid_for_openshift/](https://access.redhat.com/documentation/en-us/red_hat_jboss_data_grid/6.5/html/data_grid_for_openshift/)  
 Path: official/datagrid/imagestreams/jboss-datagrid65-client-openshift-rhel7.json  
+### jboss-datagrid71-openshift
+Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/datagrid/datagrid71-image-stream.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/datagrid/datagrid71-image-stream.json )  
+Docs: [https://access.redhat.com/documentation/en-us/red_hat_jboss_data_grid/7.1/html/data_grid_for_openshift/](https://access.redhat.com/documentation/en-us/red_hat_jboss_data_grid/7.1/html/data_grid_for_openshift/)  
+Path: official/datagrid/imagestreams/jboss-datagrid71-openshift-rhel7.json  
 ### jboss-datagrid71-client-openshift
-Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/jboss-image-streams.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/jboss-image-streams.json )  
-Docs: [https://access.redhat.com/documentation/en/red-hat-jboss-middleware-for-openshift/3/paged/red-hat-jboss-data-grid-for-openshift/](https://access.redhat.com/documentation/en/red-hat-jboss-middleware-for-openshift/3/paged/red-hat-jboss-data-grid-for-openshift/)  
+Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/datagrid/datagrid71-image-stream.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/datagrid/datagrid71-image-stream.json )  
+Docs: [https://access.redhat.com/documentation/en-us/red_hat_jboss_data_grid/7.1/html/data_grid_for_openshift/](https://access.redhat.com/documentation/en-us/red_hat_jboss_data_grid/7.1/html/data_grid_for_openshift/)  
 Path: official/datagrid/imagestreams/jboss-datagrid71-client-openshift-rhel7.json  
 ### jboss-datagrid72-openshift
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/datagrid72/templates/datagrid72-image-stream.json](https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/datagrid72/templates/datagrid72-image-stream.json )  
-Docs: [https://access.redhat.com/documentation/en/red-hat-jboss-middleware-for-openshift/3/paged/red-hat-jboss-data-grid-for-openshift/](https://access.redhat.com/documentation/en/red-hat-jboss-middleware-for-openshift/3/paged/red-hat-jboss-data-grid-for-openshift/)  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/1.1.1/templates/datagrid72-image-stream.json](https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/1.1.1/templates/datagrid72-image-stream.json )  
+Docs: [https://access.redhat.com/documentation/en-us/red_hat_jboss_data_grid/7.2/html/data_grid_for_openshift/](https://access.redhat.com/documentation/en-us/red_hat_jboss_data_grid/7.2/html/data_grid_for_openshift/)  
 Path: official/datagrid/imagestreams/jboss-datagrid72-openshift-rhel7.json  
 ## templates
 ### caching-service
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/datagrid-7-image/datagrid-services-dev/templates/caching-service.json](https://raw.githubusercontent.com/jboss-container-images/datagrid-7-image/datagrid-services-dev/templates/caching-service.json )  
-Docs: [https://github.com/jboss-container-images/datagrid-7-image/blob/datagrid-services-dev/documentation/cache-service.asciidoc](https://github.com/jboss-container-images/datagrid-7-image/blob/datagrid-services-dev/documentation/cache-service.asciidoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/datagrid-7-image/1.0.TP/templates/caching-service.json](https://raw.githubusercontent.com/jboss-container-images/datagrid-7-image/1.0.TP/templates/caching-service.json )  
+Docs: [https://github.com/jboss-container-images/datagrid-7-image/blob/1.0.TP/documentation/cache-service.asciidoc](https://github.com/jboss-container-images/datagrid-7-image/blob/1.0.TP/documentation/cache-service.asciidoc)  
 Path: official/datagrid/templates/caching-service.json  
 ### datagrid65-basic
 Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/datagrid/datagrid65-basic.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/datagrid/datagrid65-basic.json )  
@@ -116,52 +116,52 @@ Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templ
 Docs: [https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.8-1/docs/datagrid/datagrid65-postgresql.adoc](https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.8-1/docs/datagrid/datagrid65-postgresql.adoc)  
 Path: official/datagrid/templates/datagrid65-postgresql.json  
 ### datagrid71-basic
-Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/datagrid/datagrid71-basic.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/datagrid/datagrid71-basic.json )  
-Docs: [https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.8-1/docs/datagrid/datagrid71-basic.adoc](https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.8-1/docs/datagrid/datagrid71-basic.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/datagrid/datagrid71-basic.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/datagrid/datagrid71-basic.json )  
+Docs: [https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/datagrid/datagrid71-basic.adoc](https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/datagrid/datagrid71-basic.adoc)  
 Path: official/datagrid/templates/datagrid71-basic.json  
 ### datagrid71-https
-Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/datagrid/datagrid71-https.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/datagrid/datagrid71-https.json )  
-Docs: [https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.8-1/docs/datagrid/datagrid71-https.adoc](https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.8-1/docs/datagrid/datagrid71-https.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/datagrid/datagrid71-https.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/datagrid/datagrid71-https.json )  
+Docs: [https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/datagrid/datagrid71-https.adoc](https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/datagrid/datagrid71-https.adoc)  
 Path: official/datagrid/templates/datagrid71-https.json  
 ### datagrid71-mysql-persistent
-Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/datagrid/datagrid71-mysql-persistent.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/datagrid/datagrid71-mysql-persistent.json )  
-Docs: [https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.8-1/docs/datagrid/datagrid71-mysql-persistent.adoc](https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.8-1/docs/datagrid/datagrid71-mysql-persistent.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/datagrid/datagrid71-mysql-persistent.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/datagrid/datagrid71-mysql-persistent.json )  
+Docs: [https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/datagrid/datagrid71-mysql-persistent.adoc](https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/datagrid/datagrid71-mysql-persistent.adoc)  
 Path: official/datagrid/templates/datagrid71-mysql-persistent.json  
 ### datagrid71-mysql
-Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/datagrid/datagrid71-mysql.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/datagrid/datagrid71-mysql.json )  
-Docs: [https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.8-1/docs/datagrid/datagrid71-mysql.adoc](https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.8-1/docs/datagrid/datagrid71-mysql.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/datagrid/datagrid71-mysql.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/datagrid/datagrid71-mysql.json )  
+Docs: [https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/datagrid/datagrid71-mysql.adoc](https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/datagrid/datagrid71-mysql.adoc)  
 Path: official/datagrid/templates/datagrid71-mysql.json  
 ### datagrid71-postgresql-persistent
-Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/datagrid/datagrid71-postgresql-persistent.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/datagrid/datagrid71-postgresql-persistent.json )  
-Docs: [https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.8-1/docs/datagrid/datagrid71-postgresql-persistent.adoc](https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.8-1/docs/datagrid/datagrid71-postgresql-persistent.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/datagrid/datagrid71-postgresql-persistent.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/datagrid/datagrid71-postgresql-persistent.json )  
+Docs: [https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/datagrid/datagrid71-postgresql-persistent.adoc](https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/datagrid/datagrid71-postgresql-persistent.adoc)  
 Path: official/datagrid/templates/datagrid71-postgresql-persistent.json  
 ### datagrid71-postgresql
-Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/datagrid/datagrid71-postgresql.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/datagrid/datagrid71-postgresql.json )  
-Docs: [https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.8-1/docs/datagrid/datagrid71-postgresql.adoc](https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.8-1/docs/datagrid/datagrid71-postgresql.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/datagrid/datagrid71-postgresql.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/datagrid/datagrid71-postgresql.json )  
+Docs: [https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/datagrid/datagrid71-postgresql.adoc](https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/datagrid/datagrid71-postgresql.adoc)  
 Path: official/datagrid/templates/datagrid71-postgresql.json  
 ### datagrid72-basic
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/datagrid72/templates/datagrid72-basic.json](https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/datagrid72/templates/datagrid72-basic.json )  
-Docs: [https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/datagrid72-dev/docs/datagrid72-basic.adoc](https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/datagrid72-dev/docs/datagrid72-basic.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/1.1.1/templates/datagrid72-basic.json](https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/1.1.1/templates/datagrid72-basic.json )  
+Docs: [https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/1.1.1/docs/datagrid72-basic.adoc](https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/1.1.1/docs/datagrid72-basic.adoc)  
 Path: official/datagrid/templates/datagrid72-basic.json  
 ### datagrid72-https
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/datagrid72/templates/datagrid72-https.json](https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/datagrid72/templates/datagrid72-https.json )  
-Docs: [https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/datagrid72-dev/docs/datagrid72-https.adoc](https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/datagrid72-dev/docs/datagrid72-https.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/1.1.1/templates/datagrid72-https.json](https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/1.1.1/templates/datagrid72-https.json )  
+Docs: [https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/1.1.1/docs/datagrid72-https.adoc](https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/1.1.1/docs/datagrid72-https.adoc)  
 Path: official/datagrid/templates/datagrid72-https.json  
 ### datagrid72-mysql-persistent
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/datagrid72/templates/datagrid72-mysql-persistent.json](https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/datagrid72/templates/datagrid72-mysql-persistent.json )  
-Docs: [https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/datagrid72-dev/docs/datagrid72-mysql-persistent.adoc](https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/datagrid72-dev/docs/datagrid72-mysql-persistent.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/1.1.1/templates/datagrid72-mysql-persistent.json](https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/1.1.1/templates/datagrid72-mysql-persistent.json )  
+Docs: [https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/1.1.1/docs/datagrid72-mysql-persistent.adoc](https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/1.1.1/docs/datagrid72-mysql-persistent.adoc)  
 Path: official/datagrid/templates/datagrid72-mysql-persistent.json  
 ### datagrid72-mysql
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/datagrid72/templates/datagrid72-mysql.json](https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/datagrid72/templates/datagrid72-mysql.json )  
-Docs: [https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/datagrid72-dev/docs/datagrid72-mysql.adoc](https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/datagrid72-dev/docs/datagrid72-mysql.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/1.1.1/templates/datagrid72-mysql.json](https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/1.1.1/templates/datagrid72-mysql.json )  
+Docs: [https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/1.1.1/docs/datagrid72-mysql.adoc](https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/1.1.1/docs/datagrid72-mysql.adoc)  
 Path: official/datagrid/templates/datagrid72-mysql.json  
 ### datagrid72-postgresql-persistent
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/datagrid72/templates/datagrid72-postgresql-persistent.json](https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/datagrid72/templates/datagrid72-postgresql-persistent.json )  
-Docs: [https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/datagrid72-dev/docs/datagrid72-postgresql-persistent.adoc](https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/datagrid72-dev/docs/datagrid72-postgresql-persistent.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/1.1.1/templates/datagrid72-postgresql-persistent.json](https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/1.1.1/templates/datagrid72-postgresql-persistent.json )  
+Docs: [https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/1.1.1/docs/datagrid72-postgresql-persistent.adoc](https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/1.1.1/docs/datagrid72-postgresql-persistent.adoc)  
 Path: official/datagrid/templates/datagrid72-postgresql-persistent.json  
 ### datagrid72-postgresql
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/datagrid72/templates/datagrid72-postgresql.json](https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/datagrid72/templates/datagrid72-postgresql.json )  
-Docs: [https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/datagrid72-dev/docs/datagrid72-postgresql.adoc](https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/datagrid72-dev/docs/datagrid72-postgresql.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/1.1.1/templates/datagrid72-postgresql.json](https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/1.1.1/templates/datagrid72-postgresql.json )  
+Docs: [https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/1.1.1/docs/datagrid72-postgresql.adoc](https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/1.1.1/docs/datagrid72-postgresql.adoc)  
 Path: official/datagrid/templates/datagrid72-postgresql.json  
 # datavirt
 ## imagestreams

--- a/official/datagrid/imagestreams/jboss-datagrid65-client-openshift-rhel7.json
+++ b/official/datagrid/imagestreams/jboss-datagrid65-client-openshift-rhel7.json
@@ -2,13 +2,13 @@
     "apiVersion": "v1",
     "kind": "ImageStream",
     "labels": {
-        "xpaas": "1.4.8"
+        "xpaas": "1.4.16"
     },
     "metadata": {
         "annotations": {
             "openshift.io/display-name": "Red Hat JBoss Data Grid 6.5 Client Modules for EAP",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "version": "1.4.8"
+            "version": "1.4.16"
         },
         "name": "jboss-datagrid65-client-openshift"
     },
@@ -24,9 +24,12 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.access.redhat.com/jboss-datagrid-6/datagrid65-client-openshift:1.0"
+                    "name": "registry.redhat.io/jboss-datagrid-6/datagrid65-client-openshift:1.0"
                 },
-                "name": "1.0"
+                "name": "1.0",
+                "referencePolicy": {
+                    "type": "Local"
+                }
             },
             {
                 "annotations": {
@@ -38,9 +41,12 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.access.redhat.com/jboss-datagrid-6/datagrid65-client-openshift:1.1"
+                    "name": "registry.redhat.io/jboss-datagrid-6/datagrid65-client-openshift:1.1"
                 },
-                "name": "1.1"
+                "name": "1.1",
+                "referencePolicy": {
+                    "type": "Local"
+                }
             }
         ]
     }

--- a/official/datagrid/imagestreams/jboss-datagrid65-openshift-rhel7.json
+++ b/official/datagrid/imagestreams/jboss-datagrid65-openshift-rhel7.json
@@ -2,13 +2,13 @@
     "apiVersion": "v1",
     "kind": "ImageStream",
     "labels": {
-        "xpaas": "1.4.8"
+        "xpaas": "1.4.16"
     },
     "metadata": {
         "annotations": {
             "openshift.io/display-name": "Red Hat JBoss Data Grid 6.5",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "version": "1.4.8"
+            "version": "1.4.16"
         },
         "name": "jboss-datagrid65-openshift"
     },
@@ -25,9 +25,12 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.access.redhat.com/jboss-datagrid-6/datagrid65-openshift:1.2"
+                    "name": "registry.redhat.io/jboss-datagrid-6/datagrid65-openshift:1.2"
                 },
-                "name": "1.2"
+                "name": "1.2",
+                "referencePolicy": {
+                    "type": "Local"
+                }
             },
             {
                 "annotations": {
@@ -40,9 +43,12 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.access.redhat.com/jboss-datagrid-6/datagrid65-openshift:1.3"
+                    "name": "registry.redhat.io/jboss-datagrid-6/datagrid65-openshift:1.3"
                 },
-                "name": "1.3"
+                "name": "1.3",
+                "referencePolicy": {
+                    "type": "Local"
+                }
             },
             {
                 "annotations": {
@@ -55,9 +61,12 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.access.redhat.com/jboss-datagrid-6/datagrid65-openshift:1.4"
+                    "name": "registry.redhat.io/jboss-datagrid-6/datagrid65-openshift:1.4"
                 },
-                "name": "1.4"
+                "name": "1.4",
+                "referencePolicy": {
+                    "type": "Local"
+                }
             },
             {
                 "annotations": {
@@ -70,9 +79,12 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.access.redhat.com/jboss-datagrid-6/datagrid65-openshift:1.5"
+                    "name": "registry.redhat.io/jboss-datagrid-6/datagrid65-openshift:1.5"
                 },
-                "name": "1.5"
+                "name": "1.5",
+                "referencePolicy": {
+                    "type": "Local"
+                }
             },
             {
                 "annotations": {
@@ -85,9 +97,12 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.access.redhat.com/jboss-datagrid-6/datagrid65-openshift:1.6"
+                    "name": "registry.redhat.io/jboss-datagrid-6/datagrid65-openshift:1.6"
                 },
-                "name": "1.6"
+                "name": "1.6",
+                "referencePolicy": {
+                    "type": "Local"
+                }
             }
         ]
     }

--- a/official/datagrid/imagestreams/jboss-datagrid71-client-openshift-rhel7.json
+++ b/official/datagrid/imagestreams/jboss-datagrid71-client-openshift-rhel7.json
@@ -2,13 +2,13 @@
     "apiVersion": "v1",
     "kind": "ImageStream",
     "labels": {
-        "xpaas": "1.4.8"
+        "xpaas": "1.4.16"
     },
     "metadata": {
         "annotations": {
             "openshift.io/display-name": "Red Hat JBoss Data Grid 7.1 Client Modules for EAP",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "version": "1.4.8"
+            "version": "1.4.16"
         },
         "name": "jboss-datagrid71-client-openshift"
     },
@@ -24,9 +24,12 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.access.redhat.com/jboss-datagrid-7/datagrid71-client-openshift:1.0"
+                    "name": "registry.redhat.io/jboss-datagrid-7/datagrid71-client-openshift:1.0"
                 },
-                "name": "1.0"
+                "name": "1.0",
+                "referencePolicy": {
+                    "type": "Local"
+                }
             }
         ]
     }

--- a/official/datagrid/imagestreams/jboss-datagrid71-openshift-rhel7.json
+++ b/official/datagrid/imagestreams/jboss-datagrid71-openshift-rhel7.json
@@ -2,13 +2,13 @@
     "apiVersion": "v1",
     "kind": "ImageStream",
     "labels": {
-        "xpaas": "1.4.8"
+        "xpaas": "1.4.16"
     },
     "metadata": {
         "annotations": {
             "openshift.io/display-name": "Red Hat JBoss Data Grid 7.1",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "version": "1.4.8"
+            "version": "1.4.16"
         },
         "name": "jboss-datagrid71-openshift"
     },
@@ -25,9 +25,12 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.access.redhat.com/jboss-datagrid-7/datagrid71-openshift:1.0"
+                    "name": "registry.redhat.io/jboss-datagrid-7/datagrid71-openshift:1.0"
                 },
-                "name": "1.0"
+                "name": "1.0",
+                "referencePolicy": {
+                    "type": "Local"
+                }
             },
             {
                 "annotations": {
@@ -40,9 +43,12 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.access.redhat.com/jboss-datagrid-7/datagrid71-openshift:1.1"
+                    "name": "registry.redhat.io/jboss-datagrid-7/datagrid71-openshift:1.1"
                 },
-                "name": "1.1"
+                "name": "1.1",
+                "referencePolicy": {
+                    "type": "Local"
+                }
             },
             {
                 "annotations": {
@@ -55,9 +61,30 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.access.redhat.com/jboss-datagrid-7/datagrid71-openshift:1.2"
+                    "name": "registry.redhat.io/jboss-datagrid-7/datagrid71-openshift:1.2"
                 },
-                "name": "1.2"
+                "name": "1.2",
+                "referencePolicy": {
+                    "type": "Local"
+                }
+            },
+            {
+                "annotations": {
+                    "description": "JBoss Data Grid 7.1 S2I images.",
+                    "iconClass": "icon-datagrid",
+                    "openshift.io/display-name": "Red Hat JBoss Data Grid 7.1",
+                    "supports": "datagrid:7.1",
+                    "tags": "datagrid,jboss,hidden",
+                    "version": "1.3"
+                },
+                "from": {
+                    "kind": "DockerImage",
+                    "name": "registry.redhat.io/jboss-datagrid-7/datagrid71-openshift:1.3"
+                },
+                "name": "1.3",
+                "referencePolicy": {
+                    "type": "Local"
+                }
             }
         ]
     }

--- a/official/datagrid/imagestreams/jboss-datagrid72-openshift-rhel7.json
+++ b/official/datagrid/imagestreams/jboss-datagrid72-openshift-rhel7.json
@@ -22,9 +22,12 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.access.redhat.com/jboss-datagrid-7/datagrid72-openshift:1.0"
+                    "name": "registry.redhat.io/jboss-datagrid-7/datagrid72-openshift:1.0"
                 },
-                "name": "1.0"
+                "name": "1.0",
+                "referencePolicy": {
+                    "type": "Local"
+                }
             },
             {
                 "annotations": {
@@ -37,9 +40,12 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.access.redhat.com/jboss-datagrid-7/datagrid72-openshift:1.1"
+                    "name": "registry.redhat.io/jboss-datagrid-7/datagrid72-openshift:1.1"
                 },
-                "name": "1.1"
+                "name": "1.1",
+                "referencePolicy": {
+                    "type": "Local"
+                }
             }
         ]
     }

--- a/official/datagrid/templates/datagrid71-basic.json
+++ b/official/datagrid/templates/datagrid71-basic.json
@@ -3,7 +3,7 @@
     "kind": "Template",
     "labels": {
         "template": "datagrid71-basic",
-        "xpaas": "1.4.8"
+        "xpaas": "1.4.16"
     },
     "message": "A new data grid service has been created in your project. It supports connector type(s) \"${INFINISPAN_CONNECTORS}\".",
     "metadata": {
@@ -16,7 +16,7 @@
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-data-grid/",
             "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Data Grid 7.1 based application, including a deployment configuration, using using ephemeral (temporary) storage and communication using http.",
             "template.openshift.io/support-url": "https://access.redhat.com",
-            "version": "1.4.8"
+            "version": "1.4.16"
         },
         "name": "datagrid71-basic"
     },
@@ -314,7 +314,7 @@
                             ],
                             "from": {
                                 "kind": "ImageStreamTag",
-                                "name": "jboss-datagrid71-openshift:1.2",
+                                "name": "jboss-datagrid71-openshift:1.3",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}"
                             }
                         },

--- a/official/datagrid/templates/datagrid71-https.json
+++ b/official/datagrid/templates/datagrid71-https.json
@@ -3,7 +3,7 @@
     "kind": "Template",
     "labels": {
         "template": "datagrid71-https",
-        "xpaas": "1.4.8"
+        "xpaas": "1.4.16"
     },
     "message": "A new data grid service has been created in your project. It supports connector type(s) \"${INFINISPAN_CONNECTORS}\". Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "metadata": {
@@ -16,7 +16,7 @@
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-data-grid/",
             "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Data Grid 7.1 based application, including a deployment configuration, using using ephemeral (temporary) storage and secure communication using https.",
             "template.openshift.io/support-url": "https://access.redhat.com",
-            "version": "1.4.8"
+            "version": "1.4.16"
         },
         "name": "datagrid71-https"
     },
@@ -432,7 +432,7 @@
                             ],
                             "from": {
                                 "kind": "ImageStreamTag",
-                                "name": "jboss-datagrid71-openshift:1.2",
+                                "name": "jboss-datagrid71-openshift:1.3",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}"
                             }
                         },

--- a/official/datagrid/templates/datagrid71-mysql-persistent.json
+++ b/official/datagrid/templates/datagrid71-mysql-persistent.json
@@ -3,7 +3,7 @@
     "kind": "Template",
     "labels": {
         "template": "datagrid71-mysql-persistent",
-        "xpaas": "1.4.8"
+        "xpaas": "1.4.16"
     },
     "message": "A new data grid service (using MySQL with persistent storage) has been created in your project. It supports connector type(s) \"${INFINISPAN_CONNECTORS}\". The username/password for accessing the MySQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "metadata": {
@@ -16,7 +16,7 @@
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-data-grid/",
             "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Data Grid 7.1 based application, including a deployment configuration, using MySQL databased using persistence and secure communication using https.",
             "template.openshift.io/support-url": "https://access.redhat.com",
-            "version": "1.4.8"
+            "version": "1.4.16"
         },
         "name": "datagrid71-mysql-persistent"
     },
@@ -512,7 +512,7 @@
                             ],
                             "from": {
                                 "kind": "ImageStreamTag",
-                                "name": "jboss-datagrid71-openshift:1.2",
+                                "name": "jboss-datagrid71-openshift:1.3",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}"
                             }
                         },
@@ -588,6 +588,13 @@
                                 ],
                                 "image": "mysql",
                                 "imagePullPolicy": "Always",
+                                "livenessProbe": {
+                                    "initialDelaySeconds": 30,
+                                    "tcpSocket": {
+                                        "port": 3306
+                                    },
+                                    "timeoutSeconds": 1
+                                },
                                 "name": "${APPLICATION_NAME}-mysql",
                                 "ports": [
                                     {
@@ -595,6 +602,18 @@
                                         "protocol": "TCP"
                                     }
                                 ],
+                                "readinessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "/bin/sh",
+                                            "-i",
+                                            "-c",
+                                            "MYSQL_PWD=\"$MYSQL_PASSWORD\" mysql -h 127.0.0.1 -u $MYSQL_USER -D $MYSQL_DATABASE -e 'SELECT 1'"
+                                        ]
+                                    },
+                                    "initialDelaySeconds": 5,
+                                    "timeoutSeconds": 1
+                                },
                                 "volumeMounts": [
                                     {
                                         "mountPath": "/var/lib/mysql/data",

--- a/official/datagrid/templates/datagrid71-mysql.json
+++ b/official/datagrid/templates/datagrid71-mysql.json
@@ -3,7 +3,7 @@
     "kind": "Template",
     "labels": {
         "template": "datagrid71-mysql",
-        "xpaas": "1.4.8"
+        "xpaas": "1.4.16"
     },
     "message": "A new data grid service (using MySQL) has been created in your project. It supports connector type(s) \"${INFINISPAN_CONNECTORS}\". The username/password for accessing the MySQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "metadata": {
@@ -16,7 +16,7 @@
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-data-grid/",
             "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Data Grid 7.1 based application, including a deployment configuration, using MySQL databased using ephemeral (temporary) storage and secure communication using https.",
             "template.openshift.io/support-url": "https://access.redhat.com",
-            "version": "1.4.8"
+            "version": "1.4.16"
         },
         "name": "datagrid71-mysql"
     },
@@ -512,7 +512,7 @@
                             ],
                             "from": {
                                 "kind": "ImageStreamTag",
-                                "name": "jboss-datagrid71-openshift:1.2",
+                                "name": "jboss-datagrid71-openshift:1.3",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}"
                             }
                         },
@@ -588,6 +588,13 @@
                                 ],
                                 "image": "mysql",
                                 "imagePullPolicy": "Always",
+                                "livenessProbe": {
+                                    "initialDelaySeconds": 30,
+                                    "tcpSocket": {
+                                        "port": 3306
+                                    },
+                                    "timeoutSeconds": 1
+                                },
                                 "name": "${APPLICATION_NAME}-mysql",
                                 "ports": [
                                     {
@@ -595,6 +602,18 @@
                                         "protocol": "TCP"
                                     }
                                 ],
+                                "readinessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "/bin/sh",
+                                            "-i",
+                                            "-c",
+                                            "MYSQL_PWD=\"$MYSQL_PASSWORD\" mysql -h 127.0.0.1 -u $MYSQL_USER -D $MYSQL_DATABASE -e 'SELECT 1'"
+                                        ]
+                                    },
+                                    "initialDelaySeconds": 5,
+                                    "timeoutSeconds": 1
+                                },
                                 "volumeMounts": [
                                     {
                                         "mountPath": "/var/lib/mysql/data",

--- a/official/datagrid/templates/datagrid71-postgresql-persistent.json
+++ b/official/datagrid/templates/datagrid71-postgresql-persistent.json
@@ -3,7 +3,7 @@
     "kind": "Template",
     "labels": {
         "template": "datagrid71-postgresql-persistent",
-        "xpaas": "1.4.8"
+        "xpaas": "1.4.16"
     },
     "message": "A new data grid service (using PostgreSQL with persistent storage) has been created in your project. It supports connector type(s) \"${INFINISPAN_CONNECTORS}\". The username/password for accessing the MySQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "metadata": {
@@ -16,7 +16,7 @@
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-data-grid/",
             "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Data Grid 7.1 based application, including a deployment configuration, using PostgreSQL database using persistence and secure communication using https.",
             "template.openshift.io/support-url": "https://access.redhat.com",
-            "version": "1.4.8"
+            "version": "1.4.16"
         },
         "name": "datagrid71-postgresql-persistent"
     },
@@ -510,7 +510,7 @@
                             ],
                             "from": {
                                 "kind": "ImageStreamTag",
-                                "name": "jboss-datagrid71-openshift:1.2",
+                                "name": "jboss-datagrid71-openshift:1.3",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}"
                             }
                         },
@@ -578,6 +578,13 @@
                                 ],
                                 "image": "postgresql",
                                 "imagePullPolicy": "Always",
+                                "livenessProbe": {
+                                    "initialDelaySeconds": 30,
+                                    "tcpSocket": {
+                                        "port": 5432
+                                    },
+                                    "timeoutSeconds": 1
+                                },
                                 "name": "${APPLICATION_NAME}-postgresql",
                                 "ports": [
                                     {
@@ -585,6 +592,18 @@
                                         "protocol": "TCP"
                                     }
                                 ],
+                                "readinessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "/bin/sh",
+                                            "-i",
+                                            "-c",
+                                            "psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'"
+                                        ]
+                                    },
+                                    "initialDelaySeconds": 5,
+                                    "timeoutSeconds": 1
+                                },
                                 "volumeMounts": [
                                     {
                                         "mountPath": "/var/lib/pgsql/data",

--- a/official/datagrid/templates/datagrid71-postgresql.json
+++ b/official/datagrid/templates/datagrid71-postgresql.json
@@ -3,7 +3,7 @@
     "kind": "Template",
     "labels": {
         "template": "datagrid71-postgresql",
-        "xpaas": "1.4.8"
+        "xpaas": "1.4.16"
     },
     "message": "A new data grid service (using PostgreSQL) has been created in your project. It supports connector type(s) \"${INFINISPAN_CONNECTORS}\". The username/password for accessing the MySQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "metadata": {
@@ -16,7 +16,7 @@
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-data-grid/",
             "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Data Grid 7.1 based application, including a deployment configuration, using PostgreSQL database using ephemeral (temporary) storage and secure communication using https.",
             "template.openshift.io/support-url": "https://access.redhat.com",
-            "version": "1.4.8"
+            "version": "1.4.16"
         },
         "name": "datagrid71-postgresql"
     },
@@ -510,7 +510,7 @@
                             ],
                             "from": {
                                 "kind": "ImageStreamTag",
-                                "name": "jboss-datagrid71-openshift:1.2",
+                                "name": "jboss-datagrid71-openshift:1.3",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}"
                             }
                         },
@@ -578,6 +578,13 @@
                                 ],
                                 "image": "postgresql",
                                 "imagePullPolicy": "Always",
+                                "livenessProbe": {
+                                    "initialDelaySeconds": 30,
+                                    "tcpSocket": {
+                                        "port": 5432
+                                    },
+                                    "timeoutSeconds": 1
+                                },
                                 "name": "${APPLICATION_NAME}-postgresql",
                                 "ports": [
                                     {
@@ -585,6 +592,18 @@
                                         "protocol": "TCP"
                                     }
                                 ],
+                                "readinessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "/bin/sh",
+                                            "-i",
+                                            "-c",
+                                            "psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'"
+                                        ]
+                                    },
+                                    "initialDelaySeconds": 5,
+                                    "timeoutSeconds": 1
+                                },
                                 "volumeMounts": [
                                     {
                                         "mountPath": "/var/lib/pgsql/data",

--- a/official/index.json
+++ b/official/index.json
@@ -117,43 +117,43 @@
     "datagrid": {
         "imagestreams": [
             {
-                "docs": "https://access.redhat.com/documentation/en/red-hat-jboss-middleware-for-openshift/3/paged/red-hat-jboss-data-grid-for-openshift/",
+                "docs": "https://access.redhat.com/documentation/en-us/red_hat_jboss_data_grid/6.5/html/data_grid_for_openshift/",
                 "name": "jboss-datagrid65-openshift",
                 "path": "official/datagrid/imagestreams/jboss-datagrid65-openshift-rhel7.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/jboss-image-streams.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/ose-v1.4.16/templates/deprecated/datagrid65-image-stream.json"
             },
             {
-                "docs": "https://access.redhat.com/documentation/en/red-hat-jboss-middleware-for-openshift/3/paged/red-hat-jboss-data-grid-for-openshift/",
-                "name": "jboss-datagrid71-openshift",
-                "path": "official/datagrid/imagestreams/jboss-datagrid71-openshift-rhel7.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/jboss-image-streams.json"
-            },
-            {
-                "docs": "https://access.redhat.com/documentation/en/red-hat-jboss-middleware-for-openshift/3/paged/red-hat-jboss-data-grid-for-openshift/",
+                "docs": "https://access.redhat.com/documentation/en-us/red_hat_jboss_data_grid/6.5/html/data_grid_for_openshift/",
                 "name": "jboss-datagrid65-client-openshift",
                 "path": "official/datagrid/imagestreams/jboss-datagrid65-client-openshift-rhel7.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/jboss-image-streams.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/ose-v1.4.16/templates/deprecated/datagrid65-image-stream.json"
             },
             {
-                "docs": "https://access.redhat.com/documentation/en/red-hat-jboss-middleware-for-openshift/3/paged/red-hat-jboss-data-grid-for-openshift/",
+                "docs": "https://access.redhat.com/documentation/en-us/red_hat_jboss_data_grid/7.1/html/data_grid_for_openshift/",
+                "name": "jboss-datagrid71-openshift",
+                "path": "official/datagrid/imagestreams/jboss-datagrid71-openshift-rhel7.json",
+                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/datagrid/datagrid71-image-stream.json"
+            },
+            {
+                "docs": "https://access.redhat.com/documentation/en-us/red_hat_jboss_data_grid/7.1/html/data_grid_for_openshift/",
                 "name": "jboss-datagrid71-client-openshift",
                 "path": "official/datagrid/imagestreams/jboss-datagrid71-client-openshift-rhel7.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/jboss-image-streams.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/datagrid/datagrid71-image-stream.json"
             },
             {
-                "docs": "https://access.redhat.com/documentation/en/red-hat-jboss-middleware-for-openshift/3/paged/red-hat-jboss-data-grid-for-openshift/",
+                "docs": "https://access.redhat.com/documentation/en-us/red_hat_jboss_data_grid/7.2/html/data_grid_for_openshift/",
                 "name": "jboss-datagrid72-openshift",
                 "path": "official/datagrid/imagestreams/jboss-datagrid72-openshift-rhel7.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/datagrid72/templates/datagrid72-image-stream.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/1.1.1/templates/datagrid72-image-stream.json"
             }
         ],
         "templates": [
             {
                 "description": "Red Hat Data Grid is a high performance, linearly scalable, key/value data grid solution. It provides many features to serve a variety of use cases.",
-                "docs": "https://github.com/jboss-container-images/datagrid-7-image/blob/datagrid-services-dev/documentation/cache-service.asciidoc",
+                "docs": "https://github.com/jboss-container-images/datagrid-7-image/blob/1.0.TP/documentation/cache-service.asciidoc",
                 "name": "caching-service",
                 "path": "official/datagrid/templates/caching-service.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/datagrid-7-image/datagrid-services-dev/templates/caching-service.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/datagrid-7-image/1.0.TP/templates/caching-service.json"
             },
             {
                 "description": "Application template for JDG 6.5 applications.",
@@ -199,87 +199,87 @@
             },
             {
                 "description": "An example JBoss Data Grid application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
-                "docs": "https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.8-1/docs/datagrid/datagrid71-basic.adoc",
+                "docs": "https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/datagrid/datagrid71-basic.adoc",
                 "name": "datagrid71-basic",
                 "path": "official/datagrid/templates/datagrid71-basic.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/datagrid/datagrid71-basic.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/datagrid/datagrid71-basic.json"
             },
             {
                 "description": "An example JBoss Data Grid application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
-                "docs": "https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.8-1/docs/datagrid/datagrid71-https.adoc",
+                "docs": "https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/datagrid/datagrid71-https.adoc",
                 "name": "datagrid71-https",
                 "path": "official/datagrid/templates/datagrid71-https.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/datagrid/datagrid71-https.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/datagrid/datagrid71-https.json"
             },
             {
                 "description": "An example JBoss Data Grid application with a MySQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
-                "docs": "https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.8-1/docs/datagrid/datagrid71-mysql-persistent.adoc",
+                "docs": "https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/datagrid/datagrid71-mysql-persistent.adoc",
                 "name": "datagrid71-mysql-persistent",
                 "path": "official/datagrid/templates/datagrid71-mysql-persistent.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/datagrid/datagrid71-mysql-persistent.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/datagrid/datagrid71-mysql-persistent.json"
             },
             {
                 "description": "An example JBoss Data Grid application with a MySQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
-                "docs": "https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.8-1/docs/datagrid/datagrid71-mysql.adoc",
+                "docs": "https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/datagrid/datagrid71-mysql.adoc",
                 "name": "datagrid71-mysql",
                 "path": "official/datagrid/templates/datagrid71-mysql.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/datagrid/datagrid71-mysql.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/datagrid/datagrid71-mysql.json"
             },
             {
                 "description": "An example JBoss Data Grid application with a PostgreSQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
-                "docs": "https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.8-1/docs/datagrid/datagrid71-postgresql-persistent.adoc",
+                "docs": "https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/datagrid/datagrid71-postgresql-persistent.adoc",
                 "name": "datagrid71-postgresql-persistent",
                 "path": "official/datagrid/templates/datagrid71-postgresql-persistent.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/datagrid/datagrid71-postgresql-persistent.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/datagrid/datagrid71-postgresql-persistent.json"
             },
             {
                 "description": "An example JBoss Data Grid application with a PostgreSQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
-                "docs": "https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.8-1/docs/datagrid/datagrid71-postgresql.adoc",
+                "docs": "https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/datagrid/datagrid71-postgresql.adoc",
                 "name": "datagrid71-postgresql",
                 "path": "official/datagrid/templates/datagrid71-postgresql.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.8-1/datagrid/datagrid71-postgresql.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/datagrid/datagrid71-postgresql.json"
             },
             {
                 "description": "An example Red Hat JBoss Data Grid application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
-                "docs": "https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/datagrid72-dev/docs/datagrid72-basic.adoc",
+                "docs": "https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/1.1.1/docs/datagrid72-basic.adoc",
                 "name": "datagrid72-basic",
                 "path": "official/datagrid/templates/datagrid72-basic.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/datagrid72/templates/datagrid72-basic.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/1.1.1/templates/datagrid72-basic.json"
             },
             {
                 "description": "An example Red Hat JBoss Data Grid application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
-                "docs": "https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/datagrid72-dev/docs/datagrid72-https.adoc",
+                "docs": "https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/1.1.1/docs/datagrid72-https.adoc",
                 "name": "datagrid72-https",
                 "path": "official/datagrid/templates/datagrid72-https.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/datagrid72/templates/datagrid72-https.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/1.1.1/templates/datagrid72-https.json"
             },
             {
                 "description": "An example Red Hat JBoss Data Grid application with a MySQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
-                "docs": "https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/datagrid72-dev/docs/datagrid72-mysql-persistent.adoc",
+                "docs": "https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/1.1.1/docs/datagrid72-mysql-persistent.adoc",
                 "name": "datagrid72-mysql-persistent",
                 "path": "official/datagrid/templates/datagrid72-mysql-persistent.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/datagrid72/templates/datagrid72-mysql-persistent.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/1.1.1/templates/datagrid72-mysql-persistent.json"
             },
             {
                 "description": "An example Red Hat JBoss Data Grid application with a MySQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
-                "docs": "https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/datagrid72-dev/docs/datagrid72-mysql.adoc",
+                "docs": "https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/1.1.1/docs/datagrid72-mysql.adoc",
                 "name": "datagrid72-mysql",
                 "path": "official/datagrid/templates/datagrid72-mysql.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/datagrid72/templates/datagrid72-mysql.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/1.1.1/templates/datagrid72-mysql.json"
             },
             {
                 "description": "An example Red Hat JBoss Data Grid application with a PostgreSQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
-                "docs": "https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/datagrid72-dev/docs/datagrid72-postgresql-persistent.adoc",
+                "docs": "https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/1.1.1/docs/datagrid72-postgresql-persistent.adoc",
                 "name": "datagrid72-postgresql-persistent",
                 "path": "official/datagrid/templates/datagrid72-postgresql-persistent.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/datagrid72/templates/datagrid72-postgresql-persistent.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/1.1.1/templates/datagrid72-postgresql-persistent.json"
             },
             {
                 "description": "An example Red Hat JBoss Data Grid application with a PostgreSQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
-                "docs": "https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/datagrid72-dev/docs/datagrid72-postgresql.adoc",
+                "docs": "https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/blob/1.1.1/docs/datagrid72-postgresql.adoc",
                 "name": "datagrid72-postgresql",
                 "path": "official/datagrid/templates/datagrid72-postgresql.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/datagrid72/templates/datagrid72-postgresql.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/jboss-datagrid-7-openshift-image/1.1.1/templates/datagrid72-postgresql.json"
             }
         ]
     },


### PR DESCRIPTION
Restored Data Grid 6.5 image streams (moved to jboss-container-images/jboss-datagrid-7-openshift-image repo)
Updated Data Grid 7.1 to use the correct tag in jboss-openshift/application-templates
Updated Data Grid 7.2 to use the correct tag in jboss-container-images/jboss-datagrid-7-openshift-image
Updated Cache Service to use the correct tag in jboss-container-images/datagrid-7-image
All image streams now using registry.redhat.io

Signed-off-by: Osni Oliveira <osni.oliveira@redhat.com>