### PR TITLE
Migrate apps/* into apps/v1 before the old apis get dropped

### DIFF
--- a/arch/x86_64/community/infinispan/templates/infinispan-ephemeral.json
+++ b/arch/x86_64/community/infinispan/templates/infinispan-ephemeral.json
@@ -204,7 +204,7 @@
             }
         },
         {
-            "apiVersion": "apps/v1beta1",
+            "apiVersion": "apps/v1",
             "kind": "StatefulSet",
             "metadata": {
                 "labels": {

--- a/arch/x86_64/community/infinispan/templates/infinispan-persistent.json
+++ b/arch/x86_64/community/infinispan/templates/infinispan-persistent.json
@@ -204,7 +204,7 @@
             }
         },
         {
-            "apiVersion": "apps/v1beta1",
+            "apiVersion": "apps/v1",
             "kind": "StatefulSet",
             "metadata": {
                 "labels": {

--- a/arch/x86_64/official/datagrid/templates/cache-service.json
+++ b/arch/x86_64/official/datagrid/templates/cache-service.json
@@ -94,7 +94,7 @@
             }
         },
         {
-            "apiVersion": "apps/v1beta1",
+            "apiVersion": "apps/v1",
             "kind": "StatefulSet",
             "metadata": {
                 "labels": {

--- a/arch/x86_64/official/datagrid/templates/datagrid-service.json
+++ b/arch/x86_64/official/datagrid/templates/datagrid-service.json
@@ -94,7 +94,7 @@
             }
         },
         {
-            "apiVersion": "apps/v1beta1",
+            "apiVersion": "apps/v1",
             "kind": "StatefulSet",
             "metadata": {
                 "labels": {

--- a/community/infinispan/templates/infinispan-ephemeral.json
+++ b/community/infinispan/templates/infinispan-ephemeral.json
@@ -204,7 +204,7 @@
             }
         },
         {
-            "apiVersion": "apps/v1beta1",
+            "apiVersion": "apps/v1",
             "kind": "StatefulSet",
             "metadata": {
                 "labels": {

--- a/community/infinispan/templates/infinispan-persistent.json
+++ b/community/infinispan/templates/infinispan-persistent.json
@@ -204,7 +204,7 @@
             }
         },
         {
-            "apiVersion": "apps/v1beta1",
+            "apiVersion": "apps/v1",
             "kind": "StatefulSet",
             "metadata": {
                 "labels": {

--- a/official/datagrid/templates/cache-service.json
+++ b/official/datagrid/templates/cache-service.json
@@ -94,7 +94,7 @@
             }
         },
         {
-            "apiVersion": "apps/v1beta1",
+            "apiVersion": "apps/v1",
             "kind": "StatefulSet",
             "metadata": {
                 "labels": {

--- a/official/datagrid/templates/datagrid-service.json
+++ b/official/datagrid/templates/datagrid-service.json
@@ -94,7 +94,7 @@
             }
         },
         {
-            "apiVersion": "apps/v1beta1",
+            "apiVersion": "apps/v1",
             "kind": "StatefulSet",
             "metadata": {
                 "labels": {

--- a/online/professional/x86_64/official/datagrid/templates/cache-service.json
+++ b/online/professional/x86_64/official/datagrid/templates/cache-service.json
@@ -94,7 +94,7 @@
             }
         },
         {
-            "apiVersion": "apps/v1beta1",
+            "apiVersion": "apps/v1",
             "kind": "StatefulSet",
             "metadata": {
                 "labels": {

--- a/online/professional/x86_64/official/datagrid/templates/datagrid-service.json
+++ b/online/professional/x86_64/official/datagrid/templates/datagrid-service.json
@@ -94,7 +94,7 @@
             }
         },
         {
-            "apiVersion": "apps/v1beta1",
+            "apiVersion": "apps/v1",
             "kind": "StatefulSet",
             "metadata": {
                 "labels": {

--- a/operator/ocp-x86_64/official/datagrid/templates/cache-service.json
+++ b/operator/ocp-x86_64/official/datagrid/templates/cache-service.json
@@ -94,7 +94,7 @@
             }
         },
         {
-            "apiVersion": "apps/v1beta1",
+            "apiVersion": "apps/v1",
             "kind": "StatefulSet",
             "metadata": {
                 "labels": {

--- a/operator/ocp-x86_64/official/datagrid/templates/datagrid-service.json
+++ b/operator/ocp-x86_64/official/datagrid/templates/datagrid-service.json
@@ -94,7 +94,7 @@
             }
         },
         {
-            "apiVersion": "apps/v1beta1",
+            "apiVersion": "apps/v1",
             "kind": "StatefulSet",
             "metadata": {
                 "labels": {


### PR DESCRIPTION
apps/v1beta* apis are going away soon (next release)

@openshift/sig-developer-experience do we have any other repo with examples like that or is this all?

xref: https://jira.coreos.com/browse/WRKLDS-16