### PR TITLE
Update ImageStreamTag name to version only

### DIFF
--- a/official/java/imagestreams/java-rhel7.json
+++ b/official/java/imagestreams/java-rhel7.json
@@ -67,7 +67,7 @@
                 },
                 "from": {
                     "kind": "ImageStreamTag",
-                    "name": "java:11"
+                    "name": "11"
                 },
                 "name": "latest",
                 "referencePolicy": {


### PR DESCRIPTION
This is a copy of https://github.com/jboss-container-images/openjdk/pull/103 which was a problem for OCP 4.3 (see https://bugzilla.redhat.com/show_bug.cgi?id=1778613)

I've targetted `master` but I'm not sure which versions of OCP are affected nor which branches are relevant to those. Can you recommend whether we need to merge to other places too?