### PR TITLE
[KEYCLOAK-8428] [KEYCLOAK-7785] Update RH-SSO 7.2 templates to 'ose-v1.4.16'. Introduce RH-SSO 7.3 TP CD image stream and x509 https template

### DIFF
--- a/official.yaml
+++ b/official.yaml
@@ -4,7 +4,8 @@ variables:
   amq_version: ose-v1.4.12
   eap_version: ose-v1.4.16
   eap_cd_version: CD13-OS
-  rhsso_version: ose-v1.4.14
+  rhsso_zstream_version: ose-v1.4.16
+  rhsso_tpcd_version: sso-cd-dev
   webserver_version: ose-v1.4.16
   ips_ds_version: ose-v1.4.16
   rhdm_version: 7.0.1.GA
@@ -795,47 +796,62 @@ data:
           - online-professional
   sso:
     templates:
-      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{rhsso_version}/sso/sso72-https.json
-        docs: https://github.com/jboss-openshift/application-templates/blob/{rhsso_version}/docs/sso/sso72-https.adoc
+      # List templates for RH-SSO 7.2 stable / zstream images stream below
+      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{rhsso_zstream_version}/sso/sso72-https.json
+        docs: https://github.com/jboss-openshift/application-templates/blob/{rhsso_zstream_version}/docs/sso/sso72-https.adoc
         tags:
           - ocp
-      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{rhsso_version}/sso/sso72-mysql-persistent.json
-        docs: https://github.com/jboss-openshift/application-templates/blob/{rhsso_version}/docs/sso/sso72-mysql-persistent.adoc
+      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{rhsso_zstream_version}/sso/sso72-mysql-persistent.json
+        docs: https://github.com/jboss-openshift/application-templates/blob/{rhsso_zstream_version}/docs/sso/sso72-mysql-persistent.adoc
         tags:
           - ocp
-      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{rhsso_version}/sso/sso72-mysql.json
-        docs: https://github.com/jboss-openshift/application-templates/blob/{rhsso_version}/docs/sso/sso72-mysql.adoc
+      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{rhsso_zstream_version}/sso/sso72-mysql.json
+        docs: https://github.com/jboss-openshift/application-templates/blob/{rhsso_zstream_version}/docs/sso/sso72-mysql.adoc
         tags:
           - ocp
-      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{rhsso_version}/sso/sso72-postgresql-persistent.json
-        docs: https://github.com/jboss-openshift/application-templates/blob/{rhsso_version}/docs/sso/sso72-postgresql-persistent.adoc
+      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{rhsso_zstream_version}/sso/sso72-postgresql-persistent.json
+        docs: https://github.com/jboss-openshift/application-templates/blob/{rhsso_zstream_version}/docs/sso/sso72-postgresql-persistent.adoc
         tags:
           - ocp
-      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{rhsso_version}/sso/sso72-postgresql.json
-        docs: https://github.com/jboss-openshift/application-templates/blob/{rhsso_version}/docs/sso/sso72-postgresql.adoc
+      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{rhsso_zstream_version}/sso/sso72-postgresql.json
+        docs: https://github.com/jboss-openshift/application-templates/blob/{rhsso_zstream_version}/docs/sso/sso72-postgresql.adoc
         tags:
           - ocp
-      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{rhsso_version}/sso/sso72-x509-https.json
-        docs: https://github.com/jboss-openshift/application-templates/blob/{rhsso_version}/docs/sso/sso72-x509-https.adoc
+      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{rhsso_zstream_version}/sso/sso72-x509-https.json
+        docs: https://github.com/jboss-openshift/application-templates/blob/{rhsso_zstream_version}/docs/sso/sso72-x509-https.adoc
         tags:
           - ocp
           - online-starter
           - online-professional
+      # List templates for RH-SSO 7.3 Technology Preview Continuous Delivery (CD) images stream below
+      - location: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/{rhsso_tpcd_version}/templates/sso-cd-x509-https.json
+        docs: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/{rhsso_tpcd_version}/docs/templates/sso-cd-x509-https.adoc
+        tags:
+          - online-starter
+          - online-professional
     imagestreams:
-      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{rhsso_version}/sso/sso70-image-stream.json
+      # List imagestreams for RH-SSO 7.0, 7.1, 7.2 stable / stream images stream below
+      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{rhsso_zstream_version}/sso/sso70-image-stream.json
         docs: https://access.redhat.com/documentation/en/red-hat-jboss-middleware-for-openshift/3/paged/red-hat-jboss-sso-for-openshift/
         suffix: rhel7
         tags:
           - ocp
-      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{rhsso_version}/sso/sso71-image-stream.json
+      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{rhsso_zstream_version}/sso/sso71-image-stream.json
         docs: https://access.redhat.com/documentation/en/red-hat-jboss-middleware-for-openshift/3/paged/red-hat-jboss-sso-for-openshift/
         suffix: rhel7
         tags:
           - ocp
-      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{rhsso_version}/sso/sso72-image-stream.json
+      - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{rhsso_zstream_version}/sso/sso72-image-stream.json
         docs: https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.2/html-single/red_hat_single_sign-on_for_openshift/
         tags:
           - ocp
+          - online-starter
+          - online-professional
+        suffix: rhel7
+      # List imagestream for RH-SSO 7.3 Technology Preview Continuous Delivery (CD) images stream below
+      - location: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/{rhsso_tpcd_version}/templates/sso-cd-image-stream.json
+        docs: https://access.redhat.com/documentation/en-us/red_hat_single_sign-on_continuous_delivery
+        tags:
           - online-starter
           - online-professional
         suffix: rhel7

--- a/official/README.md
+++ b/official/README.md
@@ -766,42 +766,50 @@ Path: official/ruby/imagestreams/ruby-rhel7.json
 # sso
 ## imagestreams
 ### redhat-sso70-openshift
-Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/sso/sso70-image-stream.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/sso/sso70-image-stream.json )  
+Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/sso/sso70-image-stream.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/sso/sso70-image-stream.json )  
 Docs: [https://access.redhat.com/documentation/en/red-hat-jboss-middleware-for-openshift/3/paged/red-hat-jboss-sso-for-openshift/](https://access.redhat.com/documentation/en/red-hat-jboss-middleware-for-openshift/3/paged/red-hat-jboss-sso-for-openshift/)  
 Path: official/sso/imagestreams/redhat-sso70-openshift-rhel7.json  
 ### redhat-sso71-openshift
-Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/sso/sso71-image-stream.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/sso/sso71-image-stream.json )  
+Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/sso/sso71-image-stream.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/sso/sso71-image-stream.json )  
 Docs: [https://access.redhat.com/documentation/en/red-hat-jboss-middleware-for-openshift/3/paged/red-hat-jboss-sso-for-openshift/](https://access.redhat.com/documentation/en/red-hat-jboss-middleware-for-openshift/3/paged/red-hat-jboss-sso-for-openshift/)  
 Path: official/sso/imagestreams/redhat-sso71-openshift-rhel7.json  
 ### redhat-sso72-openshift
-Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/sso/sso72-image-stream.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/sso/sso72-image-stream.json )  
+Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/sso/sso72-image-stream.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/sso/sso72-image-stream.json )  
 Docs: [https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.2/html-single/red_hat_single_sign-on_for_openshift/](https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.2/html-single/red_hat_single_sign-on_for_openshift/)  
 Path: official/sso/imagestreams/redhat-sso72-openshift-rhel7.json  
+### redhat-sso-cd-openshift
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/sso-cd-dev/templates/sso-cd-image-stream.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/sso-cd-dev/templates/sso-cd-image-stream.json )  
+Docs: [https://access.redhat.com/documentation/en-us/red_hat_single_sign-on_continuous_delivery](https://access.redhat.com/documentation/en-us/red_hat_single_sign-on_continuous_delivery)  
+Path: official/sso/imagestreams/redhat-sso-cd-openshift-rhel7.json  
 ## templates
 ### sso72-https
-Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/sso/sso72-https.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/sso/sso72-https.json )  
-Docs: [https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.14/docs/sso/sso72-https.adoc](https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.14/docs/sso/sso72-https.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/sso/sso72-https.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/sso/sso72-https.json )  
+Docs: [https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/sso/sso72-https.adoc](https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/sso/sso72-https.adoc)  
 Path: official/sso/templates/sso72-https.json  
 ### sso72-mysql-persistent
-Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/sso/sso72-mysql-persistent.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/sso/sso72-mysql-persistent.json )  
-Docs: [https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.14/docs/sso/sso72-mysql-persistent.adoc](https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.14/docs/sso/sso72-mysql-persistent.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/sso/sso72-mysql-persistent.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/sso/sso72-mysql-persistent.json )  
+Docs: [https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/sso/sso72-mysql-persistent.adoc](https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/sso/sso72-mysql-persistent.adoc)  
 Path: official/sso/templates/sso72-mysql-persistent.json  
 ### sso72-mysql
-Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/sso/sso72-mysql.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/sso/sso72-mysql.json )  
-Docs: [https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.14/docs/sso/sso72-mysql.adoc](https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.14/docs/sso/sso72-mysql.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/sso/sso72-mysql.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/sso/sso72-mysql.json )  
+Docs: [https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/sso/sso72-mysql.adoc](https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/sso/sso72-mysql.adoc)  
 Path: official/sso/templates/sso72-mysql.json  
 ### sso72-postgresql-persistent
-Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/sso/sso72-postgresql-persistent.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/sso/sso72-postgresql-persistent.json )  
-Docs: [https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.14/docs/sso/sso72-postgresql-persistent.adoc](https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.14/docs/sso/sso72-postgresql-persistent.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/sso/sso72-postgresql-persistent.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/sso/sso72-postgresql-persistent.json )  
+Docs: [https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/sso/sso72-postgresql-persistent.adoc](https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/sso/sso72-postgresql-persistent.adoc)  
 Path: official/sso/templates/sso72-postgresql-persistent.json  
 ### sso72-postgresql
-Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/sso/sso72-postgresql.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/sso/sso72-postgresql.json )  
-Docs: [https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.14/docs/sso/sso72-postgresql.adoc](https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.14/docs/sso/sso72-postgresql.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/sso/sso72-postgresql.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/sso/sso72-postgresql.json )  
+Docs: [https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/sso/sso72-postgresql.adoc](https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/sso/sso72-postgresql.adoc)  
 Path: official/sso/templates/sso72-postgresql.json  
 ### sso72-x509-https
-Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/sso/sso72-x509-https.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/sso/sso72-x509-https.json )  
-Docs: [https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.14/docs/sso/sso72-x509-https.adoc](https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.14/docs/sso/sso72-x509-https.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/sso/sso72-x509-https.json](https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/sso/sso72-x509-https.json )  
+Docs: [https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/sso/sso72-x509-https.adoc](https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/sso/sso72-x509-https.adoc)  
 Path: official/sso/templates/sso72-x509-https.json  
+### sso-cd-x509-https
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/sso-cd-dev/templates/sso-cd-x509-https.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/sso-cd-dev/templates/sso-cd-x509-https.json )  
+Docs: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/sso-cd-dev/docs/templates/sso-cd-x509-https.adoc](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/sso-cd-dev/docs/templates/sso-cd-x509-https.adoc)  
+Path: official/sso/templates/sso-cd-x509-https.json  
 # webserver
 ## imagestreams
 ### jboss-webserver30-tomcat7-openshift

--- a/official/index.json
+++ b/official/index.json
@@ -1317,63 +1317,76 @@
                 "docs": "https://access.redhat.com/documentation/en/red-hat-jboss-middleware-for-openshift/3/paged/red-hat-jboss-sso-for-openshift/",
                 "name": "redhat-sso70-openshift",
                 "path": "official/sso/imagestreams/redhat-sso70-openshift-rhel7.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/sso/sso70-image-stream.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/sso/sso70-image-stream.json"
             },
             {
                 "docs": "https://access.redhat.com/documentation/en/red-hat-jboss-middleware-for-openshift/3/paged/red-hat-jboss-sso-for-openshift/",
                 "name": "redhat-sso71-openshift",
                 "path": "official/sso/imagestreams/redhat-sso71-openshift-rhel7.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/sso/sso71-image-stream.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/sso/sso71-image-stream.json"
             },
             {
                 "docs": "https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.2/html-single/red_hat_single_sign-on_for_openshift/",
                 "name": "redhat-sso72-openshift",
                 "path": "official/sso/imagestreams/redhat-sso72-openshift-rhel7.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/sso/sso72-image-stream.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/sso/sso72-image-stream.json"
+            },
+            {
+                "docs": "https://access.redhat.com/documentation/en-us/red_hat_single_sign-on_continuous_delivery",
+                "name": "redhat-sso-cd-openshift",
+                "path": "official/sso/imagestreams/redhat-sso-cd-openshift-rhel7.json",
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/sso-cd-dev/templates/sso-cd-image-stream.json"
             }
         ],
         "templates": [
             {
                 "description": "An example RH-SSO 7 application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
-                "docs": "https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.14/docs/sso/sso72-https.adoc",
+                "docs": "https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/sso/sso72-https.adoc",
                 "name": "sso72-https",
                 "path": "official/sso/templates/sso72-https.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/sso/sso72-https.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/sso/sso72-https.json"
             },
             {
                 "description": "An example RH-SSO 7 application with a MySQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
-                "docs": "https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.14/docs/sso/sso72-mysql-persistent.adoc",
+                "docs": "https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/sso/sso72-mysql-persistent.adoc",
                 "name": "sso72-mysql-persistent",
                 "path": "official/sso/templates/sso72-mysql-persistent.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/sso/sso72-mysql-persistent.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/sso/sso72-mysql-persistent.json"
             },
             {
                 "description": "An example RH-SSO 7 application with a MySQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
-                "docs": "https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.14/docs/sso/sso72-mysql.adoc",
+                "docs": "https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/sso/sso72-mysql.adoc",
                 "name": "sso72-mysql",
                 "path": "official/sso/templates/sso72-mysql.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/sso/sso72-mysql.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/sso/sso72-mysql.json"
             },
             {
                 "description": "An example RH-SSO 7 application with a PostgreSQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
-                "docs": "https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.14/docs/sso/sso72-postgresql-persistent.adoc",
+                "docs": "https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/sso/sso72-postgresql-persistent.adoc",
                 "name": "sso72-postgresql-persistent",
                 "path": "official/sso/templates/sso72-postgresql-persistent.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/sso/sso72-postgresql-persistent.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/sso/sso72-postgresql-persistent.json"
             },
             {
                 "description": "An example RH-SSO 7 application with a PostgreSQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
-                "docs": "https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.14/docs/sso/sso72-postgresql.adoc",
+                "docs": "https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/sso/sso72-postgresql.adoc",
                 "name": "sso72-postgresql",
                 "path": "official/sso/templates/sso72-postgresql.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/sso/sso72-postgresql.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/sso/sso72-postgresql.json"
             },
             {
                 "description": "An example RH-SSO 7 application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
-                "docs": "https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.14/docs/sso/sso72-x509-https.adoc",
+                "docs": "https://github.com/jboss-openshift/application-templates/blob/ose-v1.4.16/docs/sso/sso72-x509-https.adoc",
                 "name": "sso72-x509-https",
                 "path": "official/sso/templates/sso72-x509-https.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.14/sso/sso72-x509-https.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.16/sso/sso72-x509-https.json"
+            },
+            {
+                "description": "An example application based on RH-SSO 7.3 CD Tech Preview image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
+                "docs": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/sso-cd-dev/docs/templates/sso-cd-x509-https.adoc",
+                "name": "sso-cd-x509-https",
+                "path": "official/sso/templates/sso-cd-x509-https.json",
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/sso-cd-dev/templates/sso-cd-x509-https.json"
             }
         ]
     },

--- a/official/sso/imagestreams/redhat-sso-cd-openshift-rhel7.json
+++ b/official/sso/imagestreams/redhat-sso-cd-openshift-rhel7.json
@@ -1,0 +1,56 @@
+{
+    "apiVersion": "v1",
+    "kind": "ImageStream",
+    "labels": {
+        "rhsso": "7.3.0.CD03"
+    },
+    "metadata": {
+        "annotations": {
+            "description": "Red Hat Single Sign-On 7.3 continuous delivery",
+            "openshift.io/display-name": "Red Hat Single Sign-On 7.3 continuous delivery",
+            "openshift.io/provider-display-name": "Red Hat, Inc.",
+            "version": "7.3.0.CD03"
+        },
+        "name": "redhat-sso-cd-openshift"
+    },
+    "spec": {
+        "tags": [
+            {
+                "annotations": {
+                    "description": "Latest build of Red Hat Single Sign-On 7.3 continuous delivery Tech Preview image",
+                    "iconClass": "icon-sso",
+                    "openshift.io/display-name": "Red Hat Single Sign-On 7.3 continuous delivery (Tech Preview)",
+                    "supports": "sso:7.3",
+                    "tags": "sso,keycloak,redhat,hidden",
+                    "version": "latest"
+                },
+                "from": {
+                    "kind": "DockerImage",
+                    "name": "registry.redhat.io/redhat-sso-7-tech-preview/sso-cd-openshift:latest"
+                },
+                "name": "latest",
+                "referencePolicy": {
+                    "type": "Local"
+                }
+            },
+            {
+                "annotations": {
+                    "description": "Red Hat Single Sign-On 7.3 continuous delivery Tech Preview image",
+                    "iconClass": "icon-sso",
+                    "openshift.io/display-name": "Red Hat Single Sign-On 7.3 continuous delivery (Tech Preview)",
+                    "supports": "sso:7.3",
+                    "tags": "sso,keycloak,redhat,hidden",
+                    "version": "1.0"
+                },
+                "from": {
+                    "kind": "DockerImage",
+                    "name": "registry.redhat.io/redhat-sso-7-tech-preview/sso-cd-openshift:1.0"
+                },
+                "name": "1.0",
+                "referencePolicy": {
+                    "type": "Local"
+                }
+            }
+        ]
+    }
+}

--- a/official/sso/imagestreams/redhat-sso70-openshift-rhel7.json
+++ b/official/sso/imagestreams/redhat-sso70-openshift-rhel7.json
@@ -2,14 +2,14 @@
     "apiVersion": "v1",
     "kind": "ImageStream",
     "labels": {
-        "xpaas": "1.4.14"
+        "xpaas": "1.4.16"
     },
     "metadata": {
         "annotations": {
             "description": "Red Hat SSO 7.0",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.0",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "version": "1.4.14"
+            "version": "1.4.16"
         },
         "name": "redhat-sso70-openshift"
     },
@@ -26,9 +26,12 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.access.redhat.com/redhat-sso-7/sso70-openshift:1.3"
+                    "name": "registry.redhat.io/redhat-sso-7/sso70-openshift:1.3"
                 },
-                "name": "1.3"
+                "name": "1.3",
+                "referencePolicy": {
+                    "type": "Local"
+                }
             },
             {
                 "annotations": {
@@ -41,9 +44,12 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.access.redhat.com/redhat-sso-7/sso70-openshift:1.4"
+                    "name": "registry.redhat.io/redhat-sso-7/sso70-openshift:1.4"
                 },
-                "name": "1.4"
+                "name": "1.4",
+                "referencePolicy": {
+                    "type": "Local"
+                }
             }
         ]
     }

--- a/official/sso/imagestreams/redhat-sso71-openshift-rhel7.json
+++ b/official/sso/imagestreams/redhat-sso71-openshift-rhel7.json
@@ -2,14 +2,14 @@
     "apiVersion": "v1",
     "kind": "ImageStream",
     "labels": {
-        "xpaas": "1.4.14"
+        "xpaas": "1.4.16"
     },
     "metadata": {
         "annotations": {
             "description": "Red Hat SSO 7.1",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.1",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "version": "1.4.14"
+            "version": "1.4.16"
         },
         "name": "redhat-sso71-openshift"
     },
@@ -26,9 +26,12 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.access.redhat.com/redhat-sso-7/sso71-openshift:1.0"
+                    "name": "registry.redhat.io/redhat-sso-7/sso71-openshift:1.0"
                 },
-                "name": "1.0"
+                "name": "1.0",
+                "referencePolicy": {
+                    "type": "Local"
+                }
             },
             {
                 "annotations": {
@@ -41,9 +44,12 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.access.redhat.com/redhat-sso-7/sso71-openshift:1.1"
+                    "name": "registry.redhat.io/redhat-sso-7/sso71-openshift:1.1"
                 },
-                "name": "1.1"
+                "name": "1.1",
+                "referencePolicy": {
+                    "type": "Local"
+                }
             },
             {
                 "annotations": {
@@ -56,9 +62,12 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.access.redhat.com/redhat-sso-7/sso71-openshift:1.2"
+                    "name": "registry.redhat.io/redhat-sso-7/sso71-openshift:1.2"
                 },
-                "name": "1.2"
+                "name": "1.2",
+                "referencePolicy": {
+                    "type": "Local"
+                }
             },
             {
                 "annotations": {
@@ -71,9 +80,12 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.access.redhat.com/redhat-sso-7/sso71-openshift:1.3"
+                    "name": "registry.redhat.io/redhat-sso-7/sso71-openshift:1.3"
                 },
-                "name": "1.3"
+                "name": "1.3",
+                "referencePolicy": {
+                    "type": "Local"
+                }
             }
         ]
     }

--- a/official/sso/imagestreams/redhat-sso72-openshift-rhel7.json
+++ b/official/sso/imagestreams/redhat-sso72-openshift-rhel7.json
@@ -2,14 +2,14 @@
     "apiVersion": "v1",
     "kind": "ImageStream",
     "labels": {
-        "xpaas": "1.4.14"
+        "xpaas": "1.4.16"
     },
     "metadata": {
         "annotations": {
             "description": "Red Hat SSO 7.2",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.2",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "version": "1.4.14"
+            "version": "1.4.16"
         },
         "name": "redhat-sso72-openshift"
     },
@@ -26,9 +26,12 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.access.redhat.com/redhat-sso-7/sso72-openshift:1.0"
+                    "name": "registry.redhat.io/redhat-sso-7/sso72-openshift:1.0"
                 },
-                "name": "1.0"
+                "name": "1.0",
+                "referencePolicy": {
+                    "type": "Local"
+                }
             },
             {
                 "annotations": {
@@ -41,9 +44,12 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.access.redhat.com/redhat-sso-7/sso72-openshift:1.1"
+                    "name": "registry.redhat.io/redhat-sso-7/sso72-openshift:1.1"
                 },
-                "name": "1.1"
+                "name": "1.1",
+                "referencePolicy": {
+                    "type": "Local"
+                }
             },
             {
                 "annotations": {
@@ -56,9 +62,12 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.access.redhat.com/redhat-sso-7/sso72-openshift:1.2"
+                    "name": "registry.redhat.io/redhat-sso-7/sso72-openshift:1.2"
                 },
-                "name": "1.2"
+                "name": "1.2",
+                "referencePolicy": {
+                    "type": "Local"
+                }
             }
         ]
     }

--- a/official/sso/templates/sso-cd-x509-https.json
+++ b/official/sso/templates/sso-cd-x509-https.json
@@ -2,23 +2,23 @@
     "apiVersion": "v1",
     "kind": "Template",
     "labels": {
-        "template": "sso72-https",
-        "xpaas": "1.4.16"
+        "rhsso": "7.3.0.CD03",
+        "template": "sso-cd-x509-https"
     },
-    "message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
+    "message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
     "metadata": {
         "annotations": {
-            "description": "An example RH-SSO 7 application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
+            "description": "An example application based on RH-SSO 7.3 CD Tech Preview image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
             "iconClass": "icon-sso",
-            "openshift.io/display-name": "Red Hat Single Sign-On 7.2 (Ephemeral with passthrough TLS)",
+            "openshift.io/display-name": "Red Hat Single Sign-On 7.3 CD Tech Preview (Ephemeral)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "tags": "sso,keycloak,jboss,hidden",
+            "tags": "sso,keycloak,jboss",
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
-            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.2 server based deployment, securing RH-SSO communication using passthrough TLS.",
+            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.3 server based deployment, securing RH-SSO communication using re-encrypt TLS.",
             "template.openshift.io/support-url": "https://access.redhat.com",
-            "version": "1.4.16"
+            "version": "7.3.0.CD03"
         },
-        "name": "sso72-https"
+        "name": "sso-cd-x509-https"
     },
     "objects": [
         {
@@ -26,36 +26,13 @@
             "kind": "Service",
             "metadata": {
                 "annotations": {
-                    "description": "The web server's http port."
+                    "description": "The web server's https port.",
+                    "service.alpha.openshift.io/serving-cert-secret-name": "sso-x509-https-secret"
                 },
                 "labels": {
                     "application": "${APPLICATION_NAME}"
                 },
                 "name": "${APPLICATION_NAME}"
-            },
-            "spec": {
-                "ports": [
-                    {
-                        "port": 8080,
-                        "targetPort": 8080
-                    }
-                ],
-                "selector": {
-                    "deploymentConfig": "${APPLICATION_NAME}"
-                }
-            }
-        },
-        {
-            "apiVersion": "v1",
-            "kind": "Service",
-            "metadata": {
-                "annotations": {
-                    "description": "The web server's https port."
-                },
-                "labels": {
-                    "application": "${APPLICATION_NAME}"
-                },
-                "name": "secure-${APPLICATION_NAME}"
             },
             "spec": {
                 "ports": [
@@ -75,7 +52,8 @@
             "metadata": {
                 "annotations": {
                     "description": "The JGroups ping port for clustering.",
-                    "service.alpha.kubernetes.io/tolerate-unready-endpoints": "true"
+                    "service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
+                    "service.alpha.openshift.io/serving-cert-secret-name": "sso-x509-jgroups-secret"
                 },
                 "labels": {
                     "application": "${APPLICATION_NAME}"
@@ -97,26 +75,6 @@
         },
         {
             "apiVersion": "v1",
-            "id": "${APPLICATION_NAME}-http",
-            "kind": "Route",
-            "metadata": {
-                "annotations": {
-                    "description": "Route for application's http service."
-                },
-                "labels": {
-                    "application": "${APPLICATION_NAME}"
-                },
-                "name": "${APPLICATION_NAME}"
-            },
-            "spec": {
-                "host": "${HOSTNAME_HTTP}",
-                "to": {
-                    "name": "${APPLICATION_NAME}"
-                }
-            }
-        },
-        {
-            "apiVersion": "v1",
             "id": "${APPLICATION_NAME}-https",
             "kind": "Route",
             "metadata": {
@@ -126,15 +84,14 @@
                 "labels": {
                     "application": "${APPLICATION_NAME}"
                 },
-                "name": "secure-${APPLICATION_NAME}"
+                "name": "${APPLICATION_NAME}"
             },
             "spec": {
-                "host": "${HOSTNAME_HTTPS}",
                 "tls": {
-                    "termination": "passthrough"
+                    "termination": "reencrypt"
                 },
                 "to": {
-                    "name": "secure-${APPLICATION_NAME}"
+                    "name": "${APPLICATION_NAME}"
                 }
             }
         },
@@ -168,6 +125,10 @@
                             {
                                 "env": [
                                     {
+                                        "name": "SSO_HOSTNAME",
+                                        "value": "${SSO_HOSTNAME}"
+                                    },
+                                    {
                                         "name": "DB_MIN_POOL_SIZE",
                                         "value": "${DB_MIN_POOL_SIZE}"
                                     },
@@ -192,44 +153,8 @@
                                         "value": "8888"
                                     },
                                     {
-                                        "name": "HTTPS_KEYSTORE_DIR",
-                                        "value": "/etc/eap-secret-volume"
-                                    },
-                                    {
-                                        "name": "HTTPS_KEYSTORE",
-                                        "value": "${HTTPS_KEYSTORE}"
-                                    },
-                                    {
-                                        "name": "HTTPS_KEYSTORE_TYPE",
-                                        "value": "${HTTPS_KEYSTORE_TYPE}"
-                                    },
-                                    {
-                                        "name": "HTTPS_NAME",
-                                        "value": "${HTTPS_NAME}"
-                                    },
-                                    {
-                                        "name": "HTTPS_PASSWORD",
-                                        "value": "${HTTPS_PASSWORD}"
-                                    },
-                                    {
-                                        "name": "JGROUPS_ENCRYPT_SECRET",
-                                        "value": "${JGROUPS_ENCRYPT_SECRET}"
-                                    },
-                                    {
-                                        "name": "JGROUPS_ENCRYPT_KEYSTORE_DIR",
-                                        "value": "/etc/jgroups-encrypt-secret-volume"
-                                    },
-                                    {
-                                        "name": "JGROUPS_ENCRYPT_KEYSTORE",
-                                        "value": "${JGROUPS_ENCRYPT_KEYSTORE}"
-                                    },
-                                    {
-                                        "name": "JGROUPS_ENCRYPT_NAME",
-                                        "value": "${JGROUPS_ENCRYPT_NAME}"
-                                    },
-                                    {
-                                        "name": "JGROUPS_ENCRYPT_PASSWORD",
-                                        "value": "${JGROUPS_ENCRYPT_PASSWORD}"
+                                        "name": "X509_CA_BUNDLE",
+                                        "value": "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
                                     },
                                     {
                                         "name": "JGROUPS_CLUSTER_PASSWORD",
@@ -254,18 +179,6 @@
                                     {
                                         "name": "SSO_SERVICE_PASSWORD",
                                         "value": "${SSO_SERVICE_PASSWORD}"
-                                    },
-                                    {
-                                        "name": "SSO_TRUSTSTORE",
-                                        "value": "${SSO_TRUSTSTORE}"
-                                    },
-                                    {
-                                        "name": "SSO_TRUSTSTORE_DIR",
-                                        "value": "/etc/sso-secret-volume"
-                                    },
-                                    {
-                                        "name": "SSO_TRUSTSTORE_PASSWORD",
-                                        "value": "${SSO_TRUSTSTORE_PASSWORD}"
                                     }
                                 ],
                                 "image": "${APPLICATION_NAME}",
@@ -319,18 +232,13 @@
                                 },
                                 "volumeMounts": [
                                     {
-                                        "mountPath": "/etc/eap-secret-volume",
-                                        "name": "eap-keystore-volume",
+                                        "mountPath": "/etc/x509/https",
+                                        "name": "sso-x509-https-volume",
                                         "readOnly": true
                                     },
                                     {
-                                        "mountPath": "/etc/jgroups-encrypt-secret-volume",
-                                        "name": "eap-jgroups-keystore-volume",
-                                        "readOnly": true
-                                    },
-                                    {
-                                        "mountPath": "/etc/sso-secret-volume",
-                                        "name": "sso-truststore-volume",
+                                        "mountPath": "/etc/x509/jgroups",
+                                        "name": "sso-x509-jgroups-volume",
                                         "readOnly": true
                                     }
                                 ]
@@ -339,21 +247,15 @@
                         "terminationGracePeriodSeconds": 75,
                         "volumes": [
                             {
-                                "name": "eap-keystore-volume",
+                                "name": "sso-x509-https-volume",
                                 "secret": {
-                                    "secretName": "${HTTPS_SECRET}"
+                                    "secretName": "sso-x509-https-secret"
                                 }
                             },
                             {
-                                "name": "eap-jgroups-keystore-volume",
+                                "name": "sso-x509-jgroups-volume",
                                 "secret": {
-                                    "secretName": "${JGROUPS_ENCRYPT_SECRET}"
-                                }
-                            },
-                            {
-                                "name": "sso-truststore-volume",
-                                "secret": {
-                                    "secretName": "${SSO_TRUSTSTORE_SECRET}"
+                                    "secretName": "sso-x509-jgroups-secret"
                                 }
                             }
                         ]
@@ -368,7 +270,7 @@
                             ],
                             "from": {
                                 "kind": "ImageStreamTag",
-                                "name": "redhat-sso72-openshift:1.2",
+                                "name": "redhat-sso-cd-openshift:1.0",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}"
                             }
                         },
@@ -390,53 +292,19 @@
             "value": "sso"
         },
         {
-            "description": "Custom hostname for http service route. Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>",
-            "displayName": "Custom http Route Hostname",
-            "name": "HOSTNAME_HTTP",
+            "description": "Custom hostname for the RH-SSO server.",
+            "displayName": "Custom RH-SSO Server Hostname",
+            "name": "SSO_HOSTNAME",
             "required": false,
             "value": ""
         },
         {
-            "description": "Custom hostname for https service route. Leave blank for default hostname, e.g.: <application-name>.<project>.<default-domain-suffix>",
-            "displayName": "Custom https Route Hostname",
-            "name": "HOSTNAME_HTTPS",
-            "required": false,
-            "value": ""
-        },
-        {
-            "description": "The name of the secret containing the keystore file",
-            "displayName": "Server Keystore Secret Name",
-            "name": "HTTPS_SECRET",
-            "required": false,
-            "value": "sso-app-secret"
-        },
-        {
-            "description": "The name of the keystore file within the secret",
-            "displayName": "Server Keystore Filename",
-            "name": "HTTPS_KEYSTORE",
-            "required": false,
-            "value": "keystore.jks"
-        },
-        {
-            "description": "The type of the keystore file (JKS or JCEKS)",
-            "displayName": "Server Keystore Type",
-            "name": "HTTPS_KEYSTORE_TYPE",
-            "required": false,
-            "value": ""
-        },
-        {
-            "description": "The name associated with the server certificate (e.g. jboss)",
-            "displayName": "Server Certificate Name",
-            "name": "HTTPS_NAME",
-            "required": false,
-            "value": ""
-        },
-        {
-            "description": "The password for the keystore and certificate (e.g. mykeystorepass)",
-            "displayName": "Server Keystore Password",
-            "name": "HTTPS_PASSWORD",
-            "required": false,
-            "value": ""
+            "description": "The password for the JGroups cluster.",
+            "displayName": "JGroups Cluster Password",
+            "from": "[a-zA-Z0-9]{32}",
+            "generate": "expression",
+            "name": "JGROUPS_CLUSTER_PASSWORD",
+            "required": true
         },
         {
             "description": "Sets xa-pool/min-pool-size for the configured datasource.",
@@ -457,42 +325,6 @@
             "required": false
         },
         {
-            "description": "The name of the secret containing the keystore file",
-            "displayName": "JGroups Secret Name",
-            "name": "JGROUPS_ENCRYPT_SECRET",
-            "required": false,
-            "value": "sso-app-secret"
-        },
-        {
-            "description": "The name of the keystore file within the secret",
-            "displayName": "JGroups Keystore Filename",
-            "name": "JGROUPS_ENCRYPT_KEYSTORE",
-            "required": false,
-            "value": "jgroups.jceks"
-        },
-        {
-            "description": "The name associated with the server certificate (e.g. secret-key)",
-            "displayName": "JGroups Certificate Name",
-            "name": "JGROUPS_ENCRYPT_NAME",
-            "required": false,
-            "value": ""
-        },
-        {
-            "description": "The password for the keystore and certificate (e.g. password)",
-            "displayName": "JGroups Keystore Password",
-            "name": "JGROUPS_ENCRYPT_PASSWORD",
-            "required": false,
-            "value": ""
-        },
-        {
-            "description": "JGroups cluster password",
-            "displayName": "JGroups Cluster Password",
-            "from": "[a-zA-Z0-9]{8}",
-            "generate": "expression",
-            "name": "JGROUPS_CLUSTER_PASSWORD",
-            "required": true
-        },
-        {
             "description": "Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.",
             "displayName": "ImageStream Namespace",
             "name": "IMAGE_STREAM_NAMESPACE",
@@ -508,9 +340,9 @@
             "required": true
         },
         {
-            "description": "RH-SSO Server administrator password",
+            "description": "RH-SSO Server admininistrator password",
             "displayName": "RH-SSO Administrator Password",
-            "from": "[a-zA-Z0-9]{8}",
+            "from": "[a-zA-Z0-9]{32}",
             "generate": "expression",
             "name": "SSO_ADMIN_PASSWORD",
             "required": true
@@ -535,27 +367,6 @@
             "name": "SSO_SERVICE_PASSWORD",
             "required": false,
             "value": ""
-        },
-        {
-            "description": "The name of the truststore file within the secret (e.g. truststore.jks)",
-            "displayName": "RH-SSO Trust Store",
-            "name": "SSO_TRUSTSTORE",
-            "required": false,
-            "value": ""
-        },
-        {
-            "description": "The password for the truststore and certificate (e.g. mykeystorepass)",
-            "displayName": "RH-SSO Trust Store Password",
-            "name": "SSO_TRUSTSTORE_PASSWORD",
-            "required": false,
-            "value": ""
-        },
-        {
-            "description": "The name of the secret containing the truststore file (e.g. truststore-secret). Used for volume secretName",
-            "displayName": "RH-SSO Trust Store Secret",
-            "name": "SSO_TRUSTSTORE_SECRET",
-            "required": false,
-            "value": "sso-app-secret"
         },
         {
             "description": "Container memory limit.",

--- a/official/sso/templates/sso72-mysql-persistent.json
+++ b/official/sso/templates/sso72-mysql-persistent.json
@@ -3,7 +3,7 @@
     "kind": "Template",
     "labels": {
         "template": "sso72-mysql-persistent",
-        "xpaas": "1.4.14"
+        "xpaas": "1.4.16"
     },
     "message": "A new persistent RH-SSO service (using MySQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the MySQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
     "metadata": {
@@ -16,7 +16,7 @@
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
             "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.2 server based deployment, deployment configuration for MySQL using persistence, and securing RH-SSO communication using passthrough TLS.",
             "template.openshift.io/support-url": "https://access.redhat.com",
-            "version": "1.4.14"
+            "version": "1.4.16"
         },
         "name": "sso72-mysql-persistent"
     },

--- a/official/sso/templates/sso72-mysql.json
+++ b/official/sso/templates/sso72-mysql.json
@@ -3,7 +3,7 @@
     "kind": "Template",
     "labels": {
         "template": "sso72-mysql",
-        "xpaas": "1.4.14"
+        "xpaas": "1.4.16"
     },
     "message": "A new RH-SSO service (using MySQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the MySQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
     "metadata": {
@@ -16,7 +16,7 @@
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
             "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.2 server based deployment, deployment configuration for MySQL using ephemeral (temporary) storage, and securing RH-SSO communication using passthrough TLS.",
             "template.openshift.io/support-url": "https://access.redhat.com",
-            "version": "1.4.14"
+            "version": "1.4.16"
         },
         "name": "sso72-mysql"
     },

--- a/official/sso/templates/sso72-postgresql-persistent.json
+++ b/official/sso/templates/sso72-postgresql-persistent.json
@@ -3,7 +3,7 @@
     "kind": "Template",
     "labels": {
         "template": "sso72-postgresql-persistent",
-        "xpaas": "1.4.14"
+        "xpaas": "1.4.16"
     },
     "message": "A new persistent RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
     "metadata": {
@@ -16,7 +16,7 @@
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
             "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.2 server based deployment, deployment configuration for PostgreSQL using persistence, and securing RH-SSO communication using passthrough TLS.",
             "template.openshift.io/support-url": "https://access.redhat.com",
-            "version": "1.4.14"
+            "version": "1.4.16"
         },
         "name": "sso72-postgresql-persistent"
     },

--- a/official/sso/templates/sso72-postgresql.json
+++ b/official/sso/templates/sso72-postgresql.json
@@ -3,7 +3,7 @@
     "kind": "Template",
     "labels": {
         "template": "sso72-postgresql",
-        "xpaas": "1.4.14"
+        "xpaas": "1.4.16"
     },
     "message": "A new RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
     "metadata": {
@@ -16,7 +16,7 @@
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
             "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.2 server based deployment, deployment configuration for PostgreSQL using ephemeral (temporary) storage, and securing RH-SSO communication using passthrough TLS.",
             "template.openshift.io/support-url": "https://access.redhat.com",
-            "version": "1.4.14"
+            "version": "1.4.16"
         },
         "name": "sso72-postgresql"
     },

--- a/official/sso/templates/sso72-x509-https.json
+++ b/official/sso/templates/sso72-x509-https.json
@@ -3,7 +3,7 @@
     "kind": "Template",
     "labels": {
         "template": "sso72-x509-https",
-        "xpaas": "1.4.14"
+        "xpaas": "1.4.16"
     },
     "message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
     "metadata": {
@@ -16,7 +16,7 @@
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
             "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.2 server based deployment, securing RH-SSO communication using re-encrypt TLS.",
             "template.openshift.io/support-url": "https://access.redhat.com",
-            "version": "1.4.14"
+            "version": "1.4.16"
         },
         "name": "sso72-x509-https"
     },


### PR DESCRIPTION
[KEYCLOAK-8428] Update RH-SSO 7.2 image stream and templates to 'ose-v1.4.16' version
[KEYCLOAK-7785] Introduce RH-SSO 7.3 TP CD image stream and x509 https ephemeral template

Note: The RH-SSO 7.3 TP CD image stream and template was intentionally not tagged with `ocp` tag, since these are wanted solely to be available on OSOS / OSOP environments (not in OCP/OKD).

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>