### PR TITLE
Update EAP CD streams and templates to point to CD13-OS tag

### DIFF
--- a/community/perl/imagestreams/perl-centos7.json
+++ b/community/perl/imagestreams/perl-centos7.json
@@ -15,7 +15,7 @@
                     "iconClass": "icon-perl",
                     "openshift.io/display-name": "Perl (Latest)",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "sampleRepo": "https://github.com/openshift/dancer-ex.git",
+                    "sampleRepo": "https://github.com/sclorg/dancer-ex.git",
                     "supports": "perl",
                     "tags": "builder,perl"
                 },
@@ -34,7 +34,7 @@
                     "iconClass": "icon-perl",
                     "openshift.io/display-name": "Perl 5.16",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "sampleRepo": "https://github.com/openshift/dancer-ex.git",
+                    "sampleRepo": "https://github.com/sclorg/dancer-ex.git",
                     "supports": "perl:5.16,perl",
                     "tags": "hidden,builder,perl",
                     "version": "5.16"
@@ -54,7 +54,7 @@
                     "iconClass": "icon-perl",
                     "openshift.io/display-name": "Perl 5.20",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "sampleRepo": "https://github.com/openshift/dancer-ex.git",
+                    "sampleRepo": "https://github.com/sclorg/dancer-ex.git",
                     "supports": "perl:5.20,perl",
                     "tags": "hidden,builder,perl",
                     "version": "5.20"
@@ -74,7 +74,7 @@
                     "iconClass": "icon-perl",
                     "openshift.io/display-name": "Perl 5.24",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "sampleRepo": "https://github.com/openshift/dancer-ex.git",
+                    "sampleRepo": "https://github.com/sclorg/dancer-ex.git",
                     "supports": "perl:5.24,perl",
                     "tags": "builder,perl",
                     "version": "5.24"
@@ -94,7 +94,7 @@
                     "iconClass": "icon-perl",
                     "openshift.io/display-name": "Perl 5.26",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "sampleRepo": "https://github.com/openshift/dancer-ex.git",
+                    "sampleRepo": "https://github.com/sclorg/dancer-ex.git",
                     "supports": "perl:5.26,perl",
                     "tags": "builder,perl",
                     "version": "5.26"

--- a/official.yaml
+++ b/official.yaml
@@ -3,6 +3,7 @@ variables:
   openjdk_version: ose-v1.4.16
   amq_version: ose-v1.4.12
   eap_version: ose-v1.4.16
+  eap_cd_version: CD13-OS
   rhsso_version: ose-v1.4.14
   webserver_version: ose-v1.4.16
   ips_ds_version: ose-v1.4.16
@@ -490,26 +491,26 @@ data:
           - ocp
   eap-cd:
     templates:
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/eap-cd/templates/eap-cd-basic-s2i.json
-        docs: https://github.com/jboss-container-images/jboss-eap-7-openshift-image/tree/eap-cd/docs/templates/eap-cd-basic-s2i.adoc
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/{eap_cd_version}/templates/eap-cd-basic-s2i.json
+        docs: https://github.com/jboss-container-images/jboss-eap-7-openshift-image/tree/{eap_cd_version}/docs/templates/eap-cd-basic-s2i.adoc
         tags:
           - ocp
           - online-professional
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/eap-cd/templates/eap-cd-amq-persistent-s2i.json
-        docs: https://github.com/jboss-container-images/jboss-eap-7-openshift-image/tree/eap-cd/docs/templates/eap-cd-amq-persistent-s2i.adoc
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/{eap_cd_version}/templates/eap-cd-amq-persistent-s2i.json
+        docs: https://github.com/jboss-container-images/jboss-eap-7-openshift-image/tree/{eap_cd_version}/docs/templates/eap-cd-amq-persistent-s2i.adoc
         tags:
           - ocp
           - online-professional
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/eap-cd/templates/eap-cd-postgresql-persistent-s2i.json
-        docs: https://github.com/jboss-container-images/jboss-eap-7-openshift-image/tree/eap-cd/docs/templates/eap-cd-postgresql-persistent-s2i.adoc
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/{eap_cd_version}/templates/eap-cd-postgresql-persistent-s2i.json
+        docs: https://github.com/jboss-container-images/jboss-eap-7-openshift-image/tree/{eap_cd_version}/docs/templates/eap-cd-postgresql-persistent-s2i.adoc
         tags:
           - ocp
           - online-professional
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/eap-cd/templates/eap-cd-basic-s2i.json
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/{eap_cd_version}/templates/eap-cd-basic-s2i.json
         tags:
           - online-starter
     imagestreams:
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/eap-cd/templates/eap-cd-image-stream.json
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/{eap_cd_version}/templates/eap-cd-image-stream.json
         docs: https://access.redhat.com/documentation/en-us/jboss_enterprise_application_platform_continuous_delivery/13/html/getting_started_with_jboss_eap_for_openshift_container_platform/
         regex: eap-cd
         suffix: rhel7

--- a/official/README.md
+++ b/official/README.md
@@ -408,24 +408,24 @@ Path: official/eap/templates/eap72-postgresql-persistent-s2i.json
 # eap-cd
 ## imagestreams
 ### eap-cd-openshift
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/eap-cd/templates/eap-cd-image-stream.json](https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/eap-cd/templates/eap-cd-image-stream.json )  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/CD13-OS/templates/eap-cd-image-stream.json](https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/CD13-OS/templates/eap-cd-image-stream.json )  
 Docs: [https://access.redhat.com/documentation/en-us/jboss_enterprise_application_platform_continuous_delivery/13/html/getting_started_with_jboss_eap_for_openshift_container_platform/](https://access.redhat.com/documentation/en-us/jboss_enterprise_application_platform_continuous_delivery/13/html/getting_started_with_jboss_eap_for_openshift_container_platform/)  
 Path: official/eap-cd/imagestreams/eap-cd-openshift-rhel7.json  
 ## templates
 ### eap-cd-basic-s2i
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/eap-cd/templates/eap-cd-basic-s2i.json](https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/eap-cd/templates/eap-cd-basic-s2i.json )  
-Docs: [https://github.com/jboss-container-images/jboss-eap-7-openshift-image/tree/eap-cd/docs/templates/eap-cd-basic-s2i.adoc](https://github.com/jboss-container-images/jboss-eap-7-openshift-image/tree/eap-cd/docs/templates/eap-cd-basic-s2i.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/CD13-OS/templates/eap-cd-basic-s2i.json](https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/CD13-OS/templates/eap-cd-basic-s2i.json )  
+Docs: [https://github.com/jboss-container-images/jboss-eap-7-openshift-image/tree/CD13-OS/docs/templates/eap-cd-basic-s2i.adoc](https://github.com/jboss-container-images/jboss-eap-7-openshift-image/tree/CD13-OS/docs/templates/eap-cd-basic-s2i.adoc)  
 Path: official/eap-cd/templates/eap-cd-basic-s2i.json  
 ### eap-cd-amq-persistent-s2i
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/eap-cd/templates/eap-cd-amq-persistent-s2i.json](https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/eap-cd/templates/eap-cd-amq-persistent-s2i.json )  
-Docs: [https://github.com/jboss-container-images/jboss-eap-7-openshift-image/tree/eap-cd/docs/templates/eap-cd-amq-persistent-s2i.adoc](https://github.com/jboss-container-images/jboss-eap-7-openshift-image/tree/eap-cd/docs/templates/eap-cd-amq-persistent-s2i.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/CD13-OS/templates/eap-cd-amq-persistent-s2i.json](https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/CD13-OS/templates/eap-cd-amq-persistent-s2i.json )  
+Docs: [https://github.com/jboss-container-images/jboss-eap-7-openshift-image/tree/CD13-OS/docs/templates/eap-cd-amq-persistent-s2i.adoc](https://github.com/jboss-container-images/jboss-eap-7-openshift-image/tree/CD13-OS/docs/templates/eap-cd-amq-persistent-s2i.adoc)  
 Path: official/eap-cd/templates/eap-cd-amq-persistent-s2i.json  
 ### eap-cd-postgresql-persistent-s2i
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/eap-cd/templates/eap-cd-postgresql-persistent-s2i.json](https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/eap-cd/templates/eap-cd-postgresql-persistent-s2i.json )  
-Docs: [https://github.com/jboss-container-images/jboss-eap-7-openshift-image/tree/eap-cd/docs/templates/eap-cd-postgresql-persistent-s2i.adoc](https://github.com/jboss-container-images/jboss-eap-7-openshift-image/tree/eap-cd/docs/templates/eap-cd-postgresql-persistent-s2i.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/CD13-OS/templates/eap-cd-postgresql-persistent-s2i.json](https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/CD13-OS/templates/eap-cd-postgresql-persistent-s2i.json )  
+Docs: [https://github.com/jboss-container-images/jboss-eap-7-openshift-image/tree/CD13-OS/docs/templates/eap-cd-postgresql-persistent-s2i.adoc](https://github.com/jboss-container-images/jboss-eap-7-openshift-image/tree/CD13-OS/docs/templates/eap-cd-postgresql-persistent-s2i.adoc)  
 Path: official/eap-cd/templates/eap-cd-postgresql-persistent-s2i.json  
 ### eap-cd-basic-s2i
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/eap-cd/templates/eap-cd-basic-s2i.json](https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/eap-cd/templates/eap-cd-basic-s2i.json )  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/CD13-OS/templates/eap-cd-basic-s2i.json](https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/CD13-OS/templates/eap-cd-basic-s2i.json )  
 Path: official/eap-cd/templates/eap-cd-basic-s2i.json  
 # fis
 ## imagestreams

--- a/official/cakephp/templates/cakephp-example.json
+++ b/official/cakephp/templates/cakephp-example.json
@@ -261,7 +261,7 @@
             "value": "openshift"
         },
         {
-            "description": "Version of PHP image to be used (5.6, 7.0, 7.1 or latest).",
+            "description": "Version of PHP image to be used (7.1 or latest).",
             "displayName": "PHP Version",
             "name": "PHP_VERSION",
             "required": true,

--- a/official/cakephp/templates/cakephp-mysql-example.json
+++ b/official/cakephp/templates/cakephp-mysql-example.json
@@ -447,7 +447,7 @@
             "value": "openshift"
         },
         {
-            "description": "Version of PHP image to be used (5.6, 7.0, 7.1 or latest).",
+            "description": "Version of PHP image to be used (7.1 or latest).",
             "displayName": "PHP Version",
             "name": "PHP_VERSION",
             "required": true,

--- a/official/cakephp/templates/cakephp-mysql-persistent.json
+++ b/official/cakephp/templates/cakephp-mysql-persistent.json
@@ -466,7 +466,7 @@
             "value": "openshift"
         },
         {
-            "description": "Version of PHP image to be used (5.6, 7.0, 7.1 or latest).",
+            "description": "Version of PHP image to be used (7.1 or latest).",
             "displayName": "PHP Version",
             "name": "PHP_VERSION",
             "required": true,

--- a/official/dancer/templates/dancer-example.json
+++ b/official/dancer/templates/dancer-example.json
@@ -105,7 +105,7 @@
                         ],
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "perl:5.24",
+                            "name": "perl:5.26",
                             "namespace": "${NAMESPACE}"
                         }
                     },

--- a/official/dancer/templates/dancer-mysql-example.json
+++ b/official/dancer/templates/dancer-mysql-example.json
@@ -118,7 +118,7 @@
                         ],
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "perl:5.24",
+                            "name": "perl:5.26",
                             "namespace": "${NAMESPACE}"
                         }
                     },

--- a/official/dancer/templates/dancer-mysql-persistent.json
+++ b/official/dancer/templates/dancer-mysql-persistent.json
@@ -118,7 +118,7 @@
                         ],
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "perl:5.24",
+                            "name": "perl:5.26",
                             "namespace": "${NAMESPACE}"
                         }
                     },

--- a/official/django/templates/django-example.json
+++ b/official/django/templates/django-example.json
@@ -249,7 +249,7 @@
             "value": "openshift"
         },
         {
-            "description": "Version of Python image to be used (3.4, 3.5, 3.6 or latest).",
+            "description": "Version of Python image to be used (3.6 or latest).",
             "displayName": "Version of Python Image",
             "name": "PYTHON_VERSION",
             "required": true,

--- a/official/django/templates/django-psql-example.json
+++ b/official/django/templates/django-psql-example.json
@@ -424,18 +424,18 @@
             "value": "openshift"
         },
         {
-            "description": "Version of Python image to be used (3.4, 3.5, 3.6 or latest).",
+            "description": "Version of Python image to be used (3.6 or latest).",
             "displayName": "Version of Python Image",
             "name": "PYTHON_VERSION",
             "required": true,
             "value": "3.6"
         },
         {
-            "description": "Version of PostgreSQL image to be used (9.4, 9.5, 9.6 or latest).",
+            "description": "Version of PostgreSQL image to be used (10 or latest).",
             "displayName": "Version of PostgreSQL Image",
             "name": "POSTGRESQL_VERSION",
             "required": true,
-            "value": "9.6"
+            "value": "10"
         },
         {
             "description": "Maximum amount of memory the Django container can use.",

--- a/official/django/templates/django-psql-persistent.json
+++ b/official/django/templates/django-psql-persistent.json
@@ -443,18 +443,18 @@
             "value": "openshift"
         },
         {
-            "description": "Version of Python image to be used (3.4, 3.5, 3.6 or latest).",
+            "description": "Version of Python image to be used (3.6 or latest).",
             "displayName": "Version of Python Image",
             "name": "PYTHON_VERSION",
             "required": true,
             "value": "3.6"
         },
         {
-            "description": "Version of PostgreSQL image to be used (9.4, 9.5, 9.6 or latest).",
+            "description": "Version of PostgreSQL image to be used (10 or latest).",
             "displayName": "Version of PostgreSQL Image",
             "name": "POSTGRESQL_VERSION",
             "required": true,
-            "value": "9.6"
+            "value": "10"
         },
         {
             "description": "Maximum amount of memory the Django container can use.",

--- a/official/index.json
+++ b/official/index.json
@@ -707,37 +707,37 @@
                 "docs": "https://access.redhat.com/documentation/en-us/jboss_enterprise_application_platform_continuous_delivery/13/html/getting_started_with_jboss_eap_for_openshift_container_platform/",
                 "name": "eap-cd-openshift",
                 "path": "official/eap-cd/imagestreams/eap-cd-openshift-rhel7.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/eap-cd/templates/eap-cd-image-stream.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/CD13-OS/templates/eap-cd-image-stream.json"
             }
         ],
         "templates": [
             {
                 "description": "An example JBoss Enterprise Application Platform continuous delivery application. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap-cd/README.adoc",
-                "docs": "https://github.com/jboss-container-images/jboss-eap-7-openshift-image/tree/eap-cd/docs/templates/eap-cd-basic-s2i.adoc",
+                "docs": "https://github.com/jboss-container-images/jboss-eap-7-openshift-image/tree/CD13-OS/docs/templates/eap-cd-basic-s2i.adoc",
                 "name": "eap-cd-basic-s2i",
                 "path": "official/eap-cd/templates/eap-cd-basic-s2i.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/eap-cd/templates/eap-cd-basic-s2i.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/CD13-OS/templates/eap-cd-basic-s2i.json"
             },
             {
                 "description": "An example JBoss Enterprise Application Platform continuous delivery application using Red Hat JBoss AMQ with persistence and secure communication using https. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap-cd/README.adoc",
-                "docs": "https://github.com/jboss-container-images/jboss-eap-7-openshift-image/tree/eap-cd/docs/templates/eap-cd-amq-persistent-s2i.adoc",
+                "docs": "https://github.com/jboss-container-images/jboss-eap-7-openshift-image/tree/CD13-OS/docs/templates/eap-cd-amq-persistent-s2i.adoc",
                 "name": "eap-cd-amq-persistent-s2i",
                 "path": "official/eap-cd/templates/eap-cd-amq-persistent-s2i.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/eap-cd/templates/eap-cd-amq-persistent-s2i.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/CD13-OS/templates/eap-cd-amq-persistent-s2i.json"
             },
             {
                 "description": "An example JBoss Enterprise Application Platform continuous delivery application with a persistent PostgreSQL database. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap-cd/README.adoc",
-                "docs": "https://github.com/jboss-container-images/jboss-eap-7-openshift-image/tree/eap-cd/docs/templates/eap-cd-postgresql-persistent-s2i.adoc",
+                "docs": "https://github.com/jboss-container-images/jboss-eap-7-openshift-image/tree/CD13-OS/docs/templates/eap-cd-postgresql-persistent-s2i.adoc",
                 "name": "eap-cd-postgresql-persistent-s2i",
                 "path": "official/eap-cd/templates/eap-cd-postgresql-persistent-s2i.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/eap-cd/templates/eap-cd-postgresql-persistent-s2i.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/CD13-OS/templates/eap-cd-postgresql-persistent-s2i.json"
             },
             {
                 "description": "An example JBoss Enterprise Application Platform continuous delivery application. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap-cd/README.adoc",
                 "docs": "",
                 "name": "eap-cd-basic-s2i",
                 "path": "official/eap-cd/templates/eap-cd-basic-s2i.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/eap-cd/templates/eap-cd-basic-s2i.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/CD13-OS/templates/eap-cd-basic-s2i.json"
             }
         ]
     },

--- a/official/jenkins/templates/jenkins-ephemeral.json
+++ b/official/jenkins/templates/jenkins-ephemeral.json
@@ -11,7 +11,7 @@
             "description": "Jenkins service, without persistent storage.\n\nWARNING: Any data stored will be lost upon pod destruction. Only use this template for testing.",
             "iconClass": "icon-jenkins",
             "openshift.io/display-name": "Jenkins (Ephemeral)",
-            "openshift.io/documentation-url": "https://docs.openshift.org/latest/using_images/other_images/jenkins.html",
+            "openshift.io/documentation-url": "https://docs.okd.io/latest/using_images/other_images/jenkins.html",
             "openshift.io/long-description": "This template deploys a Jenkins server capable of managing OpenShift Pipeline builds and supporting OpenShift-based oauth login.  The Jenkins configuration is stored in non-persistent storage, so this configuration should be used for experimental purposes only.",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "openshift.io/support-url": "https://access.redhat.com",

--- a/official/jenkins/templates/jenkins-persistent.json
+++ b/official/jenkins/templates/jenkins-persistent.json
@@ -11,7 +11,7 @@
             "description": "Jenkins service, with persistent storage.\n\nNOTE: You must have persistent volumes available in your cluster to use this template.",
             "iconClass": "icon-jenkins",
             "openshift.io/display-name": "Jenkins",
-            "openshift.io/documentation-url": "https://docs.openshift.org/latest/using_images/other_images/jenkins.html",
+            "openshift.io/documentation-url": "https://docs.okd.io/latest/using_images/other_images/jenkins.html",
             "openshift.io/long-description": "This template deploys a Jenkins server capable of managing OpenShift Pipeline builds and supporting OpenShift-based oauth login.",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "openshift.io/support-url": "https://access.redhat.com",

--- a/official/mariadb/templates/mariadb-ephemeral.json
+++ b/official/mariadb/templates/mariadb-ephemeral.json
@@ -248,7 +248,7 @@
             "value": "sampledb"
         },
         {
-            "description": "Version of MariaDB image to be used (10.1, 10.2 or latest).",
+            "description": "Version of MariaDB image to be used (10.2 or latest).",
             "displayName": "Version of MariaDB Image",
             "name": "MARIADB_VERSION",
             "required": true,

--- a/official/mariadb/templates/mariadb-persistent.json
+++ b/official/mariadb/templates/mariadb-persistent.json
@@ -265,7 +265,7 @@
             "value": "sampledb"
         },
         {
-            "description": "Version of MariaDB image to be used (10.1, 10.2 or latest).",
+            "description": "Version of MariaDB image to be used (10.2 or latest).",
             "displayName": "Version of MariaDB Image",
             "name": "MARIADB_VERSION",
             "required": true,

--- a/official/mongodb/templates/mongodb-ephemeral.json
+++ b/official/mongodb/templates/mongodb-ephemeral.json
@@ -267,11 +267,11 @@
             "required": true
         },
         {
-            "description": "Version of MongoDB image to be used (2.4, 2.6, 3.2 or latest).",
+            "description": "Version of MongoDB image to be used (3.6 or latest).",
             "displayName": "Version of MongoDB Image",
             "name": "MONGODB_VERSION",
             "required": true,
-            "value": "3.2"
+            "value": "3.6"
         }
     ]
 }

--- a/official/mongodb/templates/mongodb-persistent.json
+++ b/official/mongodb/templates/mongodb-persistent.json
@@ -291,11 +291,11 @@
             "value": "1Gi"
         },
         {
-            "description": "Version of MongoDB image to be used (2.4, 2.6, 3.2 or latest).",
+            "description": "Version of MongoDB image to be used (3.6 or latest).",
             "displayName": "Version of MongoDB Image",
             "name": "MONGODB_VERSION",
             "required": true,
-            "value": "3.2"
+            "value": "3.6"
         }
     ]
 }

--- a/official/nodejs/templates/nodejs-mongo-persistent.json
+++ b/official/nodejs/templates/nodejs-mongo-persistent.json
@@ -456,11 +456,11 @@
             "value": "8"
         },
         {
-            "description": "Version of MongoDB image to be used (3.2, 3.4, or latest).",
+            "description": "Version of MongoDB image to be used (3.6 or latest).",
             "displayName": "Version of MongoDB Image",
             "name": "MONGODB_VERSION",
             "required": true,
-            "value": "3.4"
+            "value": "3.6"
         },
         {
             "description": "Maximum amount of memory the Node.js container can use.",

--- a/official/nodejs/templates/nodejs-mongodb-example.json
+++ b/official/nodejs/templates/nodejs-mongodb-example.json
@@ -440,11 +440,11 @@
             "value": "8"
         },
         {
-            "description": "Version of MongoDB image to be used (3.2, 3.4, or latest).",
+            "description": "Version of MongoDB image to be used (3.6 or latest).",
             "displayName": "Version of MongoDB Image",
             "name": "MONGODB_VERSION",
             "required": true,
-            "value": "3.4"
+            "value": "3.6"
         },
         {
             "description": "Maximum amount of memory the Node.js container can use.",

--- a/official/perl/imagestreams/perl-rhel7.json
+++ b/official/perl/imagestreams/perl-rhel7.json
@@ -15,7 +15,7 @@
                     "iconClass": "icon-perl",
                     "openshift.io/display-name": "Perl (Latest)",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "sampleRepo": "https://github.com/openshift/dancer-ex.git",
+                    "sampleRepo": "https://github.com/sclorg/dancer-ex.git",
                     "supports": "perl",
                     "tags": "builder,perl"
                 },
@@ -34,7 +34,7 @@
                     "iconClass": "icon-perl",
                     "openshift.io/display-name": "Perl 5.16",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "sampleRepo": "https://github.com/openshift/dancer-ex.git",
+                    "sampleRepo": "https://github.com/sclorg/dancer-ex.git",
                     "supports": "perl:5.16,perl",
                     "tags": "hidden,builder,perl",
                     "version": "5.16"
@@ -54,7 +54,7 @@
                     "iconClass": "icon-perl",
                     "openshift.io/display-name": "Perl 5.20",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "sampleRepo": "https://github.com/openshift/dancer-ex.git",
+                    "sampleRepo": "https://github.com/sclorg/dancer-ex.git",
                     "supports": "perl:5.20,perl",
                     "tags": "hidden,builder,perl",
                     "version": "5.20"
@@ -74,7 +74,7 @@
                     "iconClass": "icon-perl",
                     "openshift.io/display-name": "Perl 5.24",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "sampleRepo": "https://github.com/openshift/dancer-ex.git",
+                    "sampleRepo": "https://github.com/sclorg/dancer-ex.git",
                     "supports": "perl:5.24,perl",
                     "tags": "builder,perl",
                     "version": "5.24"
@@ -94,7 +94,7 @@
                     "iconClass": "icon-perl",
                     "openshift.io/display-name": "Perl 5.26",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "sampleRepo": "https://github.com/openshift/dancer-ex.git",
+                    "sampleRepo": "https://github.com/sclorg/dancer-ex.git",
                     "supports": "perl:5.26,perl",
                     "tags": "builder,perl",
                     "version": "5.26"

--- a/official/postgresql/templates/postgresql-ephemeral.json
+++ b/official/postgresql/templates/postgresql-ephemeral.json
@@ -248,11 +248,11 @@
             "value": "sampledb"
         },
         {
-            "description": "Version of PostgreSQL image to be used (9.4, 9.5, 9.6 or latest).",
+            "description": "Version of PostgreSQL image to be used (10 or latest).",
             "displayName": "Version of PostgreSQL Image",
             "name": "POSTGRESQL_VERSION",
             "required": true,
-            "value": "9.6"
+            "value": "10"
         }
     ]
 }

--- a/official/postgresql/templates/postgresql-persistent.json
+++ b/official/postgresql/templates/postgresql-persistent.json
@@ -272,11 +272,11 @@
             "value": "1Gi"
         },
         {
-            "description": "Version of PostgreSQL image to be used (9.4, 9.5, 9.6 or latest).",
+            "description": "Version of PostgreSQL image to be used (10 or latest).",
             "displayName": "Version of PostgreSQL Image",
             "name": "POSTGRESQL_VERSION",
             "required": true,
-            "value": "9.6"
+            "value": "10"
         }
     ]
 }

--- a/official/rails/templates/rails-pgsql-persistent.json
+++ b/official/rails/templates/rails-pgsql-persistent.json
@@ -120,7 +120,7 @@
                         ],
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "ruby:2.3",
+                            "name": "ruby:2.5",
                             "namespace": "${NAMESPACE}"
                         }
                     },
@@ -461,7 +461,7 @@
                             ],
                             "from": {
                                 "kind": "ImageStreamTag",
-                                "name": "postgresql:9.5",
+                                "name": "postgresql:10",
                                 "namespace": "${NAMESPACE}"
                             }
                         },

--- a/official/rails/templates/rails-postgresql-example.json
+++ b/official/rails/templates/rails-postgresql-example.json
@@ -120,7 +120,7 @@
                         ],
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "ruby:2.3",
+                            "name": "ruby:2.5",
                             "namespace": "${NAMESPACE}"
                         }
                     },
@@ -442,7 +442,7 @@
                             ],
                             "from": {
                                 "kind": "ImageStreamTag",
-                                "name": "postgresql:9.5",
+                                "name": "postgresql:10",
                                 "namespace": "${NAMESPACE}"
                             }
                         },


### PR DESCRIPTION
Signed-off-by: Ken Wills <kwills@redhat.com>

Note no changes in templates, just adding a tag to fix the source version.