### PR TITLE
remove lone ppc piece of content

### DIFF
--- a/official.yaml
+++ b/official.yaml
@@ -29,13 +29,6 @@ data:
           - ocp
           - online-starter
           - online-professional
-      - location: https://raw.githubusercontent.com/sclorg/s2i-ruby-container/master/imagestreams/ruby-rhel7-ppc64le.json
-        docs: https://github.com/sclorg/s2i-ruby-container/blob/master/README.md
-        regex: ruby
-        suffix: rhel7
-        tags:
-          - ocp
-          - arch_ppc64le
   rails:
     templates:
       - location: https://raw.githubusercontent.com/sclorg/rails-ex/master/openshift/templates/rails-postgresql.json

--- a/official/README.md
+++ b/official/README.md
@@ -736,10 +736,6 @@ Path: official/rhpam/templates/rhpam74-trial-ephemeral.json
 Source URL: [https://raw.githubusercontent.com/sclorg/s2i-ruby-container/master/imagestreams/ruby-rhel7.json](https://raw.githubusercontent.com/sclorg/s2i-ruby-container/master/imagestreams/ruby-rhel7.json )  
 Docs: [https://github.com/sclorg/s2i-ruby-container/blob/master/README.md](https://github.com/sclorg/s2i-ruby-container/blob/master/README.md)  
 Path: official/ruby/imagestreams/ruby-rhel7.json  
-### ruby
-Source URL: [https://raw.githubusercontent.com/sclorg/s2i-ruby-container/master/imagestreams/ruby-rhel7-ppc64le.json](https://raw.githubusercontent.com/sclorg/s2i-ruby-container/master/imagestreams/ruby-rhel7-ppc64le.json )  
-Docs: [https://github.com/sclorg/s2i-ruby-container/blob/master/README.md](https://github.com/sclorg/s2i-ruby-container/blob/master/README.md)  
-Path: official/ruby/imagestreams/ruby-rhel7.json  
 # sso
 ## imagestreams
 ### redhat-sso70-openshift

--- a/official/index.json
+++ b/official/index.json
@@ -1252,12 +1252,6 @@
                 "name": "ruby",
                 "path": "official/ruby/imagestreams/ruby-rhel7.json",
                 "source_url": "https://raw.githubusercontent.com/sclorg/s2i-ruby-container/master/imagestreams/ruby-rhel7.json"
-            },
-            {
-                "docs": "https://github.com/sclorg/s2i-ruby-container/blob/master/README.md",
-                "name": "ruby",
-                "path": "official/ruby/imagestreams/ruby-rhel7.json",
-                "source_url": "https://raw.githubusercontent.com/sclorg/s2i-ruby-container/master/imagestreams/ruby-rhel7-ppc64le.json"
             }
         ]
     },

--- a/official/ruby/imagestreams/ruby-rhel7.json
+++ b/official/ruby/imagestreams/ruby-rhel7.json
@@ -17,7 +17,7 @@
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
                     "sampleRepo": "https://github.com/sclorg/ruby-ex.git",
                     "supports": "ruby",
-                    "tags": "builder,ruby,ppc64le"
+                    "tags": "builder,ruby"
                 },
                 "from": {
                     "kind": "ImageStreamTag",
@@ -30,13 +30,53 @@
             },
             {
                 "annotations": {
+                    "description": "Build and run Ruby 2.3 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.3/README.md.",
+                    "iconClass": "icon-ruby",
+                    "openshift.io/display-name": "Ruby 2.3",
+                    "openshift.io/provider-display-name": "Red Hat, Inc.",
+                    "sampleRepo": "https://github.com/sclorg/ruby-ex.git",
+                    "supports": "ruby:2.3,ruby",
+                    "tags": "hidden,builder,ruby",
+                    "version": "2.3"
+                },
+                "from": {
+                    "kind": "DockerImage",
+                    "name": "registry.redhat.io/rhscl/ruby-23-rhel7:latest"
+                },
+                "name": "2.3",
+                "referencePolicy": {
+                    "type": "Local"
+                }
+            },
+            {
+                "annotations": {
+                    "description": "Build and run Ruby 2.4 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.4/README.md.",
+                    "iconClass": "icon-ruby",
+                    "openshift.io/display-name": "Ruby 2.4",
+                    "openshift.io/provider-display-name": "Red Hat, Inc.",
+                    "sampleRepo": "https://github.com/sclorg/ruby-ex.git",
+                    "supports": "ruby:2.4,ruby",
+                    "tags": "builder,ruby",
+                    "version": "2.4"
+                },
+                "from": {
+                    "kind": "DockerImage",
+                    "name": "registry.redhat.io/rhscl/ruby-24-rhel7:latest"
+                },
+                "name": "2.4",
+                "referencePolicy": {
+                    "type": "Local"
+                }
+            },
+            {
+                "annotations": {
                     "description": "Build and run Ruby 2.5 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.5/README.md.",
                     "iconClass": "icon-ruby",
                     "openshift.io/display-name": "Ruby 2.5",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
                     "sampleRepo": "https://github.com/sclorg/ruby-ex.git",
                     "supports": "ruby:2.5,ruby",
-                    "tags": "builder,ruby,ppc64le",
+                    "tags": "builder,ruby",
                     "version": "2.5"
                 },
                 "from": {


### PR DESCRIPTION
per recent discussions in slack wrt 4.3 push 2 prod, non-x86, epic work items 

nuke the one lone ppc layover from 3.10

@bparees @openshift/openshift-team-developer-experience PTAL