### PR TITLE
Use nodeshift for upstream community Node.js

### DIFF
--- a/community.yaml
+++ b/community.yaml
@@ -52,8 +52,8 @@ data:
           - okd
   nodejs:
     imagestreams:
-      - location: https://raw.githubusercontent.com/bucharest-gold/centos7-s2i-nodejs/master/imagestreams/nodejs-centos7.json
-        docs: https://github.com/bucharest-gold/centos7-s2i-nodejs/blob/master/README.md
+      - location: https://raw.githubusercontent.com/nodeshift/centos7-s2i-nodejs/master/imagestreams/nodejs-centos7.json
+        docs: https://github.com/nodeshift/centos7-s2i-nodejs/blob/master/README.md
         regex: nodejs
         suffix: centos7
         tags:

--- a/community/README.md
+++ b/community/README.md
@@ -73,8 +73,8 @@ Path: community/nginx/imagestreams/nginx-centos7.json
 # nodejs
 ## imagestreams
 ### nodejs
-Source URL: [https://raw.githubusercontent.com/bucharest-gold/centos7-s2i-nodejs/master/imagestreams/nodejs-centos7.json](https://raw.githubusercontent.com/bucharest-gold/centos7-s2i-nodejs/master/imagestreams/nodejs-centos7.json )  
-Docs: [https://github.com/bucharest-gold/centos7-s2i-nodejs/blob/master/README.md](https://github.com/bucharest-gold/centos7-s2i-nodejs/blob/master/README.md)  
+Source URL: [https://raw.githubusercontent.com/nodeshift/centos7-s2i-nodejs/master/imagestreams/nodejs-centos7.json](https://raw.githubusercontent.com/nodeshift/centos7-s2i-nodejs/master/imagestreams/nodejs-centos7.json )  
+Docs: [https://github.com/nodeshift/centos7-s2i-nodejs/blob/master/README.md](https://github.com/nodeshift/centos7-s2i-nodejs/blob/master/README.md)  
 Path: community/nodejs/imagestreams/nodejs-centos7.json  
 # perl
 ## imagestreams

--- a/community/index.json
+++ b/community/index.json
@@ -125,10 +125,10 @@
     "nodejs": {
         "imagestreams": [
             {
-                "docs": "https://github.com/bucharest-gold/centos7-s2i-nodejs/blob/master/README.md",
+                "docs": "https://github.com/nodeshift/centos7-s2i-nodejs/blob/master/README.md",
                 "name": "nodejs",
                 "path": "community/nodejs/imagestreams/nodejs-centos7.json",
-                "source_url": "https://raw.githubusercontent.com/bucharest-gold/centos7-s2i-nodejs/master/imagestreams/nodejs-centos7.json"
+                "source_url": "https://raw.githubusercontent.com/nodeshift/centos7-s2i-nodejs/master/imagestreams/nodejs-centos7.json"
             }
         ]
     },

--- a/community/nodejs/imagestreams/nodejs-centos7.json
+++ b/community/nodejs/imagestreams/nodejs-centos7.json
@@ -21,7 +21,7 @@
                 },
                 "from": {
                     "kind": "ImageStreamTag",
-                    "name": "10"
+                    "name": "11"
                 },
                 "name": "latest",
                 "referencePolicy": {
@@ -141,6 +141,25 @@
                     "name": "docker.io/nodeshift/centos7-s2i-nodejs:10.x"
                 },
                 "name": "10",
+                "referencePolicy": {
+                    "type": "Local"
+                }
+            },
+            {
+                "annotations": {
+                    "description": "Build and run Node.js 11 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/nodeshift/centos7-s2i-nodejs.",
+                    "iconClass": "icon-nodejs",
+                    "openshift.io/display-name": "Node.js 11",
+                    "openshift.io/provider-display-name": "Red Hat, Inc.",
+                    "sampleRepo": "https://github.com/sclorg/nodejs-ex.git",
+                    "tags": "builder,nodejs",
+                    "version": "11"
+                },
+                "from": {
+                    "kind": "DockerImage",
+                    "name": "docker.io/nodeshift/centos7-s2i-nodejs:11.x"
+                },
+                "name": "11",
                 "referencePolicy": {
                     "type": "Local"
                 }


### PR DESCRIPTION
The GitHub organization for RHOAR Node.js community images have changed
from `bucharest-gold` to `nodeshift`. This commit updates the library
references to point to the new organization.