### PR TITLE
[KEYCLOAK-8428] Update to  "v7.3.7.GA" release of the RH-SSO 7.3 for OpenShift image

### DIFF
--- a/official.yaml
+++ b/official.yaml
@@ -6,7 +6,7 @@ variables:
   eap_cd_version: CD18
   rhsso72_zstream_version: v7.2.6.GA
   rhsso_tpcd_version: sso-cd-dev
-  rhsso73_zstream_version: v7.3.2.GA
+  rhsso73_zstream_version: v7.3.7.GA
   webserver_version: ose-v1.4.17
   webserver3_version: jws31-v1.4
   webserver5_version: jws50-v1.2

--- a/official/README.md
+++ b/official/README.md
@@ -836,7 +836,7 @@ Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso
 Docs: [https://access.redhat.com/documentation/en-us/red_hat_single_sign-on_continuous_delivery](https://access.redhat.com/documentation/en-us/red_hat_single_sign-on_continuous_delivery)  
 Path: official/sso/imagestreams/redhat-sso-cd-openshift-rhel8-rhel7.json  
 ### redhat-sso73-openshift
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.2.GA/templates/sso73-image-stream.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.2.GA/templates/sso73-image-stream.json )  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.7.GA/templates/sso73-image-stream.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.7.GA/templates/sso73-image-stream.json )  
 Docs: [https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.3/html-single/red_hat_single_sign-on_for_openshift/](https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.3/html-single/red_hat_single_sign-on_for_openshift/)  
 Path: official/sso/imagestreams/redhat-sso73-openshift-rhel7.json  
 ## templates
@@ -869,36 +869,36 @@ Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso
 Docs: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/sso-cd-dev/docs/templates/sso-cd-x509-https.adoc](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/sso-cd-dev/docs/templates/sso-cd-x509-https.adoc)  
 Path: official/sso/templates/sso-cd-x509-https.json  
 ### sso73-https
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.2.GA/templates/sso73-https.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.2.GA/templates/sso73-https.json )  
-Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.2.GA/docs/templates/sso73-https.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.2.GA/docs/templates/sso73-https.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.7.GA/templates/sso73-https.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.7.GA/templates/sso73-https.json )  
+Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.7.GA/docs/templates/sso73-https.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.7.GA/docs/templates/sso73-https.adoc)  
 Path: official/sso/templates/sso73-https.json  
 ### sso73-mysql-persistent
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.2.GA/templates/sso73-mysql-persistent.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.2.GA/templates/sso73-mysql-persistent.json )  
-Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.2.GA/docs/templates/sso73-mysql-persistent.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.2.GA/docs/templates/sso73-mysql-persistent.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.7.GA/templates/sso73-mysql-persistent.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.7.GA/templates/sso73-mysql-persistent.json )  
+Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.7.GA/docs/templates/sso73-mysql-persistent.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.7.GA/docs/templates/sso73-mysql-persistent.adoc)  
 Path: official/sso/templates/sso73-mysql-persistent.json  
 ### sso73-mysql
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.2.GA/templates/sso73-mysql.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.2.GA/templates/sso73-mysql.json )  
-Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.2.GA/docs/templates/sso73-mysql.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.2.GA/docs/templates/sso73-mysql.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.7.GA/templates/sso73-mysql.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.7.GA/templates/sso73-mysql.json )  
+Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.7.GA/docs/templates/sso73-mysql.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.7.GA/docs/templates/sso73-mysql.adoc)  
 Path: official/sso/templates/sso73-mysql.json  
 ### sso73-postgresql-persistent
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.2.GA/templates/sso73-postgresql-persistent.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.2.GA/templates/sso73-postgresql-persistent.json )  
-Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.2.GA/docs/templates/sso73-postgresql-persistent.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.2.GA/docs/templates/sso73-postgresql-persistent.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.7.GA/templates/sso73-postgresql-persistent.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.7.GA/templates/sso73-postgresql-persistent.json )  
+Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.7.GA/docs/templates/sso73-postgresql-persistent.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.7.GA/docs/templates/sso73-postgresql-persistent.adoc)  
 Path: official/sso/templates/sso73-postgresql-persistent.json  
 ### sso73-postgresql
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.2.GA/templates/sso73-postgresql.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.2.GA/templates/sso73-postgresql.json )  
-Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.2.GA/docs/templates/sso73-postgresql.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.2.GA/docs/templates/sso73-postgresql.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.7.GA/templates/sso73-postgresql.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.7.GA/templates/sso73-postgresql.json )  
+Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.7.GA/docs/templates/sso73-postgresql.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.7.GA/docs/templates/sso73-postgresql.adoc)  
 Path: official/sso/templates/sso73-postgresql.json  
 ### sso73-x509-https
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.2.GA/templates/sso73-x509-https.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.2.GA/templates/sso73-x509-https.json )  
-Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.2.GA/docs/templates/sso73-x509-https.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.2.GA/docs/templates/sso73-x509-https.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.7.GA/templates/sso73-x509-https.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.7.GA/templates/sso73-x509-https.json )  
+Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.7.GA/docs/templates/sso73-x509-https.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.7.GA/docs/templates/sso73-x509-https.adoc)  
 Path: official/sso/templates/sso73-x509-https.json  
 ### sso73-x509-mysql-persistent
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.2.GA/templates/sso73-x509-mysql-persistent.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.2.GA/templates/sso73-x509-mysql-persistent.json )  
-Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.2.GA/docs/templates/sso73-x509-mysql-persistent.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.2.GA/docs/templates/sso73-x509-mysql-persistent.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.7.GA/templates/sso73-x509-mysql-persistent.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.7.GA/templates/sso73-x509-mysql-persistent.json )  
+Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.7.GA/docs/templates/sso73-x509-mysql-persistent.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.7.GA/docs/templates/sso73-x509-mysql-persistent.adoc)  
 Path: official/sso/templates/sso73-x509-mysql-persistent.json  
 ### sso73-x509-postgresql-persistent
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.2.GA/templates/sso73-x509-postgresql-persistent.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.2.GA/templates/sso73-x509-postgresql-persistent.json )  
-Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.2.GA/docs/templates/sso73-x509-postgresql-persistent.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.2.GA/docs/templates/sso73-x509-postgresql-persistent.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.7.GA/templates/sso73-x509-postgresql-persistent.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.7.GA/templates/sso73-x509-postgresql-persistent.json )  
+Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.7.GA/docs/templates/sso73-x509-postgresql-persistent.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.7.GA/docs/templates/sso73-x509-postgresql-persistent.adoc)  
 Path: official/sso/templates/sso73-x509-postgresql-persistent.json  
 # webserver
 ## imagestreams

--- a/official/index.json
+++ b/official/index.json
@@ -1405,7 +1405,7 @@
                 "docs": "https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.3/html-single/red_hat_single_sign-on_for_openshift/",
                 "name": "redhat-sso73-openshift",
                 "path": "official/sso/imagestreams/redhat-sso73-openshift-rhel7.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.2.GA/templates/sso73-image-stream.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.7.GA/templates/sso73-image-stream.json"
             }
         ],
         "templates": [
@@ -1460,59 +1460,59 @@
             },
             {
                 "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
-                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.2.GA/docs/templates/sso73-https.adoc",
+                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.7.GA/docs/templates/sso73-https.adoc",
                 "name": "sso73-https",
                 "path": "official/sso/templates/sso73-https.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.2.GA/templates/sso73-https.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.7.GA/templates/sso73-https.json"
             },
             {
                 "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
-                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.2.GA/docs/templates/sso73-mysql-persistent.adoc",
+                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.7.GA/docs/templates/sso73-mysql-persistent.adoc",
                 "name": "sso73-mysql-persistent",
                 "path": "official/sso/templates/sso73-mysql-persistent.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.2.GA/templates/sso73-mysql-persistent.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.7.GA/templates/sso73-mysql-persistent.json"
             },
             {
                 "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
-                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.2.GA/docs/templates/sso73-mysql.adoc",
+                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.7.GA/docs/templates/sso73-mysql.adoc",
                 "name": "sso73-mysql",
                 "path": "official/sso/templates/sso73-mysql.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.2.GA/templates/sso73-mysql.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.7.GA/templates/sso73-mysql.json"
             },
             {
                 "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
-                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.2.GA/docs/templates/sso73-postgresql-persistent.adoc",
+                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.7.GA/docs/templates/sso73-postgresql-persistent.adoc",
                 "name": "sso73-postgresql-persistent",
                 "path": "official/sso/templates/sso73-postgresql-persistent.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.2.GA/templates/sso73-postgresql-persistent.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.7.GA/templates/sso73-postgresql-persistent.json"
             },
             {
                 "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
-                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.2.GA/docs/templates/sso73-postgresql.adoc",
+                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.7.GA/docs/templates/sso73-postgresql.adoc",
                 "name": "sso73-postgresql",
                 "path": "official/sso/templates/sso73-postgresql.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.2.GA/templates/sso73-postgresql.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.7.GA/templates/sso73-postgresql.json"
             },
             {
                 "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
-                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.2.GA/docs/templates/sso73-x509-https.adoc",
+                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.7.GA/docs/templates/sso73-x509-https.adoc",
                 "name": "sso73-x509-https",
                 "path": "official/sso/templates/sso73-x509-https.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.2.GA/templates/sso73-x509-https.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.7.GA/templates/sso73-x509-https.json"
             },
             {
                 "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
-                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.2.GA/docs/templates/sso73-x509-mysql-persistent.adoc",
+                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.7.GA/docs/templates/sso73-x509-mysql-persistent.adoc",
                 "name": "sso73-x509-mysql-persistent",
                 "path": "official/sso/templates/sso73-x509-mysql-persistent.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.2.GA/templates/sso73-x509-mysql-persistent.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.7.GA/templates/sso73-x509-mysql-persistent.json"
             },
             {
                 "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
-                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.2.GA/docs/templates/sso73-x509-postgresql-persistent.adoc",
+                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.7.GA/docs/templates/sso73-x509-postgresql-persistent.adoc",
                 "name": "sso73-x509-postgresql-persistent",
                 "path": "official/sso/templates/sso73-x509-postgresql-persistent.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.2.GA/templates/sso73-x509-postgresql-persistent.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.7.GA/templates/sso73-x509-postgresql-persistent.json"
             }
         ]
     },

--- a/official/sso/imagestreams/redhat-sso73-openshift-rhel7.json
+++ b/official/sso/imagestreams/redhat-sso73-openshift-rhel7.json
@@ -2,14 +2,14 @@
     "apiVersion": "v1",
     "kind": "ImageStream",
     "labels": {
-        "rhsso": "7.3.2.GA"
+        "rhsso": "7.3.7.GA"
     },
     "metadata": {
         "annotations": {
             "description": "Red Hat Single Sign-On 7.3",
             "openshift.io/display-name": "Red Hat Single Sign-On 7.3",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "version": "7.3.2.GA"
+            "version": "7.3.7.GA"
         },
         "name": "redhat-sso73-openshift"
     },

--- a/official/sso/templates/sso73-https.json
+++ b/official/sso/templates/sso73-https.json
@@ -2,7 +2,7 @@
     "apiVersion": "v1",
     "kind": "Template",
     "labels": {
-        "rhsso": "7.3.2.GA",
+        "rhsso": "7.3.7.GA",
         "template": "sso73-https"
     },
     "message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
@@ -16,7 +16,7 @@
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
             "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.3 server based deployment, securing RH-SSO communication using passthrough TLS.",
             "template.openshift.io/support-url": "https://access.redhat.com",
-            "version": "7.3.2.GA"
+            "version": "7.3.7.GA"
         },
         "name": "sso73-https"
     },

--- a/official/sso/templates/sso73-mysql-persistent.json
+++ b/official/sso/templates/sso73-mysql-persistent.json
@@ -2,7 +2,7 @@
     "apiVersion": "v1",
     "kind": "Template",
     "labels": {
-        "rhsso": "7.3.2.GA",
+        "rhsso": "7.3.7.GA",
         "template": "sso73-mysql-persistent"
     },
     "message": "A new persistent RH-SSO service (using MySQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the MySQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
@@ -16,7 +16,7 @@
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
             "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.3 server based deployment, deployment configuration for MySQL using persistence, and securing RH-SSO communication using passthrough TLS.",
             "template.openshift.io/support-url": "https://access.redhat.com",
-            "version": "7.3.2.GA"
+            "version": "7.3.7.GA"
         },
         "name": "sso73-mysql-persistent"
     },
@@ -499,11 +499,13 @@
                                 "image": "mysql",
                                 "imagePullPolicy": "Always",
                                 "livenessProbe": {
-                                    "initialDelaySeconds": 30,
+                                    "failureThreshold": 3,
+                                    "initialDelaySeconds": 90,
+                                    "successThreshold:": 1,
                                     "tcpSocket": {
                                         "port": 3306
                                     },
-                                    "timeoutSeconds": 1
+                                    "timeoutSeconds": 10
                                 },
                                 "name": "${APPLICATION_NAME}-mysql",
                                 "ports": [
@@ -521,8 +523,10 @@
                                             "MYSQL_PWD=\"$MYSQL_PASSWORD\" mysql -h 127.0.0.1 -u $MYSQL_USER -D $MYSQL_DATABASE -e 'SELECT 1'"
                                         ]
                                     },
-                                    "initialDelaySeconds": 5,
-                                    "timeoutSeconds": 1
+                                    "failureThreshold": 3,
+                                    "initialDelaySeconds": 90,
+                                    "successThreshold:": 1,
+                                    "timeoutSeconds": 10
                                 },
                                 "volumeMounts": [
                                     {

--- a/official/sso/templates/sso73-mysql.json
+++ b/official/sso/templates/sso73-mysql.json
@@ -2,7 +2,7 @@
     "apiVersion": "v1",
     "kind": "Template",
     "labels": {
-        "rhsso": "7.3.2.GA",
+        "rhsso": "7.3.7.GA",
         "template": "sso73-mysql"
     },
     "message": "A new RH-SSO service (using MySQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the MySQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
@@ -16,7 +16,7 @@
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
             "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.3 server based deployment, deployment configuration for MySQL using ephemeral (temporary) storage, and securing RH-SSO communication using passthrough TLS.",
             "template.openshift.io/support-url": "https://access.redhat.com",
-            "version": "7.3.2.GA"
+            "version": "7.3.7.GA"
         },
         "name": "sso73-mysql"
     },

--- a/official/sso/templates/sso73-postgresql-persistent.json
+++ b/official/sso/templates/sso73-postgresql-persistent.json
@@ -2,7 +2,7 @@
     "apiVersion": "v1",
     "kind": "Template",
     "labels": {
-        "rhsso": "7.3.2.GA",
+        "rhsso": "7.3.7.GA",
         "template": "sso73-postgresql-persistent"
     },
     "message": "A new persistent RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
@@ -16,7 +16,7 @@
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
             "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.3 server based deployment, deployment configuration for PostgreSQL using persistence, and securing RH-SSO communication using passthrough TLS.",
             "template.openshift.io/support-url": "https://access.redhat.com",
-            "version": "7.3.2.GA"
+            "version": "7.3.7.GA"
         },
         "name": "sso73-postgresql-persistent"
     },
@@ -491,11 +491,13 @@
                                 "image": "postgresql",
                                 "imagePullPolicy": "Always",
                                 "livenessProbe": {
-                                    "initialDelaySeconds": 30,
+                                    "failureThreshold": 3,
+                                    "initialDelaySeconds": 90,
+                                    "successThreshold:": 1,
                                     "tcpSocket": {
                                         "port": 5432
                                     },
-                                    "timeoutSeconds": 1
+                                    "timeoutSeconds": 10
                                 },
                                 "name": "${APPLICATION_NAME}-postgresql",
                                 "ports": [
@@ -513,8 +515,10 @@
                                             "psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'"
                                         ]
                                     },
-                                    "initialDelaySeconds": 5,
-                                    "timeoutSeconds": 1
+                                    "failureThreshold": 3,
+                                    "initialDelaySeconds": 90,
+                                    "successThreshold:": 1,
+                                    "timeoutSeconds": 10
                                 },
                                 "volumeMounts": [
                                     {
@@ -814,7 +818,7 @@
             "displayName": "PostgreSQL Image Stream Tag",
             "name": "POSTGRESQL_IMAGE_STREAM_TAG",
             "required": true,
-            "value": "9.5"
+            "value": "10"
         },
         {
             "description": "Container memory limit.",

--- a/official/sso/templates/sso73-postgresql.json
+++ b/official/sso/templates/sso73-postgresql.json
@@ -2,7 +2,7 @@
     "apiVersion": "v1",
     "kind": "Template",
     "labels": {
-        "rhsso": "7.3.2.GA",
+        "rhsso": "7.3.7.GA",
         "template": "sso73-postgresql"
     },
     "message": "A new RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
@@ -16,7 +16,7 @@
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
             "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.3 server based deployment, deployment configuration for PostgreSQL using ephemeral (temporary) storage, and securing RH-SSO communication using passthrough TLS.",
             "template.openshift.io/support-url": "https://access.redhat.com",
-            "version": "7.3.2.GA"
+            "version": "7.3.7.GA"
         },
         "name": "sso73-postgresql"
     },
@@ -796,7 +796,7 @@
             "displayName": "PostgreSQL Image Stream Tag",
             "name": "POSTGRESQL_IMAGE_STREAM_TAG",
             "required": true,
-            "value": "9.5"
+            "value": "10"
         },
         {
             "description": "Container memory limit.",

--- a/official/sso/templates/sso73-x509-https.json
+++ b/official/sso/templates/sso73-x509-https.json
@@ -2,7 +2,7 @@
     "apiVersion": "v1",
     "kind": "Template",
     "labels": {
-        "rhsso": "7.3.2.GA",
+        "rhsso": "7.3.7.GA",
         "template": "sso73-x509-https"
     },
     "message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
@@ -16,7 +16,7 @@
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
             "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.3 server based deployment, securing RH-SSO communication using re-encrypt TLS.",
             "template.openshift.io/support-url": "https://access.redhat.com",
-            "version": "7.3.2.GA"
+            "version": "7.3.7.GA"
         },
         "name": "sso73-x509-https"
     },
@@ -154,7 +154,7 @@
                                     },
                                     {
                                         "name": "X509_CA_BUNDLE",
-                                        "value": "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+                                        "value": "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
                                     },
                                     {
                                         "name": "JGROUPS_CLUSTER_PASSWORD",

--- a/official/sso/templates/sso73-x509-mysql-persistent.json
+++ b/official/sso/templates/sso73-x509-mysql-persistent.json
@@ -2,7 +2,7 @@
     "apiVersion": "v1",
     "kind": "Template",
     "labels": {
-        "rhsso": "7.3.2.GA",
+        "rhsso": "7.3.7.GA",
         "template": "sso73-x509-mysql-persistent"
     },
     "message": "A new persistent RH-SSO service (using MySQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the MySQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
@@ -16,7 +16,7 @@
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
             "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.3 server based deployment, deployment configuration for MySQL using persistence, and securing RH-SSO communication using re-encrypt TLS.",
             "template.openshift.io/support-url": "https://access.redhat.com",
-            "version": "7.3.2.GA"
+            "version": "7.3.7.GA"
         },
         "name": "sso73-x509-mysql-persistent"
     },
@@ -203,7 +203,7 @@
                                     },
                                     {
                                         "name": "X509_CA_BUNDLE",
-                                        "value": "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+                                        "value": "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
                                     },
                                     {
                                         "name": "JGROUPS_CLUSTER_PASSWORD",
@@ -396,11 +396,13 @@
                                 "image": "mysql",
                                 "imagePullPolicy": "Always",
                                 "livenessProbe": {
-                                    "initialDelaySeconds": 30,
+                                    "failureThreshold": 3,
+                                    "initialDelaySeconds": 90,
+                                    "successThreshold:": 1,
                                     "tcpSocket": {
                                         "port": 3306
                                     },
-                                    "timeoutSeconds": 1
+                                    "timeoutSeconds": 10
                                 },
                                 "name": "${APPLICATION_NAME}-mysql",
                                 "ports": [
@@ -418,8 +420,10 @@
                                             "MYSQL_PWD=\"$MYSQL_PASSWORD\" mysql -h 127.0.0.1 -u $MYSQL_USER -D $MYSQL_DATABASE -e 'SELECT 1'"
                                         ]
                                     },
-                                    "initialDelaySeconds": 5,
-                                    "timeoutSeconds": 1
+                                    "failureThreshold": 3,
+                                    "initialDelaySeconds": 90,
+                                    "successThreshold:": 1,
+                                    "timeoutSeconds": 10
                                 },
                                 "volumeMounts": [
                                     {

--- a/official/sso/templates/sso73-x509-postgresql-persistent.json
+++ b/official/sso/templates/sso73-x509-postgresql-persistent.json
@@ -2,7 +2,7 @@
     "apiVersion": "v1",
     "kind": "Template",
     "labels": {
-        "rhsso": "7.3.2.GA",
+        "rhsso": "7.3.7.GA",
         "template": "sso73-x509-postgresql-persistent"
     },
     "message": "A new persistent RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
@@ -16,7 +16,7 @@
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
             "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.3 server based deployment, deployment configuration for PostgreSQL using persistence, and securing RH-SSO communication using re-encrypt TLS.",
             "template.openshift.io/support-url": "https://access.redhat.com",
-            "version": "7.3.2.GA"
+            "version": "7.3.7.GA"
         },
         "name": "sso73-x509-postgresql-persistent"
     },
@@ -203,7 +203,7 @@
                                     },
                                     {
                                         "name": "X509_CA_BUNDLE",
-                                        "value": "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+                                        "value": "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
                                     },
                                     {
                                         "name": "JGROUPS_CLUSTER_PASSWORD",
@@ -388,11 +388,13 @@
                                 "image": "postgresql",
                                 "imagePullPolicy": "Always",
                                 "livenessProbe": {
-                                    "initialDelaySeconds": 30,
+                                    "failureThreshold": 3,
+                                    "initialDelaySeconds": 90,
+                                    "successThreshold:": 1,
                                     "tcpSocket": {
                                         "port": 5432
                                     },
-                                    "timeoutSeconds": 1
+                                    "timeoutSeconds": 10
                                 },
                                 "name": "${APPLICATION_NAME}-postgresql",
                                 "ports": [
@@ -410,8 +412,10 @@
                                             "psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'"
                                         ]
                                     },
-                                    "initialDelaySeconds": 5,
-                                    "timeoutSeconds": 1
+                                    "failureThreshold": 3,
+                                    "initialDelaySeconds": 90,
+                                    "successThreshold:": 1,
+                                    "timeoutSeconds": 10
                                 },
                                 "volumeMounts": [
                                     {
@@ -613,7 +617,7 @@
             "displayName": "PostgreSQL Image Stream Tag",
             "name": "POSTGRESQL_IMAGE_STREAM_TAG",
             "required": true,
-            "value": "9.5"
+            "value": "10"
         },
         {
             "description": "Container memory limit.",


### PR DESCRIPTION

    [KEYCLOAK-8428] Update to / import latest "v7.3.7.GA" release of
    image stream and templates for the Red Hat Single Sign-On 7.3
    for OpenShift image
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

See [RHEA-2020:0948](https://access.redhat.com/errata/RHEA-2020:0948) for further details about the release