### PR TITLE
[KEYCLOAK-14317] Update the RH-SSO v7.3.8.GA / v7.4.0.GA templates to address OCP v4 change from RHBZ#1813894

### DIFF
--- a/official.yaml
+++ b/official.yaml
@@ -6,8 +6,8 @@ variables:
   eap_cd_version: CD18
   rhsso72_zstream_version: v7.2.6.GA
   rhsso_tpcd_version: sso-cd-dev
-  rhsso73_zstream_version: v7.3.8.GA
-  rhsso74_zstream_version: v7.4.0.GA
+  rhsso73_zstream_version: v7.3.8.GA-RHBZ-1813894-fix
+  rhsso74_zstream_version: v7.4.0.GA-RHBZ-1813894-fix
   webserver_version: ose-v1.4.17
   webserver3_version: jws31-v1.4
   webserver5_version: jws50-v1.2
@@ -1042,18 +1042,18 @@ data:
         docs: https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/{rhsso73_zstream_version}/docs/templates/sso73-postgresql.adoc
         tags:
           - ocp
-      - location: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/{rhsso73_zstream_version}/templates/sso73-x509-https.json
-        docs: https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/{rhsso73_zstream_version}/docs/templates/sso73-x509-https.adoc
+      - location: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/{rhsso73_zstream_version}/templates/sso73-ocp4-x509-https.json
+        docs: https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/{rhsso73_zstream_version}/docs/templates/sso73-ocp4-x509-https.adoc
         tags:
           - ocp
           - online-starter
           - online-professional
-      - location: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/{rhsso73_zstream_version}/templates/sso73-x509-mysql-persistent.json
-        docs: https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/{rhsso73_zstream_version}/docs/templates/sso73-x509-mysql-persistent.adoc
+      - location: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/{rhsso73_zstream_version}/templates/sso73-ocp4-x509-mysql-persistent.json
+        docs: https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/{rhsso73_zstream_version}/docs/templates/sso73-ocp4-x509-mysql-persistent.adoc
         tags:
           - ocp
-      - location: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/{rhsso73_zstream_version}/templates/sso73-x509-postgresql-persistent.json
-        docs: https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/{rhsso73_zstream_version}/docs/templates/sso73-x509-postgresql-persistent.adoc
+      - location: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/{rhsso73_zstream_version}/templates/sso73-ocp4-x509-postgresql-persistent.json
+        docs: https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/{rhsso73_zstream_version}/docs/templates/sso73-ocp4-x509-postgresql-persistent.adoc
         tags:
           - ocp
       # List templates for RH-SSO 7.4.x on OpenJDK stable / zstream images stream below
@@ -1069,12 +1069,12 @@ data:
         docs: https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/{rhsso74_zstream_version}/docs/templates/sso74-postgresql.adoc
         tags:
           - ocp
-      - location: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/{rhsso74_zstream_version}/templates/sso74-x509-https.json
-        docs: https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/{rhsso74_zstream_version}/docs/templates/sso74-x509-https.adoc
+      - location: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/{rhsso74_zstream_version}/templates/sso74-ocp4-x509-https.json
+        docs: https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/{rhsso74_zstream_version}/docs/templates/sso74-ocp4-x509-https.adoc
         tags:
           - ocp
-      - location: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/{rhsso74_zstream_version}/templates/sso74-x509-postgresql-persistent.json
-        docs: https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/{rhsso74_zstream_version}/docs/templates/sso74-x509-postgresql-persistent.adoc
+      - location: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/{rhsso74_zstream_version}/templates/sso74-ocp4-x509-postgresql-persistent.json
+        docs: https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/{rhsso74_zstream_version}/docs/templates/sso74-ocp4-x509-postgresql-persistent.adoc
         tags:
           - ocp
     imagestreams:

--- a/official/README.md
+++ b/official/README.md
@@ -840,11 +840,11 @@ Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso
 Docs: [https://access.redhat.com/documentation/en-us/red_hat_single_sign-on_continuous_delivery](https://access.redhat.com/documentation/en-us/red_hat_single_sign-on_continuous_delivery)  
 Path: official/sso/imagestreams/redhat-sso-cd-openshift-rhel8-rhel7.json  
 ### redhat-sso73-openshift
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA/templates/sso73-image-stream.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA/templates/sso73-image-stream.json )  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA-RHBZ-1813894-fix/templates/sso73-image-stream.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA-RHBZ-1813894-fix/templates/sso73-image-stream.json )  
 Docs: [https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.3/html-single/red_hat_single_sign-on_for_openshift/](https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.3/html-single/red_hat_single_sign-on_for_openshift/)  
 Path: official/sso/imagestreams/redhat-sso73-openshift-rhel7.json  
 ### sso74-openshift-rhel8
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA/templates/sso74-image-stream.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA/templates/sso74-image-stream.json )  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA-RHBZ-1813894-fix/templates/sso74-image-stream.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA-RHBZ-1813894-fix/templates/sso74-image-stream.json )  
 Docs: [https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.4/html-single/red_hat_single_sign-on_for_openshift/](https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.4/html-single/red_hat_single_sign-on_for_openshift/)  
 Path: official/sso/imagestreams/sso74-openshift-rhel8.json  
 ## templates
@@ -877,57 +877,57 @@ Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso
 Docs: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/sso-cd-dev/docs/templates/sso-cd-x509-https.adoc](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/sso-cd-dev/docs/templates/sso-cd-x509-https.adoc)  
 Path: official/sso/templates/sso-cd-x509-https.json  
 ### sso73-https
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA/templates/sso73-https.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA/templates/sso73-https.json )  
-Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA/docs/templates/sso73-https.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA/docs/templates/sso73-https.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA-RHBZ-1813894-fix/templates/sso73-https.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA-RHBZ-1813894-fix/templates/sso73-https.json )  
+Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA-RHBZ-1813894-fix/docs/templates/sso73-https.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA-RHBZ-1813894-fix/docs/templates/sso73-https.adoc)  
 Path: official/sso/templates/sso73-https.json  
 ### sso73-mysql-persistent
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA/templates/sso73-mysql-persistent.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA/templates/sso73-mysql-persistent.json )  
-Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA/docs/templates/sso73-mysql-persistent.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA/docs/templates/sso73-mysql-persistent.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA-RHBZ-1813894-fix/templates/sso73-mysql-persistent.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA-RHBZ-1813894-fix/templates/sso73-mysql-persistent.json )  
+Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA-RHBZ-1813894-fix/docs/templates/sso73-mysql-persistent.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA-RHBZ-1813894-fix/docs/templates/sso73-mysql-persistent.adoc)  
 Path: official/sso/templates/sso73-mysql-persistent.json  
 ### sso73-mysql
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA/templates/sso73-mysql.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA/templates/sso73-mysql.json )  
-Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA/docs/templates/sso73-mysql.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA/docs/templates/sso73-mysql.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA-RHBZ-1813894-fix/templates/sso73-mysql.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA-RHBZ-1813894-fix/templates/sso73-mysql.json )  
+Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA-RHBZ-1813894-fix/docs/templates/sso73-mysql.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA-RHBZ-1813894-fix/docs/templates/sso73-mysql.adoc)  
 Path: official/sso/templates/sso73-mysql.json  
 ### sso73-postgresql-persistent
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA/templates/sso73-postgresql-persistent.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA/templates/sso73-postgresql-persistent.json )  
-Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA/docs/templates/sso73-postgresql-persistent.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA/docs/templates/sso73-postgresql-persistent.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA-RHBZ-1813894-fix/templates/sso73-postgresql-persistent.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA-RHBZ-1813894-fix/templates/sso73-postgresql-persistent.json )  
+Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA-RHBZ-1813894-fix/docs/templates/sso73-postgresql-persistent.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA-RHBZ-1813894-fix/docs/templates/sso73-postgresql-persistent.adoc)  
 Path: official/sso/templates/sso73-postgresql-persistent.json  
 ### sso73-postgresql
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA/templates/sso73-postgresql.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA/templates/sso73-postgresql.json )  
-Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA/docs/templates/sso73-postgresql.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA/docs/templates/sso73-postgresql.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA-RHBZ-1813894-fix/templates/sso73-postgresql.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA-RHBZ-1813894-fix/templates/sso73-postgresql.json )  
+Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA-RHBZ-1813894-fix/docs/templates/sso73-postgresql.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA-RHBZ-1813894-fix/docs/templates/sso73-postgresql.adoc)  
 Path: official/sso/templates/sso73-postgresql.json  
-### sso73-x509-https
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA/templates/sso73-x509-https.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA/templates/sso73-x509-https.json )  
-Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA/docs/templates/sso73-x509-https.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA/docs/templates/sso73-x509-https.adoc)  
-Path: official/sso/templates/sso73-x509-https.json  
-### sso73-x509-mysql-persistent
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA/templates/sso73-x509-mysql-persistent.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA/templates/sso73-x509-mysql-persistent.json )  
-Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA/docs/templates/sso73-x509-mysql-persistent.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA/docs/templates/sso73-x509-mysql-persistent.adoc)  
-Path: official/sso/templates/sso73-x509-mysql-persistent.json  
-### sso73-x509-postgresql-persistent
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA/templates/sso73-x509-postgresql-persistent.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA/templates/sso73-x509-postgresql-persistent.json )  
-Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA/docs/templates/sso73-x509-postgresql-persistent.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA/docs/templates/sso73-x509-postgresql-persistent.adoc)  
-Path: official/sso/templates/sso73-x509-postgresql-persistent.json  
+### sso73-ocp4-x509-https
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA-RHBZ-1813894-fix/templates/sso73-ocp4-x509-https.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA-RHBZ-1813894-fix/templates/sso73-ocp4-x509-https.json )  
+Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA-RHBZ-1813894-fix/docs/templates/sso73-ocp4-x509-https.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA-RHBZ-1813894-fix/docs/templates/sso73-ocp4-x509-https.adoc)  
+Path: official/sso/templates/sso73-ocp4-x509-https.json  
+### sso73-ocp4-x509-mysql-persistent
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA-RHBZ-1813894-fix/templates/sso73-ocp4-x509-mysql-persistent.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA-RHBZ-1813894-fix/templates/sso73-ocp4-x509-mysql-persistent.json )  
+Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA-RHBZ-1813894-fix/docs/templates/sso73-ocp4-x509-mysql-persistent.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA-RHBZ-1813894-fix/docs/templates/sso73-ocp4-x509-mysql-persistent.adoc)  
+Path: official/sso/templates/sso73-ocp4-x509-mysql-persistent.json  
+### sso73-ocp4-x509-postgresql-persistent
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA-RHBZ-1813894-fix/templates/sso73-ocp4-x509-postgresql-persistent.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA-RHBZ-1813894-fix/templates/sso73-ocp4-x509-postgresql-persistent.json )  
+Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA-RHBZ-1813894-fix/docs/templates/sso73-ocp4-x509-postgresql-persistent.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA-RHBZ-1813894-fix/docs/templates/sso73-ocp4-x509-postgresql-persistent.adoc)  
+Path: official/sso/templates/sso73-ocp4-x509-postgresql-persistent.json  
 ### sso74-https
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA/templates/sso74-https.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA/templates/sso74-https.json )  
-Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.4.0.GA/docs/templates/sso74-https.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.4.0.GA/docs/templates/sso74-https.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA-RHBZ-1813894-fix/templates/sso74-https.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA-RHBZ-1813894-fix/templates/sso74-https.json )  
+Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.4.0.GA-RHBZ-1813894-fix/docs/templates/sso74-https.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.4.0.GA-RHBZ-1813894-fix/docs/templates/sso74-https.adoc)  
 Path: official/sso/templates/sso74-https.json  
 ### sso74-postgresql-persistent
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA/templates/sso74-postgresql-persistent.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA/templates/sso74-postgresql-persistent.json )  
-Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.4.0.GA/docs/templates/sso74-postgresql-persistent.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.4.0.GA/docs/templates/sso74-postgresql-persistent.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA-RHBZ-1813894-fix/templates/sso74-postgresql-persistent.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA-RHBZ-1813894-fix/templates/sso74-postgresql-persistent.json )  
+Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.4.0.GA-RHBZ-1813894-fix/docs/templates/sso74-postgresql-persistent.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.4.0.GA-RHBZ-1813894-fix/docs/templates/sso74-postgresql-persistent.adoc)  
 Path: official/sso/templates/sso74-postgresql-persistent.json  
 ### sso74-postgresql
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA/templates/sso74-postgresql.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA/templates/sso74-postgresql.json )  
-Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.4.0.GA/docs/templates/sso74-postgresql.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.4.0.GA/docs/templates/sso74-postgresql.adoc)  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA-RHBZ-1813894-fix/templates/sso74-postgresql.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA-RHBZ-1813894-fix/templates/sso74-postgresql.json )  
+Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.4.0.GA-RHBZ-1813894-fix/docs/templates/sso74-postgresql.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.4.0.GA-RHBZ-1813894-fix/docs/templates/sso74-postgresql.adoc)  
 Path: official/sso/templates/sso74-postgresql.json  
-### sso74-x509-https
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA/templates/sso74-x509-https.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA/templates/sso74-x509-https.json )  
-Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.4.0.GA/docs/templates/sso74-x509-https.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.4.0.GA/docs/templates/sso74-x509-https.adoc)  
-Path: official/sso/templates/sso74-x509-https.json  
-### sso74-x509-postgresql-persistent
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA/templates/sso74-x509-postgresql-persistent.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA/templates/sso74-x509-postgresql-persistent.json )  
-Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.4.0.GA/docs/templates/sso74-x509-postgresql-persistent.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.4.0.GA/docs/templates/sso74-x509-postgresql-persistent.adoc)  
-Path: official/sso/templates/sso74-x509-postgresql-persistent.json  
+### sso74-ocp4-x509-https
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA-RHBZ-1813894-fix/templates/sso74-ocp4-x509-https.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA-RHBZ-1813894-fix/templates/sso74-ocp4-x509-https.json )  
+Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.4.0.GA-RHBZ-1813894-fix/docs/templates/sso74-ocp4-x509-https.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.4.0.GA-RHBZ-1813894-fix/docs/templates/sso74-ocp4-x509-https.adoc)  
+Path: official/sso/templates/sso74-ocp4-x509-https.json  
+### sso74-ocp4-x509-postgresql-persistent
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA-RHBZ-1813894-fix/templates/sso74-ocp4-x509-postgresql-persistent.json](https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA-RHBZ-1813894-fix/templates/sso74-ocp4-x509-postgresql-persistent.json )  
+Docs: [https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.4.0.GA-RHBZ-1813894-fix/docs/templates/sso74-ocp4-x509-postgresql-persistent.adoc](https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.4.0.GA-RHBZ-1813894-fix/docs/templates/sso74-ocp4-x509-postgresql-persistent.adoc)  
+Path: official/sso/templates/sso74-ocp4-x509-postgresql-persistent.json  
 # webserver
 ## imagestreams
 ### jboss-webserver30-tomcat7-openshift

--- a/official/index.json
+++ b/official/index.json
@@ -1411,13 +1411,13 @@
                 "docs": "https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.3/html-single/red_hat_single_sign-on_for_openshift/",
                 "name": "redhat-sso73-openshift",
                 "path": "official/sso/imagestreams/redhat-sso73-openshift-rhel7.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA/templates/sso73-image-stream.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA-RHBZ-1813894-fix/templates/sso73-image-stream.json"
             },
             {
                 "docs": "https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.4/html-single/red_hat_single_sign-on_for_openshift/",
                 "name": "sso74-openshift-rhel8",
                 "path": "official/sso/imagestreams/sso74-openshift-rhel8.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA/templates/sso74-image-stream.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA-RHBZ-1813894-fix/templates/sso74-image-stream.json"
             }
         ],
         "templates": [
@@ -1472,94 +1472,94 @@
             },
             {
                 "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
-                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA/docs/templates/sso73-https.adoc",
+                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA-RHBZ-1813894-fix/docs/templates/sso73-https.adoc",
                 "name": "sso73-https",
                 "path": "official/sso/templates/sso73-https.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA/templates/sso73-https.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA-RHBZ-1813894-fix/templates/sso73-https.json"
             },
             {
                 "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
-                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA/docs/templates/sso73-mysql-persistent.adoc",
+                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA-RHBZ-1813894-fix/docs/templates/sso73-mysql-persistent.adoc",
                 "name": "sso73-mysql-persistent",
                 "path": "official/sso/templates/sso73-mysql-persistent.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA/templates/sso73-mysql-persistent.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA-RHBZ-1813894-fix/templates/sso73-mysql-persistent.json"
             },
             {
                 "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
-                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA/docs/templates/sso73-mysql.adoc",
+                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA-RHBZ-1813894-fix/docs/templates/sso73-mysql.adoc",
                 "name": "sso73-mysql",
                 "path": "official/sso/templates/sso73-mysql.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA/templates/sso73-mysql.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA-RHBZ-1813894-fix/templates/sso73-mysql.json"
             },
             {
                 "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
-                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA/docs/templates/sso73-postgresql-persistent.adoc",
+                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA-RHBZ-1813894-fix/docs/templates/sso73-postgresql-persistent.adoc",
                 "name": "sso73-postgresql-persistent",
                 "path": "official/sso/templates/sso73-postgresql-persistent.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA/templates/sso73-postgresql-persistent.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA-RHBZ-1813894-fix/templates/sso73-postgresql-persistent.json"
             },
             {
                 "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
-                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA/docs/templates/sso73-postgresql.adoc",
+                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA-RHBZ-1813894-fix/docs/templates/sso73-postgresql.adoc",
                 "name": "sso73-postgresql",
                 "path": "official/sso/templates/sso73-postgresql.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA/templates/sso73-postgresql.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA-RHBZ-1813894-fix/templates/sso73-postgresql.json"
             },
             {
                 "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
-                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA/docs/templates/sso73-x509-https.adoc",
-                "name": "sso73-x509-https",
-                "path": "official/sso/templates/sso73-x509-https.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA/templates/sso73-x509-https.json"
+                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA-RHBZ-1813894-fix/docs/templates/sso73-ocp4-x509-https.adoc",
+                "name": "sso73-ocp4-x509-https",
+                "path": "official/sso/templates/sso73-ocp4-x509-https.json",
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA-RHBZ-1813894-fix/templates/sso73-ocp4-x509-https.json"
             },
             {
                 "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
-                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA/docs/templates/sso73-x509-mysql-persistent.adoc",
-                "name": "sso73-x509-mysql-persistent",
-                "path": "official/sso/templates/sso73-x509-mysql-persistent.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA/templates/sso73-x509-mysql-persistent.json"
+                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA-RHBZ-1813894-fix/docs/templates/sso73-ocp4-x509-mysql-persistent.adoc",
+                "name": "sso73-ocp4-x509-mysql-persistent",
+                "path": "official/sso/templates/sso73-ocp4-x509-mysql-persistent.json",
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA-RHBZ-1813894-fix/templates/sso73-ocp4-x509-mysql-persistent.json"
             },
             {
                 "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
-                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA/docs/templates/sso73-x509-postgresql-persistent.adoc",
-                "name": "sso73-x509-postgresql-persistent",
-                "path": "official/sso/templates/sso73-x509-postgresql-persistent.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA/templates/sso73-x509-postgresql-persistent.json"
+                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.3.8.GA-RHBZ-1813894-fix/docs/templates/sso73-ocp4-x509-postgresql-persistent.adoc",
+                "name": "sso73-ocp4-x509-postgresql-persistent",
+                "path": "official/sso/templates/sso73-ocp4-x509-postgresql-persistent.json",
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.3.8.GA-RHBZ-1813894-fix/templates/sso73-ocp4-x509-postgresql-persistent.json"
             },
             {
                 "description": "An example application based on RH-SSO 7.4 on OpenJDK image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/tree/sso74-dev/docs.",
-                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.4.0.GA/docs/templates/sso74-https.adoc",
+                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.4.0.GA-RHBZ-1813894-fix/docs/templates/sso74-https.adoc",
                 "name": "sso74-https",
                 "path": "official/sso/templates/sso74-https.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA/templates/sso74-https.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA-RHBZ-1813894-fix/templates/sso74-https.json"
             },
             {
                 "description": "An example application based on RH-SSO 7.4 on OpenJDK image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/tree/sso74-dev/docs.",
-                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.4.0.GA/docs/templates/sso74-postgresql-persistent.adoc",
+                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.4.0.GA-RHBZ-1813894-fix/docs/templates/sso74-postgresql-persistent.adoc",
                 "name": "sso74-postgresql-persistent",
                 "path": "official/sso/templates/sso74-postgresql-persistent.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA/templates/sso74-postgresql-persistent.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA-RHBZ-1813894-fix/templates/sso74-postgresql-persistent.json"
             },
             {
                 "description": "An example application based on RH-SSO 7.4 on OpenJDK image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/tree/sso74-dev/docs.",
-                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.4.0.GA/docs/templates/sso74-postgresql.adoc",
+                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.4.0.GA-RHBZ-1813894-fix/docs/templates/sso74-postgresql.adoc",
                 "name": "sso74-postgresql",
                 "path": "official/sso/templates/sso74-postgresql.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA/templates/sso74-postgresql.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA-RHBZ-1813894-fix/templates/sso74-postgresql.json"
             },
             {
                 "description": "An example application based on RH-SSO 7.4 on OpenJDK image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/tree/sso74-dev/docs.",
-                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.4.0.GA/docs/templates/sso74-x509-https.adoc",
-                "name": "sso74-x509-https",
-                "path": "official/sso/templates/sso74-x509-https.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA/templates/sso74-x509-https.json"
+                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.4.0.GA-RHBZ-1813894-fix/docs/templates/sso74-ocp4-x509-https.adoc",
+                "name": "sso74-ocp4-x509-https",
+                "path": "official/sso/templates/sso74-ocp4-x509-https.json",
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA-RHBZ-1813894-fix/templates/sso74-ocp4-x509-https.json"
             },
             {
                 "description": "An example application based on RH-SSO 7.4 on OpenJDK image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/tree/sso74-dev/docs.",
-                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.4.0.GA/docs/templates/sso74-x509-postgresql-persistent.adoc",
-                "name": "sso74-x509-postgresql-persistent",
-                "path": "official/sso/templates/sso74-x509-postgresql-persistent.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA/templates/sso74-x509-postgresql-persistent.json"
+                "docs": "https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/v7.4.0.GA-RHBZ-1813894-fix/docs/templates/sso74-ocp4-x509-postgresql-persistent.adoc",
+                "name": "sso74-ocp4-x509-postgresql-persistent",
+                "path": "official/sso/templates/sso74-ocp4-x509-postgresql-persistent.json",
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/v7.4.0.GA-RHBZ-1813894-fix/templates/sso74-ocp4-x509-postgresql-persistent.json"
             }
         ]
     },

--- a/official/sso/templates/sso73-ocp4-x509-https.json
+++ b/official/sso/templates/sso73-ocp4-x509-https.json
@@ -3,31 +3,44 @@
     "kind": "Template",
     "labels": {
         "rhsso": "7.3.8.GA",
-        "template": "sso73-x509-mysql-persistent"
+        "template": "sso73-ocp4-x509-https"
     },
-    "message": "A new persistent RH-SSO service (using MySQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the MySQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
+    "message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
     "metadata": {
         "annotations": {
             "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
             "iconClass": "icon-sso",
-            "openshift.io/display-name": "Red Hat Single Sign-On 7.3 + MySQL (Persistent)",
+            "openshift.io/display-name": "Red Hat Single Sign-On 7.3 (Ephemeral)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "tags": "sso,keycloak,jboss",
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
-            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.3 server based deployment, deployment configuration for MySQL using persistence, and securing RH-SSO communication using re-encrypt TLS.",
+            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.3 server based deployment, securing RH-SSO communication using re-encrypt TLS.",
             "template.openshift.io/support-url": "https://access.redhat.com",
             "version": "7.3.8.GA"
         },
-        "name": "sso73-x509-mysql-persistent"
+        "name": "sso73-ocp4-x509-https"
     },
     "objects": [
+        {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {
+                "annotations": {
+                    "description": "ConfigMap providing service ca bundle.",
+                    "service.beta.openshift.io/inject-cabundle": "true"
+                },
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "name": "${APPLICATION_NAME}-service-ca"
+            }
+        },
         {
             "apiVersion": "v1",
             "kind": "Service",
             "metadata": {
                 "annotations": {
                     "description": "The web server's https port.",
-                    "service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mysql\", \"kind\": \"Service\"}]",
                     "service.alpha.openshift.io/serving-cert-secret-name": "sso-x509-https-secret"
                 },
                 "labels": {
@@ -44,30 +57,6 @@
                 ],
                 "selector": {
                     "deploymentConfig": "${APPLICATION_NAME}"
-                }
-            }
-        },
-        {
-            "apiVersion": "v1",
-            "kind": "Service",
-            "metadata": {
-                "annotations": {
-                    "description": "The database server's port."
-                },
-                "labels": {
-                    "application": "${APPLICATION_NAME}"
-                },
-                "name": "${APPLICATION_NAME}-mysql"
-            },
-            "spec": {
-                "ports": [
-                    {
-                        "port": 3306,
-                        "targetPort": 3306
-                    }
-                ],
-                "selector": {
-                    "deploymentConfig": "${APPLICATION_NAME}-mysql"
                 }
             }
         },
@@ -154,30 +143,6 @@
                                         "value": "${SSO_HOSTNAME}"
                                     },
                                     {
-                                        "name": "DB_SERVICE_PREFIX_MAPPING",
-                                        "value": "${APPLICATION_NAME}-mysql=DB"
-                                    },
-                                    {
-                                        "name": "DB_JNDI",
-                                        "value": "${DB_JNDI}"
-                                    },
-                                    {
-                                        "name": "DB_USERNAME",
-                                        "value": "${DB_USERNAME}"
-                                    },
-                                    {
-                                        "name": "DB_PASSWORD",
-                                        "value": "${DB_PASSWORD}"
-                                    },
-                                    {
-                                        "name": "DB_DATABASE",
-                                        "value": "${DB_DATABASE}"
-                                    },
-                                    {
-                                        "name": "TX_DATABASE_PREFIX_MAPPING",
-                                        "value": "${APPLICATION_NAME}-mysql=DB"
-                                    },
-                                    {
                                         "name": "DB_MIN_POOL_SIZE",
                                         "value": "${DB_MIN_POOL_SIZE}"
                                     },
@@ -203,7 +168,7 @@
                                     },
                                     {
                                         "name": "X509_CA_BUNDLE",
-                                        "value": "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+                                        "value": "/var/run/configmaps/service-ca/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
                                     },
                                     {
                                         "name": "JGROUPS_CLUSTER_PASSWORD",
@@ -289,6 +254,11 @@
                                         "mountPath": "/etc/x509/jgroups",
                                         "name": "sso-x509-jgroups-volume",
                                         "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/run/configmaps/service-ca",
+                                        "name": "service-ca",
+                                        "readOnly": true
                                     }
                                 ]
                             }
@@ -306,6 +276,12 @@
                                 "secret": {
                                     "secretName": "sso-x509-jgroups-secret"
                                 }
+                            },
+                            {
+                                "configMap": {
+                                    "name": "${APPLICATION_NAME}-service-ca"
+                                },
+                                "name": "service-ca"
                             }
                         ]
                     }
@@ -329,160 +305,6 @@
                         "type": "ConfigChange"
                     }
                 ]
-            }
-        },
-        {
-            "apiVersion": "v1",
-            "kind": "DeploymentConfig",
-            "metadata": {
-                "labels": {
-                    "application": "${APPLICATION_NAME}"
-                },
-                "name": "${APPLICATION_NAME}-mysql"
-            },
-            "spec": {
-                "replicas": 1,
-                "selector": {
-                    "deploymentConfig": "${APPLICATION_NAME}-mysql"
-                },
-                "strategy": {
-                    "type": "Recreate"
-                },
-                "template": {
-                    "metadata": {
-                        "labels": {
-                            "application": "${APPLICATION_NAME}",
-                            "deploymentConfig": "${APPLICATION_NAME}-mysql"
-                        },
-                        "name": "${APPLICATION_NAME}-mysql"
-                    },
-                    "spec": {
-                        "containers": [
-                            {
-                                "env": [
-                                    {
-                                        "name": "MYSQL_USER",
-                                        "value": "${DB_USERNAME}"
-                                    },
-                                    {
-                                        "name": "MYSQL_PASSWORD",
-                                        "value": "${DB_PASSWORD}"
-                                    },
-                                    {
-                                        "name": "MYSQL_DATABASE",
-                                        "value": "${DB_DATABASE}"
-                                    },
-                                    {
-                                        "name": "MYSQL_LOWER_CASE_TABLE_NAMES",
-                                        "value": "${MYSQL_LOWER_CASE_TABLE_NAMES}"
-                                    },
-                                    {
-                                        "name": "MYSQL_MAX_CONNECTIONS",
-                                        "value": "${MYSQL_MAX_CONNECTIONS}"
-                                    },
-                                    {
-                                        "name": "MYSQL_FT_MIN_WORD_LEN",
-                                        "value": "${MYSQL_FT_MIN_WORD_LEN}"
-                                    },
-                                    {
-                                        "name": "MYSQL_FT_MAX_WORD_LEN",
-                                        "value": "${MYSQL_FT_MAX_WORD_LEN}"
-                                    },
-                                    {
-                                        "name": "MYSQL_AIO",
-                                        "value": "${MYSQL_AIO}"
-                                    }
-                                ],
-                                "image": "mysql",
-                                "imagePullPolicy": "Always",
-                                "livenessProbe": {
-                                    "failureThreshold": 3,
-                                    "initialDelaySeconds": 90,
-                                    "successThreshold:": 1,
-                                    "tcpSocket": {
-                                        "port": 3306
-                                    },
-                                    "timeoutSeconds": 10
-                                },
-                                "name": "${APPLICATION_NAME}-mysql",
-                                "ports": [
-                                    {
-                                        "containerPort": 3306,
-                                        "protocol": "TCP"
-                                    }
-                                ],
-                                "readinessProbe": {
-                                    "exec": {
-                                        "command": [
-                                            "/bin/sh",
-                                            "-i",
-                                            "-c",
-                                            "MYSQL_PWD=\"$MYSQL_PASSWORD\" mysql -h 127.0.0.1 -u $MYSQL_USER -D $MYSQL_DATABASE -e 'SELECT 1'"
-                                        ]
-                                    },
-                                    "failureThreshold": 3,
-                                    "initialDelaySeconds": 90,
-                                    "successThreshold:": 1,
-                                    "timeoutSeconds": 10
-                                },
-                                "volumeMounts": [
-                                    {
-                                        "mountPath": "/var/lib/mysql/data",
-                                        "name": "${APPLICATION_NAME}-mysql-pvol"
-                                    }
-                                ]
-                            }
-                        ],
-                        "terminationGracePeriodSeconds": 60,
-                        "volumes": [
-                            {
-                                "name": "${APPLICATION_NAME}-mysql-pvol",
-                                "persistentVolumeClaim": {
-                                    "claimName": "${APPLICATION_NAME}-mysql-claim"
-                                }
-                            }
-                        ]
-                    }
-                },
-                "triggers": [
-                    {
-                        "imageChangeParams": {
-                            "automatic": true,
-                            "containerNames": [
-                                "${APPLICATION_NAME}-mysql"
-                            ],
-                            "from": {
-                                "kind": "ImageStreamTag",
-                                "name": "mysql:${MYSQL_IMAGE_STREAM_TAG}",
-                                "namespace": "${IMAGE_STREAM_NAMESPACE}"
-                            }
-                        },
-                        "type": "ImageChange"
-                    },
-                    {
-                        "type": "ConfigChange"
-                    }
-                ]
-            }
-        },
-        {
-            "apiVersion": "v1",
-            "kind": "PersistentVolumeClaim",
-            "metadata": {
-                "labels": {
-                    "application": "${APPLICATION_NAME}"
-                },
-                "name": "${APPLICATION_NAME}-mysql-claim"
-            },
-            "spec": {
-                "accessModes": [
-                    "ReadWriteOnce"
-                ],
-                "resources": {
-                    "requests": {
-                        "storage": "${VOLUME_CAPACITY}"
-                    }
-                }
             }
         }
     ],
@@ -510,20 +332,6 @@
             "required": true
         },
         {
-            "description": "Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mysql",
-            "displayName": "Database JNDI Name",
-            "name": "DB_JNDI",
-            "required": false,
-            "value": "java:jboss/datasources/KeycloakDS"
-        },
-        {
-            "description": "Database name",
-            "displayName": "Database Name",
-            "name": "DB_DATABASE",
-            "required": true,
-            "value": "root"
-        },
-        {
             "description": "Sets xa-pool/min-pool-size for the configured datasource.",
             "displayName": "Datasource Minimum Pool Size",
             "name": "DB_MIN_POOL_SIZE",
@@ -542,59 +350,6 @@
             "required": false
         },
         {
-            "description": "Sets how the table names are stored and compared.",
-            "displayName": "MySQL Lower Case Table Names",
-            "name": "MYSQL_LOWER_CASE_TABLE_NAMES",
-            "required": false
-        },
-        {
-            "description": "The maximum permitted number of simultaneous client connections.",
-            "displayName": "MySQL Maximum number of connections",
-            "name": "MYSQL_MAX_CONNECTIONS",
-            "required": false
-        },
-        {
-            "description": "The minimum length of the word to be included in a FULLTEXT index.",
-            "displayName": "MySQL FullText Minimum Word Length",
-            "name": "MYSQL_FT_MIN_WORD_LEN",
-            "required": false
-        },
-        {
-            "description": "The maximum length of the word to be included in a FULLTEXT index.",
-            "displayName": "MySQL FullText Maximum Word Length",
-            "name": "MYSQL_FT_MAX_WORD_LEN",
-            "required": false
-        },
-        {
-            "description": "Controls the innodb_use_native_aio setting value if the native AIO is broken.",
-            "displayName": "MySQL AIO",
-            "name": "MYSQL_AIO",
-            "required": false
-        },
-        {
-            "description": "Database user name",
-            "displayName": "Database Username",
-            "from": "user[a-zA-Z0-9]{3}",
-            "generate": "expression",
-            "name": "DB_USERNAME",
-            "required": true
-        },
-        {
-            "description": "Database user password",
-            "displayName": "Database Password",
-            "from": "[a-zA-Z0-9]{32}",
-            "generate": "expression",
-            "name": "DB_PASSWORD",
-            "required": true
-        },
-        {
-            "description": "Size of persistent storage for database volume.",
-            "displayName": "Database Volume Capacity",
-            "name": "VOLUME_CAPACITY",
-            "required": true,
-            "value": "1Gi"
-        },
-        {
             "description": "Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.",
             "displayName": "ImageStream Namespace",
             "name": "IMAGE_STREAM_NAMESPACE",
@@ -610,8 +365,8 @@
             "required": true
         },
         {
-            "description": "RH-SSO Server administrator password",
-            "displayName": "RH_SSO Administrator Password",
+            "description": "RH-SSO Server admininistrator password",
+            "displayName": "RH-SSO Administrator Password",
             "from": "[a-zA-Z0-9]{32}",
             "generate": "expression",
             "name": "SSO_ADMIN_PASSWORD",
@@ -625,7 +380,7 @@
             "value": ""
         },
         {
-            "description": "The username used to access the RH-SSO service.  This is used by clients to create the appliction client(s) within the specified RH-SSO realm.",
+            "description": "The username used to access the RH-SSO service. This is used by clients to create the appliction client(s) within the specified RH-SSO realm.",
             "displayName": "RH-SSO Service Username",
             "name": "SSO_SERVICE_USERNAME",
             "required": false,
@@ -637,13 +392,6 @@
             "name": "SSO_SERVICE_PASSWORD",
             "required": false,
             "value": ""
-        },
-        {
-            "description": "The tag to use for the \"mysql\" image stream.  Typically, this aligns with the major.minor version of MySQL.",
-            "displayName": "MySQL Image Stream Tag",
-            "name": "MYSQL_IMAGE_STREAM_TAG",
-            "required": true,
-            "value": "5.7"
         },
         {
             "description": "Container memory limit.",

--- a/official/sso/templates/sso73-ocp4-x509-mysql-persistent.json
+++ b/official/sso/templates/sso73-ocp4-x509-mysql-persistent.json
@@ -2,32 +2,46 @@
     "apiVersion": "v1",
     "kind": "Template",
     "labels": {
-        "rhsso": "7.4.0.GA",
-        "template": "sso74-x509-postgresql-persistent"
+        "rhsso": "7.3.8.GA",
+        "template": "sso73-ocp4-x509-mysql-persistent"
     },
-    "message": "A new persistent RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
+    "message": "A new persistent RH-SSO service (using MySQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the MySQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
     "metadata": {
         "annotations": {
-            "description": "An example application based on RH-SSO 7.4 on OpenJDK image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/tree/sso74-dev/docs.",
+            "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
             "iconClass": "icon-sso",
-            "openshift.io/display-name": "Red Hat Single Sign-On 7.4 on OpenJDK + PostgreSQL (Persistent)",
+            "openshift.io/display-name": "Red Hat Single Sign-On 7.3 + MySQL (Persistent)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "tags": "sso,keycloak,jboss",
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
-            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.4 on OpenJDK server based deployment, deployment configuration for PostgreSQL using persistence, and securing RH-SSO communication using re-encrypt TLS.",
+            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.3 server based deployment, deployment configuration for MySQL using persistence, and securing RH-SSO communication using re-encrypt TLS.",
             "template.openshift.io/support-url": "https://access.redhat.com",
-            "version": "7.4.0.GA"
+            "version": "7.3.8.GA"
         },
-        "name": "sso74-x509-postgresql-persistent"
+        "name": "sso73-ocp4-x509-mysql-persistent"
     },
     "objects": [
+        {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {
+                "annotations": {
+                    "description": "ConfigMap providing service ca bundle.",
+                    "service.beta.openshift.io/inject-cabundle": "true"
+                },
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "name": "${APPLICATION_NAME}-service-ca"
+            }
+        },
         {
             "apiVersion": "v1",
             "kind": "Service",
             "metadata": {
                 "annotations": {
                     "description": "The web server's https port.",
-                    "service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-postgresql\", \"kind\": \"Service\"}]",
+                    "service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mysql\", \"kind\": \"Service\"}]",
                     "service.alpha.openshift.io/serving-cert-secret-name": "sso-x509-https-secret"
                 },
                 "labels": {
@@ -57,17 +71,17 @@
                 "labels": {
                     "application": "${APPLICATION_NAME}"
                 },
-                "name": "${APPLICATION_NAME}-postgresql"
+                "name": "${APPLICATION_NAME}-mysql"
             },
             "spec": {
                 "ports": [
                     {
-                        "port": 5432,
-                        "targetPort": 5432
+                        "port": 3306,
+                        "targetPort": 3306
                     }
                 ],
                 "selector": {
-                    "deploymentConfig": "${APPLICATION_NAME}-postgresql"
+                    "deploymentConfig": "${APPLICATION_NAME}-mysql"
                 }
             }
         },
@@ -155,7 +169,7 @@
                                     },
                                     {
                                         "name": "DB_SERVICE_PREFIX_MAPPING",
-                                        "value": "${APPLICATION_NAME}-postgresql=DB"
+                                        "value": "${APPLICATION_NAME}-mysql=DB"
                                     },
                                     {
                                         "name": "DB_JNDI",
@@ -175,7 +189,7 @@
                                     },
                                     {
                                         "name": "TX_DATABASE_PREFIX_MAPPING",
-                                        "value": "${APPLICATION_NAME}-postgresql=DB"
+                                        "value": "${APPLICATION_NAME}-mysql=DB"
                                     },
                                     {
                                         "name": "DB_MIN_POOL_SIZE",
@@ -203,7 +217,7 @@
                                     },
                                     {
                                         "name": "X509_CA_BUNDLE",
-                                        "value": "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+                                        "value": "/var/run/configmaps/service-ca/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
                                     },
                                     {
                                         "name": "JGROUPS_CLUSTER_PASSWORD",
@@ -289,6 +303,11 @@
                                         "mountPath": "/etc/x509/jgroups",
                                         "name": "sso-x509-jgroups-volume",
                                         "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/run/configmaps/service-ca",
+                                        "name": "service-ca",
+                                        "readOnly": true
                                     }
                                 ]
                             }
@@ -306,6 +325,12 @@
                                 "secret": {
                                     "secretName": "sso-x509-jgroups-secret"
                                 }
+                            },
+                            {
+                                "configMap": {
+                                    "name": "${APPLICATION_NAME}-service-ca"
+                                },
+                                "name": "service-ca"
                             }
                         ]
                     }
@@ -319,7 +344,7 @@
                             ],
                             "from": {
                                 "kind": "ImageStreamTag",
-                                "name": "sso74-openshift-rhel8:7.4",
+                                "name": "redhat-sso73-openshift:1.0",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}"
                             }
                         },
@@ -338,12 +363,12 @@
                 "labels": {
                     "application": "${APPLICATION_NAME}"
                 },
-                "name": "${APPLICATION_NAME}-postgresql"
+                "name": "${APPLICATION_NAME}-mysql"
             },
             "spec": {
                 "replicas": 1,
                 "selector": {
-                    "deploymentConfig": "${APPLICATION_NAME}-postgresql"
+                    "deploymentConfig": "${APPLICATION_NAME}-mysql"
                 },
                 "strategy": {
                     "type": "Recreate"
@@ -352,54 +377,62 @@
                     "metadata": {
                         "labels": {
                             "application": "${APPLICATION_NAME}",
-                            "deploymentConfig": "${APPLICATION_NAME}-postgresql"
+                            "deploymentConfig": "${APPLICATION_NAME}-mysql"
                         },
-                        "name": "${APPLICATION_NAME}-postgresql"
+                        "name": "${APPLICATION_NAME}-mysql"
                     },
                     "spec": {
                         "containers": [
                             {
                                 "env": [
                                     {
-                                        "name": "POSTGRESQL_USER",
+                                        "name": "MYSQL_USER",
                                         "value": "${DB_USERNAME}"
                                     },
                                     {
-                                        "name": "POSTGRESQL_PASSWORD",
+                                        "name": "MYSQL_PASSWORD",
                                         "value": "${DB_PASSWORD}"
                                     },
                                     {
-                                        "name": "POSTGRESQL_DATABASE",
+                                        "name": "MYSQL_DATABASE",
                                         "value": "${DB_DATABASE}"
                                     },
                                     {
-                                        "name": "POSTGRESQL_MAX_CONNECTIONS",
-                                        "value": "${POSTGRESQL_MAX_CONNECTIONS}"
+                                        "name": "MYSQL_LOWER_CASE_TABLE_NAMES",
+                                        "value": "${MYSQL_LOWER_CASE_TABLE_NAMES}"
                                     },
                                     {
-                                        "name": "POSTGRESQL_MAX_PREPARED_TRANSACTIONS",
-                                        "value": "${POSTGRESQL_MAX_CONNECTIONS}"
+                                        "name": "MYSQL_MAX_CONNECTIONS",
+                                        "value": "${MYSQL_MAX_CONNECTIONS}"
                                     },
                                     {
-                                        "name": "POSTGRESQL_SHARED_BUFFERS",
-                                        "value": "${POSTGRESQL_SHARED_BUFFERS}"
+                                        "name": "MYSQL_FT_MIN_WORD_LEN",
+                                        "value": "${MYSQL_FT_MIN_WORD_LEN}"
+                                    },
+                                    {
+                                        "name": "MYSQL_FT_MAX_WORD_LEN",
+                                        "value": "${MYSQL_FT_MAX_WORD_LEN}"
+                                    },
+                                    {
+                                        "name": "MYSQL_AIO",
+                                        "value": "${MYSQL_AIO}"
                                     }
                                 ],
-                                "image": "postgresql",
+                                "image": "mysql",
                                 "imagePullPolicy": "Always",
                                 "livenessProbe": {
                                     "failureThreshold": 3,
                                     "initialDelaySeconds": 90,
                                     "successThreshold:": 1,
                                     "tcpSocket": {
-                                        "port": 5432
+                                        "port": 3306
                                     },
                                     "timeoutSeconds": 10
                                 },
-                                "name": "${APPLICATION_NAME}-postgresql",
+                                "name": "${APPLICATION_NAME}-mysql",
                                 "ports": [
                                     {
-                                        "containerPort": 5432,
+                                        "containerPort": 3306,
                                         "protocol": "TCP"
                                     }
                                 ],
@@ -409,7 +442,7 @@
                                             "/bin/sh",
                                             "-i",
                                             "-c",
-                                            "psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'"
+                                            "MYSQL_PWD=\"$MYSQL_PASSWORD\" mysql -h 127.0.0.1 -u $MYSQL_USER -D $MYSQL_DATABASE -e 'SELECT 1'"
                                         ]
                                     },
                                     "failureThreshold": 3,
@@ -419,8 +452,8 @@
                                 },
                                 "volumeMounts": [
                                     {
-                                        "mountPath": "/var/lib/pgsql/data",
-                                        "name": "${APPLICATION_NAME}-postgresql-pvol"
+                                        "mountPath": "/var/lib/mysql/data",
+                                        "name": "${APPLICATION_NAME}-mysql-pvol"
                                     }
                                 ]
                             }
@@ -428,9 +461,9 @@
                         "terminationGracePeriodSeconds": 60,
                         "volumes": [
                             {
-                                "name": "${APPLICATION_NAME}-postgresql-pvol",
+                                "name": "${APPLICATION_NAME}-mysql-pvol",
                                 "persistentVolumeClaim": {
-                                    "claimName": "${APPLICATION_NAME}-postgresql-claim"
+                                    "claimName": "${APPLICATION_NAME}-mysql-claim"
                                 }
                             }
                         ]
@@ -441,11 +474,11 @@
                         "imageChangeParams": {
                             "automatic": true,
                             "containerNames": [
-                                "${APPLICATION_NAME}-postgresql"
+                                "${APPLICATION_NAME}-mysql"
                             ],
                             "from": {
                                 "kind": "ImageStreamTag",
-                                "name": "postgresql:${POSTGRESQL_IMAGE_STREAM_TAG}",
+                                "name": "mysql:${MYSQL_IMAGE_STREAM_TAG}",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}"
                             }
                         },
@@ -464,7 +497,7 @@
                 "labels": {
                     "application": "${APPLICATION_NAME}"
                 },
-                "name": "${APPLICATION_NAME}-postgresql-claim"
+                "name": "${APPLICATION_NAME}-mysql-claim"
             },
             "spec": {
                 "accessModes": [
@@ -502,7 +535,7 @@
             "required": true
         },
         {
-            "description": "Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/postgresql",
+            "description": "Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mysql",
             "displayName": "Database JNDI Name",
             "name": "DB_JNDI",
             "required": false,
@@ -534,15 +567,33 @@
             "required": false
         },
         {
-            "description": "The maximum number of client connections allowed. This also sets the maximum number of prepared transactions.",
-            "displayName": "PostgreSQL Maximum number of connections",
-            "name": "POSTGRESQL_MAX_CONNECTIONS",
+            "description": "Sets how the table names are stored and compared.",
+            "displayName": "MySQL Lower Case Table Names",
+            "name": "MYSQL_LOWER_CASE_TABLE_NAMES",
             "required": false
         },
         {
-            "description": "Configures how much memory is dedicated to PostgreSQL for caching data.",
-            "displayName": "PostgreSQL Shared Buffers",
-            "name": "POSTGRESQL_SHARED_BUFFERS",
+            "description": "The maximum permitted number of simultaneous client connections.",
+            "displayName": "MySQL Maximum number of connections",
+            "name": "MYSQL_MAX_CONNECTIONS",
+            "required": false
+        },
+        {
+            "description": "The minimum length of the word to be included in a FULLTEXT index.",
+            "displayName": "MySQL FullText Minimum Word Length",
+            "name": "MYSQL_FT_MIN_WORD_LEN",
+            "required": false
+        },
+        {
+            "description": "The maximum length of the word to be included in a FULLTEXT index.",
+            "displayName": "MySQL FullText Maximum Word Length",
+            "name": "MYSQL_FT_MAX_WORD_LEN",
+            "required": false
+        },
+        {
+            "description": "Controls the innodb_use_native_aio setting value if the native AIO is broken.",
+            "displayName": "MySQL AIO",
+            "name": "MYSQL_AIO",
             "required": false
         },
         {
@@ -585,7 +636,7 @@
         },
         {
             "description": "RH-SSO Server administrator password",
-            "displayName": "RH-SSO Administrator Password",
+            "displayName": "RH_SSO Administrator Password",
             "from": "[a-zA-Z0-9]{32}",
             "generate": "expression",
             "name": "SSO_ADMIN_PASSWORD",
@@ -599,7 +650,7 @@
             "value": ""
         },
         {
-            "description": "The username used to access the RH-SSO service. This is used by clients to create the appliction client(s) within the specified RH-SSO realm.",
+            "description": "The username used to access the RH-SSO service.  This is used by clients to create the appliction client(s) within the specified RH-SSO realm.",
             "displayName": "RH-SSO Service Username",
             "name": "SSO_SERVICE_USERNAME",
             "required": false,
@@ -613,11 +664,11 @@
             "value": ""
         },
         {
-            "description": "The tag to use for the \"postgresql\" image stream.  Typically, this aligns with the major.minor version of PostgreSQL.",
-            "displayName": "PostgreSQL Image Stream Tag",
-            "name": "POSTGRESQL_IMAGE_STREAM_TAG",
+            "description": "The tag to use for the \"mysql\" image stream.  Typically, this aligns with the major.minor version of MySQL.",
+            "displayName": "MySQL Image Stream Tag",
+            "name": "MYSQL_IMAGE_STREAM_TAG",
             "required": true,
-            "value": "10"
+            "value": "5.7"
         },
         {
             "description": "Container memory limit.",

--- a/official/sso/templates/sso73-ocp4-x509-postgresql-persistent.json
+++ b/official/sso/templates/sso73-ocp4-x509-postgresql-persistent.json
@@ -3,30 +3,45 @@
     "kind": "Template",
     "labels": {
         "rhsso": "7.3.8.GA",
-        "template": "sso73-x509-https"
+        "template": "sso73-ocp4-x509-postgresql-persistent"
     },
-    "message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
+    "message": "A new persistent RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
     "metadata": {
         "annotations": {
             "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
             "iconClass": "icon-sso",
-            "openshift.io/display-name": "Red Hat Single Sign-On 7.3 (Ephemeral)",
+            "openshift.io/display-name": "Red Hat Single Sign-On 7.3 + PostgreSQL (Persistent)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "tags": "sso,keycloak,jboss",
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
-            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.3 server based deployment, securing RH-SSO communication using re-encrypt TLS.",
+            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.3 server based deployment, deployment configuration for PostgreSQL using persistence, and securing RH-SSO communication using re-encrypt TLS.",
             "template.openshift.io/support-url": "https://access.redhat.com",
             "version": "7.3.8.GA"
         },
-        "name": "sso73-x509-https"
+        "name": "sso73-ocp4-x509-postgresql-persistent"
     },
     "objects": [
+        {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {
+                "annotations": {
+                    "description": "ConfigMap providing service ca bundle.",
+                    "service.beta.openshift.io/inject-cabundle": "true"
+                },
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "name": "${APPLICATION_NAME}-service-ca"
+            }
+        },
         {
             "apiVersion": "v1",
             "kind": "Service",
             "metadata": {
                 "annotations": {
                     "description": "The web server's https port.",
+                    "service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-postgresql\", \"kind\": \"Service\"}]",
                     "service.alpha.openshift.io/serving-cert-secret-name": "sso-x509-https-secret"
                 },
                 "labels": {
@@ -43,6 +58,30 @@
                 ],
                 "selector": {
                     "deploymentConfig": "${APPLICATION_NAME}"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "annotations": {
+                    "description": "The database server's port."
+                },
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "name": "${APPLICATION_NAME}-postgresql"
+            },
+            "spec": {
+                "ports": [
+                    {
+                        "port": 5432,
+                        "targetPort": 5432
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}-postgresql"
                 }
             }
         },
@@ -129,6 +168,30 @@
                                         "value": "${SSO_HOSTNAME}"
                                     },
                                     {
+                                        "name": "DB_SERVICE_PREFIX_MAPPING",
+                                        "value": "${APPLICATION_NAME}-postgresql=DB"
+                                    },
+                                    {
+                                        "name": "DB_JNDI",
+                                        "value": "${DB_JNDI}"
+                                    },
+                                    {
+                                        "name": "DB_USERNAME",
+                                        "value": "${DB_USERNAME}"
+                                    },
+                                    {
+                                        "name": "DB_PASSWORD",
+                                        "value": "${DB_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "DB_DATABASE",
+                                        "value": "${DB_DATABASE}"
+                                    },
+                                    {
+                                        "name": "TX_DATABASE_PREFIX_MAPPING",
+                                        "value": "${APPLICATION_NAME}-postgresql=DB"
+                                    },
+                                    {
                                         "name": "DB_MIN_POOL_SIZE",
                                         "value": "${DB_MIN_POOL_SIZE}"
                                     },
@@ -154,7 +217,7 @@
                                     },
                                     {
                                         "name": "X509_CA_BUNDLE",
-                                        "value": "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+                                        "value": "/var/run/configmaps/service-ca/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
                                     },
                                     {
                                         "name": "JGROUPS_CLUSTER_PASSWORD",
@@ -240,6 +303,11 @@
                                         "mountPath": "/etc/x509/jgroups",
                                         "name": "sso-x509-jgroups-volume",
                                         "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/run/configmaps/service-ca",
+                                        "name": "service-ca",
+                                        "readOnly": true
                                     }
                                 ]
                             }
@@ -257,6 +325,12 @@
                                 "secret": {
                                     "secretName": "sso-x509-jgroups-secret"
                                 }
+                            },
+                            {
+                                "configMap": {
+                                    "name": "${APPLICATION_NAME}-service-ca"
+                                },
+                                "name": "service-ca"
                             }
                         ]
                     }
@@ -280,6 +354,152 @@
                         "type": "ConfigChange"
                     }
                 ]
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "DeploymentConfig",
+            "metadata": {
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "name": "${APPLICATION_NAME}-postgresql"
+            },
+            "spec": {
+                "replicas": 1,
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}-postgresql"
+                },
+                "strategy": {
+                    "type": "Recreate"
+                },
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "application": "${APPLICATION_NAME}",
+                            "deploymentConfig": "${APPLICATION_NAME}-postgresql"
+                        },
+                        "name": "${APPLICATION_NAME}-postgresql"
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "env": [
+                                    {
+                                        "name": "POSTGRESQL_USER",
+                                        "value": "${DB_USERNAME}"
+                                    },
+                                    {
+                                        "name": "POSTGRESQL_PASSWORD",
+                                        "value": "${DB_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "POSTGRESQL_DATABASE",
+                                        "value": "${DB_DATABASE}"
+                                    },
+                                    {
+                                        "name": "POSTGRESQL_MAX_CONNECTIONS",
+                                        "value": "${POSTGRESQL_MAX_CONNECTIONS}"
+                                    },
+                                    {
+                                        "name": "POSTGRESQL_MAX_PREPARED_TRANSACTIONS",
+                                        "value": "${POSTGRESQL_MAX_CONNECTIONS}"
+                                    },
+                                    {
+                                        "name": "POSTGRESQL_SHARED_BUFFERS",
+                                        "value": "${POSTGRESQL_SHARED_BUFFERS}"
+                                    }
+                                ],
+                                "image": "postgresql",
+                                "imagePullPolicy": "Always",
+                                "livenessProbe": {
+                                    "failureThreshold": 3,
+                                    "initialDelaySeconds": 90,
+                                    "successThreshold:": 1,
+                                    "tcpSocket": {
+                                        "port": 5432
+                                    },
+                                    "timeoutSeconds": 10
+                                },
+                                "name": "${APPLICATION_NAME}-postgresql",
+                                "ports": [
+                                    {
+                                        "containerPort": 5432,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readinessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "/bin/sh",
+                                            "-i",
+                                            "-c",
+                                            "psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'"
+                                        ]
+                                    },
+                                    "failureThreshold": 3,
+                                    "initialDelaySeconds": 90,
+                                    "successThreshold:": 1,
+                                    "timeoutSeconds": 10
+                                },
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/var/lib/pgsql/data",
+                                        "name": "${APPLICATION_NAME}-postgresql-pvol"
+                                    }
+                                ]
+                            }
+                        ],
+                        "terminationGracePeriodSeconds": 60,
+                        "volumes": [
+                            {
+                                "name": "${APPLICATION_NAME}-postgresql-pvol",
+                                "persistentVolumeClaim": {
+                                    "claimName": "${APPLICATION_NAME}-postgresql-claim"
+                                }
+                            }
+                        ]
+                    }
+                },
+                "triggers": [
+                    {
+                        "imageChangeParams": {
+                            "automatic": true,
+                            "containerNames": [
+                                "${APPLICATION_NAME}-postgresql"
+                            ],
+                            "from": {
+                                "kind": "ImageStreamTag",
+                                "name": "postgresql:${POSTGRESQL_IMAGE_STREAM_TAG}",
+                                "namespace": "${IMAGE_STREAM_NAMESPACE}"
+                            }
+                        },
+                        "type": "ImageChange"
+                    },
+                    {
+                        "type": "ConfigChange"
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "PersistentVolumeClaim",
+            "metadata": {
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "name": "${APPLICATION_NAME}-postgresql-claim"
+            },
+            "spec": {
+                "accessModes": [
+                    "ReadWriteOnce"
+                ],
+                "resources": {
+                    "requests": {
+                        "storage": "${VOLUME_CAPACITY}"
+                    }
+                }
             }
         }
     ],
@@ -307,6 +527,20 @@
             "required": true
         },
         {
+            "description": "Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/postgresql",
+            "displayName": "Database JNDI Name",
+            "name": "DB_JNDI",
+            "required": false,
+            "value": "java:jboss/datasources/KeycloakDS"
+        },
+        {
+            "description": "Database name",
+            "displayName": "Database Name",
+            "name": "DB_DATABASE",
+            "required": true,
+            "value": "root"
+        },
+        {
             "description": "Sets xa-pool/min-pool-size for the configured datasource.",
             "displayName": "Datasource Minimum Pool Size",
             "name": "DB_MIN_POOL_SIZE",
@@ -325,6 +559,41 @@
             "required": false
         },
         {
+            "description": "The maximum number of client connections allowed. This also sets the maximum number of prepared transactions.",
+            "displayName": "PostgreSQL Maximum number of connections",
+            "name": "POSTGRESQL_MAX_CONNECTIONS",
+            "required": false
+        },
+        {
+            "description": "Configures how much memory is dedicated to PostgreSQL for caching data.",
+            "displayName": "PostgreSQL Shared Buffers",
+            "name": "POSTGRESQL_SHARED_BUFFERS",
+            "required": false
+        },
+        {
+            "description": "Database user name",
+            "displayName": "Database Username",
+            "from": "user[a-zA-Z0-9]{3}",
+            "generate": "expression",
+            "name": "DB_USERNAME",
+            "required": true
+        },
+        {
+            "description": "Database user password",
+            "displayName": "Database Password",
+            "from": "[a-zA-Z0-9]{32}",
+            "generate": "expression",
+            "name": "DB_PASSWORD",
+            "required": true
+        },
+        {
+            "description": "Size of persistent storage for database volume.",
+            "displayName": "Database Volume Capacity",
+            "name": "VOLUME_CAPACITY",
+            "required": true,
+            "value": "1Gi"
+        },
+        {
             "description": "Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.",
             "displayName": "ImageStream Namespace",
             "name": "IMAGE_STREAM_NAMESPACE",
@@ -340,7 +609,7 @@
             "required": true
         },
         {
-            "description": "RH-SSO Server admininistrator password",
+            "description": "RH-SSO Server administrator password",
             "displayName": "RH-SSO Administrator Password",
             "from": "[a-zA-Z0-9]{32}",
             "generate": "expression",
@@ -367,6 +636,13 @@
             "name": "SSO_SERVICE_PASSWORD",
             "required": false,
             "value": ""
+        },
+        {
+            "description": "The tag to use for the \"postgresql\" image stream.  Typically, this aligns with the major.minor version of PostgreSQL.",
+            "displayName": "PostgreSQL Image Stream Tag",
+            "name": "POSTGRESQL_IMAGE_STREAM_TAG",
+            "required": true,
+            "value": "10"
         },
         {
             "description": "Container memory limit.",

--- a/official/sso/templates/sso74-ocp4-x509-https.json
+++ b/official/sso/templates/sso74-ocp4-x509-https.json
@@ -2,32 +2,45 @@
     "apiVersion": "v1",
     "kind": "Template",
     "labels": {
-        "rhsso": "7.3.8.GA",
-        "template": "sso73-x509-postgresql-persistent"
+        "rhsso": "7.4.0.GA",
+        "template": "sso74-ocp4-x509-https"
     },
-    "message": "A new persistent RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
+    "message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
     "metadata": {
         "annotations": {
-            "description": "An example application based on RH-SSO 7.3 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/docs.",
+            "description": "An example application based on RH-SSO 7.4 on OpenJDK image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/tree/sso74-dev/docs.",
             "iconClass": "icon-sso",
-            "openshift.io/display-name": "Red Hat Single Sign-On 7.3 + PostgreSQL (Persistent)",
+            "openshift.io/display-name": "Red Hat Single Sign-On 7.4 on OpenJDK (Ephemeral)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "tags": "sso,keycloak,jboss",
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
-            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.3 server based deployment, deployment configuration for PostgreSQL using persistence, and securing RH-SSO communication using re-encrypt TLS.",
+            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.4 on OpenJDK server based deployment, securing RH-SSO communication using re-encrypt TLS.",
             "template.openshift.io/support-url": "https://access.redhat.com",
-            "version": "7.3.8.GA"
+            "version": "7.4.0.GA"
         },
-        "name": "sso73-x509-postgresql-persistent"
+        "name": "sso74-ocp4-x509-https"
     },
     "objects": [
+        {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {
+                "annotations": {
+                    "description": "ConfigMap providing service ca bundle.",
+                    "service.beta.openshift.io/inject-cabundle": "true"
+                },
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "name": "${APPLICATION_NAME}-service-ca"
+            }
+        },
         {
             "apiVersion": "v1",
             "kind": "Service",
             "metadata": {
                 "annotations": {
                     "description": "The web server's https port.",
-                    "service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-postgresql\", \"kind\": \"Service\"}]",
                     "service.alpha.openshift.io/serving-cert-secret-name": "sso-x509-https-secret"
                 },
                 "labels": {
@@ -44,30 +57,6 @@
                 ],
                 "selector": {
                     "deploymentConfig": "${APPLICATION_NAME}"
-                }
-            }
-        },
-        {
-            "apiVersion": "v1",
-            "kind": "Service",
-            "metadata": {
-                "annotations": {
-                    "description": "The database server's port."
-                },
-                "labels": {
-                    "application": "${APPLICATION_NAME}"
-                },
-                "name": "${APPLICATION_NAME}-postgresql"
-            },
-            "spec": {
-                "ports": [
-                    {
-                        "port": 5432,
-                        "targetPort": 5432
-                    }
-                ],
-                "selector": {
-                    "deploymentConfig": "${APPLICATION_NAME}-postgresql"
                 }
             }
         },
@@ -154,30 +143,6 @@
                                         "value": "${SSO_HOSTNAME}"
                                     },
                                     {
-                                        "name": "DB_SERVICE_PREFIX_MAPPING",
-                                        "value": "${APPLICATION_NAME}-postgresql=DB"
-                                    },
-                                    {
-                                        "name": "DB_JNDI",
-                                        "value": "${DB_JNDI}"
-                                    },
-                                    {
-                                        "name": "DB_USERNAME",
-                                        "value": "${DB_USERNAME}"
-                                    },
-                                    {
-                                        "name": "DB_PASSWORD",
-                                        "value": "${DB_PASSWORD}"
-                                    },
-                                    {
-                                        "name": "DB_DATABASE",
-                                        "value": "${DB_DATABASE}"
-                                    },
-                                    {
-                                        "name": "TX_DATABASE_PREFIX_MAPPING",
-                                        "value": "${APPLICATION_NAME}-postgresql=DB"
-                                    },
-                                    {
                                         "name": "DB_MIN_POOL_SIZE",
                                         "value": "${DB_MIN_POOL_SIZE}"
                                     },
@@ -203,7 +168,7 @@
                                     },
                                     {
                                         "name": "X509_CA_BUNDLE",
-                                        "value": "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+                                        "value": "/var/run/configmaps/service-ca/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
                                     },
                                     {
                                         "name": "JGROUPS_CLUSTER_PASSWORD",
@@ -289,6 +254,11 @@
                                         "mountPath": "/etc/x509/jgroups",
                                         "name": "sso-x509-jgroups-volume",
                                         "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/run/configmaps/service-ca",
+                                        "name": "service-ca",
+                                        "readOnly": true
                                     }
                                 ]
                             }
@@ -306,6 +276,12 @@
                                 "secret": {
                                     "secretName": "sso-x509-jgroups-secret"
                                 }
+                            },
+                            {
+                                "configMap": {
+                                    "name": "${APPLICATION_NAME}-service-ca"
+                                },
+                                "name": "service-ca"
                             }
                         ]
                     }
@@ -319,7 +295,7 @@
                             ],
                             "from": {
                                 "kind": "ImageStreamTag",
-                                "name": "redhat-sso73-openshift:1.0",
+                                "name": "sso74-openshift-rhel8:7.4",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}"
                             }
                         },
@@ -329,152 +305,6 @@
                         "type": "ConfigChange"
                     }
                 ]
-            }
-        },
-        {
-            "apiVersion": "v1",
-            "kind": "DeploymentConfig",
-            "metadata": {
-                "labels": {
-                    "application": "${APPLICATION_NAME}"
-                },
-                "name": "${APPLICATION_NAME}-postgresql"
-            },
-            "spec": {
-                "replicas": 1,
-                "selector": {
-                    "deploymentConfig": "${APPLICATION_NAME}-postgresql"
-                },
-                "strategy": {
-                    "type": "Recreate"
-                },
-                "template": {
-                    "metadata": {
-                        "labels": {
-                            "application": "${APPLICATION_NAME}",
-                            "deploymentConfig": "${APPLICATION_NAME}-postgresql"
-                        },
-                        "name": "${APPLICATION_NAME}-postgresql"
-                    },
-                    "spec": {
-                        "containers": [
-                            {
-                                "env": [
-                                    {
-                                        "name": "POSTGRESQL_USER",
-                                        "value": "${DB_USERNAME}"
-                                    },
-                                    {
-                                        "name": "POSTGRESQL_PASSWORD",
-                                        "value": "${DB_PASSWORD}"
-                                    },
-                                    {
-                                        "name": "POSTGRESQL_DATABASE",
-                                        "value": "${DB_DATABASE}"
-                                    },
-                                    {
-                                        "name": "POSTGRESQL_MAX_CONNECTIONS",
-                                        "value": "${POSTGRESQL_MAX_CONNECTIONS}"
-                                    },
-                                    {
-                                        "name": "POSTGRESQL_MAX_PREPARED_TRANSACTIONS",
-                                        "value": "${POSTGRESQL_MAX_CONNECTIONS}"
-                                    },
-                                    {
-                                        "name": "POSTGRESQL_SHARED_BUFFERS",
-                                        "value": "${POSTGRESQL_SHARED_BUFFERS}"
-                                    }
-                                ],
-                                "image": "postgresql",
-                                "imagePullPolicy": "Always",
-                                "livenessProbe": {
-                                    "failureThreshold": 3,
-                                    "initialDelaySeconds": 90,
-                                    "successThreshold:": 1,
-                                    "tcpSocket": {
-                                        "port": 5432
-                                    },
-                                    "timeoutSeconds": 10
-                                },
-                                "name": "${APPLICATION_NAME}-postgresql",
-                                "ports": [
-                                    {
-                                        "containerPort": 5432,
-                                        "protocol": "TCP"
-                                    }
-                                ],
-                                "readinessProbe": {
-                                    "exec": {
-                                        "command": [
-                                            "/bin/sh",
-                                            "-i",
-                                            "-c",
-                                            "psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'"
-                                        ]
-                                    },
-                                    "failureThreshold": 3,
-                                    "initialDelaySeconds": 90,
-                                    "successThreshold:": 1,
-                                    "timeoutSeconds": 10
-                                },
-                                "volumeMounts": [
-                                    {
-                                        "mountPath": "/var/lib/pgsql/data",
-                                        "name": "${APPLICATION_NAME}-postgresql-pvol"
-                                    }
-                                ]
-                            }
-                        ],
-                        "terminationGracePeriodSeconds": 60,
-                        "volumes": [
-                            {
-                                "name": "${APPLICATION_NAME}-postgresql-pvol",
-                                "persistentVolumeClaim": {
-                                    "claimName": "${APPLICATION_NAME}-postgresql-claim"
-                                }
-                            }
-                        ]
-                    }
-                },
-                "triggers": [
-                    {
-                        "imageChangeParams": {
-                            "automatic": true,
-                            "containerNames": [
-                                "${APPLICATION_NAME}-postgresql"
-                            ],
-                            "from": {
-                                "kind": "ImageStreamTag",
-                                "name": "postgresql:${POSTGRESQL_IMAGE_STREAM_TAG}",
-                                "namespace": "${IMAGE_STREAM_NAMESPACE}"
-                            }
-                        },
-                        "type": "ImageChange"
-                    },
-                    {
-                        "type": "ConfigChange"
-                    }
-                ]
-            }
-        },
-        {
-            "apiVersion": "v1",
-            "kind": "PersistentVolumeClaim",
-            "metadata": {
-                "labels": {
-                    "application": "${APPLICATION_NAME}"
-                },
-                "name": "${APPLICATION_NAME}-postgresql-claim"
-            },
-            "spec": {
-                "accessModes": [
-                    "ReadWriteOnce"
-                ],
-                "resources": {
-                    "requests": {
-                        "storage": "${VOLUME_CAPACITY}"
-                    }
-                }
             }
         }
     ],
@@ -502,20 +332,6 @@
             "required": true
         },
         {
-            "description": "Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/postgresql",
-            "displayName": "Database JNDI Name",
-            "name": "DB_JNDI",
-            "required": false,
-            "value": "java:jboss/datasources/KeycloakDS"
-        },
-        {
-            "description": "Database name",
-            "displayName": "Database Name",
-            "name": "DB_DATABASE",
-            "required": true,
-            "value": "root"
-        },
-        {
             "description": "Sets xa-pool/min-pool-size for the configured datasource.",
             "displayName": "Datasource Minimum Pool Size",
             "name": "DB_MIN_POOL_SIZE",
@@ -534,41 +350,6 @@
             "required": false
         },
         {
-            "description": "The maximum number of client connections allowed. This also sets the maximum number of prepared transactions.",
-            "displayName": "PostgreSQL Maximum number of connections",
-            "name": "POSTGRESQL_MAX_CONNECTIONS",
-            "required": false
-        },
-        {
-            "description": "Configures how much memory is dedicated to PostgreSQL for caching data.",
-            "displayName": "PostgreSQL Shared Buffers",
-            "name": "POSTGRESQL_SHARED_BUFFERS",
-            "required": false
-        },
-        {
-            "description": "Database user name",
-            "displayName": "Database Username",
-            "from": "user[a-zA-Z0-9]{3}",
-            "generate": "expression",
-            "name": "DB_USERNAME",
-            "required": true
-        },
-        {
-            "description": "Database user password",
-            "displayName": "Database Password",
-            "from": "[a-zA-Z0-9]{32}",
-            "generate": "expression",
-            "name": "DB_PASSWORD",
-            "required": true
-        },
-        {
-            "description": "Size of persistent storage for database volume.",
-            "displayName": "Database Volume Capacity",
-            "name": "VOLUME_CAPACITY",
-            "required": true,
-            "value": "1Gi"
-        },
-        {
             "description": "Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.",
             "displayName": "ImageStream Namespace",
             "name": "IMAGE_STREAM_NAMESPACE",
@@ -584,7 +365,7 @@
             "required": true
         },
         {
-            "description": "RH-SSO Server administrator password",
+            "description": "RH-SSO Server admininistrator password",
             "displayName": "RH-SSO Administrator Password",
             "from": "[a-zA-Z0-9]{32}",
             "generate": "expression",
@@ -611,13 +392,6 @@
             "name": "SSO_SERVICE_PASSWORD",
             "required": false,
             "value": ""
-        },
-        {
-            "description": "The tag to use for the \"postgresql\" image stream.  Typically, this aligns with the major.minor version of PostgreSQL.",
-            "displayName": "PostgreSQL Image Stream Tag",
-            "name": "POSTGRESQL_IMAGE_STREAM_TAG",
-            "required": true,
-            "value": "10"
         },
         {
             "description": "Container memory limit.",

--- a/official/sso/templates/sso74-ocp4-x509-postgresql-persistent.json
+++ b/official/sso/templates/sso74-ocp4-x509-postgresql-persistent.json
@@ -3,30 +3,45 @@
     "kind": "Template",
     "labels": {
         "rhsso": "7.4.0.GA",
-        "template": "sso74-x509-https"
+        "template": "sso74-ocp4-x509-postgresql-persistent"
     },
-    "message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
+    "message": "A new persistent RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
     "metadata": {
         "annotations": {
             "description": "An example application based on RH-SSO 7.4 on OpenJDK image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/tree/sso74-dev/docs.",
             "iconClass": "icon-sso",
-            "openshift.io/display-name": "Red Hat Single Sign-On 7.4 on OpenJDK (Ephemeral)",
+            "openshift.io/display-name": "Red Hat Single Sign-On 7.4 on OpenJDK + PostgreSQL (Persistent)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "tags": "sso,keycloak,jboss",
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
-            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.4 on OpenJDK server based deployment, securing RH-SSO communication using re-encrypt TLS.",
+            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.4 on OpenJDK server based deployment, deployment configuration for PostgreSQL using persistence, and securing RH-SSO communication using re-encrypt TLS.",
             "template.openshift.io/support-url": "https://access.redhat.com",
             "version": "7.4.0.GA"
         },
-        "name": "sso74-x509-https"
+        "name": "sso74-ocp4-x509-postgresql-persistent"
     },
     "objects": [
+        {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {
+                "annotations": {
+                    "description": "ConfigMap providing service ca bundle.",
+                    "service.beta.openshift.io/inject-cabundle": "true"
+                },
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "name": "${APPLICATION_NAME}-service-ca"
+            }
+        },
         {
             "apiVersion": "v1",
             "kind": "Service",
             "metadata": {
                 "annotations": {
                     "description": "The web server's https port.",
+                    "service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-postgresql\", \"kind\": \"Service\"}]",
                     "service.alpha.openshift.io/serving-cert-secret-name": "sso-x509-https-secret"
                 },
                 "labels": {
@@ -43,6 +58,30 @@
                 ],
                 "selector": {
                     "deploymentConfig": "${APPLICATION_NAME}"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "annotations": {
+                    "description": "The database server's port."
+                },
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "name": "${APPLICATION_NAME}-postgresql"
+            },
+            "spec": {
+                "ports": [
+                    {
+                        "port": 5432,
+                        "targetPort": 5432
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}-postgresql"
                 }
             }
         },
@@ -129,6 +168,30 @@
                                         "value": "${SSO_HOSTNAME}"
                                     },
                                     {
+                                        "name": "DB_SERVICE_PREFIX_MAPPING",
+                                        "value": "${APPLICATION_NAME}-postgresql=DB"
+                                    },
+                                    {
+                                        "name": "DB_JNDI",
+                                        "value": "${DB_JNDI}"
+                                    },
+                                    {
+                                        "name": "DB_USERNAME",
+                                        "value": "${DB_USERNAME}"
+                                    },
+                                    {
+                                        "name": "DB_PASSWORD",
+                                        "value": "${DB_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "DB_DATABASE",
+                                        "value": "${DB_DATABASE}"
+                                    },
+                                    {
+                                        "name": "TX_DATABASE_PREFIX_MAPPING",
+                                        "value": "${APPLICATION_NAME}-postgresql=DB"
+                                    },
+                                    {
                                         "name": "DB_MIN_POOL_SIZE",
                                         "value": "${DB_MIN_POOL_SIZE}"
                                     },
@@ -154,7 +217,7 @@
                                     },
                                     {
                                         "name": "X509_CA_BUNDLE",
-                                        "value": "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+                                        "value": "/var/run/configmaps/service-ca/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
                                     },
                                     {
                                         "name": "JGROUPS_CLUSTER_PASSWORD",
@@ -240,6 +303,11 @@
                                         "mountPath": "/etc/x509/jgroups",
                                         "name": "sso-x509-jgroups-volume",
                                         "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/var/run/configmaps/service-ca",
+                                        "name": "service-ca",
+                                        "readOnly": true
                                     }
                                 ]
                             }
@@ -257,6 +325,12 @@
                                 "secret": {
                                     "secretName": "sso-x509-jgroups-secret"
                                 }
+                            },
+                            {
+                                "configMap": {
+                                    "name": "${APPLICATION_NAME}-service-ca"
+                                },
+                                "name": "service-ca"
                             }
                         ]
                     }
@@ -280,6 +354,152 @@
                         "type": "ConfigChange"
                     }
                 ]
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "DeploymentConfig",
+            "metadata": {
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "name": "${APPLICATION_NAME}-postgresql"
+            },
+            "spec": {
+                "replicas": 1,
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}-postgresql"
+                },
+                "strategy": {
+                    "type": "Recreate"
+                },
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "application": "${APPLICATION_NAME}",
+                            "deploymentConfig": "${APPLICATION_NAME}-postgresql"
+                        },
+                        "name": "${APPLICATION_NAME}-postgresql"
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "env": [
+                                    {
+                                        "name": "POSTGRESQL_USER",
+                                        "value": "${DB_USERNAME}"
+                                    },
+                                    {
+                                        "name": "POSTGRESQL_PASSWORD",
+                                        "value": "${DB_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "POSTGRESQL_DATABASE",
+                                        "value": "${DB_DATABASE}"
+                                    },
+                                    {
+                                        "name": "POSTGRESQL_MAX_CONNECTIONS",
+                                        "value": "${POSTGRESQL_MAX_CONNECTIONS}"
+                                    },
+                                    {
+                                        "name": "POSTGRESQL_MAX_PREPARED_TRANSACTIONS",
+                                        "value": "${POSTGRESQL_MAX_CONNECTIONS}"
+                                    },
+                                    {
+                                        "name": "POSTGRESQL_SHARED_BUFFERS",
+                                        "value": "${POSTGRESQL_SHARED_BUFFERS}"
+                                    }
+                                ],
+                                "image": "postgresql",
+                                "imagePullPolicy": "Always",
+                                "livenessProbe": {
+                                    "failureThreshold": 3,
+                                    "initialDelaySeconds": 90,
+                                    "successThreshold:": 1,
+                                    "tcpSocket": {
+                                        "port": 5432
+                                    },
+                                    "timeoutSeconds": 10
+                                },
+                                "name": "${APPLICATION_NAME}-postgresql",
+                                "ports": [
+                                    {
+                                        "containerPort": 5432,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readinessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "/bin/sh",
+                                            "-i",
+                                            "-c",
+                                            "psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'"
+                                        ]
+                                    },
+                                    "failureThreshold": 3,
+                                    "initialDelaySeconds": 90,
+                                    "successThreshold:": 1,
+                                    "timeoutSeconds": 10
+                                },
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/var/lib/pgsql/data",
+                                        "name": "${APPLICATION_NAME}-postgresql-pvol"
+                                    }
+                                ]
+                            }
+                        ],
+                        "terminationGracePeriodSeconds": 60,
+                        "volumes": [
+                            {
+                                "name": "${APPLICATION_NAME}-postgresql-pvol",
+                                "persistentVolumeClaim": {
+                                    "claimName": "${APPLICATION_NAME}-postgresql-claim"
+                                }
+                            }
+                        ]
+                    }
+                },
+                "triggers": [
+                    {
+                        "imageChangeParams": {
+                            "automatic": true,
+                            "containerNames": [
+                                "${APPLICATION_NAME}-postgresql"
+                            ],
+                            "from": {
+                                "kind": "ImageStreamTag",
+                                "name": "postgresql:${POSTGRESQL_IMAGE_STREAM_TAG}",
+                                "namespace": "${IMAGE_STREAM_NAMESPACE}"
+                            }
+                        },
+                        "type": "ImageChange"
+                    },
+                    {
+                        "type": "ConfigChange"
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "PersistentVolumeClaim",
+            "metadata": {
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "name": "${APPLICATION_NAME}-postgresql-claim"
+            },
+            "spec": {
+                "accessModes": [
+                    "ReadWriteOnce"
+                ],
+                "resources": {
+                    "requests": {
+                        "storage": "${VOLUME_CAPACITY}"
+                    }
+                }
             }
         }
     ],
@@ -307,6 +527,20 @@
             "required": true
         },
         {
+            "description": "Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/postgresql",
+            "displayName": "Database JNDI Name",
+            "name": "DB_JNDI",
+            "required": false,
+            "value": "java:jboss/datasources/KeycloakDS"
+        },
+        {
+            "description": "Database name",
+            "displayName": "Database Name",
+            "name": "DB_DATABASE",
+            "required": true,
+            "value": "root"
+        },
+        {
             "description": "Sets xa-pool/min-pool-size for the configured datasource.",
             "displayName": "Datasource Minimum Pool Size",
             "name": "DB_MIN_POOL_SIZE",
@@ -325,6 +559,41 @@
             "required": false
         },
         {
+            "description": "The maximum number of client connections allowed. This also sets the maximum number of prepared transactions.",
+            "displayName": "PostgreSQL Maximum number of connections",
+            "name": "POSTGRESQL_MAX_CONNECTIONS",
+            "required": false
+        },
+        {
+            "description": "Configures how much memory is dedicated to PostgreSQL for caching data.",
+            "displayName": "PostgreSQL Shared Buffers",
+            "name": "POSTGRESQL_SHARED_BUFFERS",
+            "required": false
+        },
+        {
+            "description": "Database user name",
+            "displayName": "Database Username",
+            "from": "user[a-zA-Z0-9]{3}",
+            "generate": "expression",
+            "name": "DB_USERNAME",
+            "required": true
+        },
+        {
+            "description": "Database user password",
+            "displayName": "Database Password",
+            "from": "[a-zA-Z0-9]{32}",
+            "generate": "expression",
+            "name": "DB_PASSWORD",
+            "required": true
+        },
+        {
+            "description": "Size of persistent storage for database volume.",
+            "displayName": "Database Volume Capacity",
+            "name": "VOLUME_CAPACITY",
+            "required": true,
+            "value": "1Gi"
+        },
+        {
             "description": "Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.",
             "displayName": "ImageStream Namespace",
             "name": "IMAGE_STREAM_NAMESPACE",
@@ -340,7 +609,7 @@
             "required": true
         },
         {
-            "description": "RH-SSO Server admininistrator password",
+            "description": "RH-SSO Server administrator password",
             "displayName": "RH-SSO Administrator Password",
             "from": "[a-zA-Z0-9]{32}",
             "generate": "expression",
@@ -367,6 +636,13 @@
             "name": "SSO_SERVICE_PASSWORD",
             "required": false,
             "value": ""
+        },
+        {
+            "description": "The tag to use for the \"postgresql\" image stream.  Typically, this aligns with the major.minor version of PostgreSQL.",
+            "displayName": "PostgreSQL Image Stream Tag",
+            "name": "POSTGRESQL_IMAGE_STREAM_TAG",
+            "required": true,
+            "value": "10"
         },
         {
             "description": "Container memory limit.",


### PR DESCRIPTION
    [KEYCLOAK-14317] Update the RH-SSO v7.3.8.GA / v7.4.0.GA
    templates to address OCP v4 change from RHBZ#1813894 (replace former soon
    to be deprecated "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt" with
    the new "service.beta.openshift.io/inject-cabundle=true" annotation)
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

  Thanks to @marun for the heads-up & submitting the corresponding PRs against the jboss-container-images RH-SSO repo!

  @gabemontero PTAL (once got a chance)

Thanks!
Jan