### PR TITLE
modified the mailcatcher.json template readyness probe

### DIFF
--- a/community/mailcatcher/templates/mailcatcher.json
+++ b/community/mailcatcher/templates/mailcatcher.json
@@ -125,6 +125,7 @@
                                     "exec": {
                                         "command": [
                                             "/usr/bin/pgrep",
+                                            "-f",
                                             "mailcatcher"
                                         ]
                                     },


### PR DESCRIPTION
Currently the readyness probe is failing for this template because it's only trying to match the `/usr/local/bin/ruby` bit of the command, with the added "-f" flag it will match against the full command that includes the "mailcatcher" command.
