### PR TITLE
fixing openjdk_version in community.yaml

### DIFF
--- a/community.yaml
+++ b/community.yaml
@@ -105,14 +105,14 @@ data:
           - okd
   java:
     templates:
-      - location: https://raw.githubusercontent.com/jboss-container-images/openjdk/{openjdk_version}/templates/openjdk-web-basic-s2i.json
+      - location: https://raw.githubusercontent.com/jboss-container-images/openjdk/develop/templates/openjdk-web-basic-s2i.json
         docs: https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/paged/red_hat_java_s2i_for_openshift/
         tags:
           - okd
           - online-starter
           - online-professional
     imagestreams:
-      - location: https://github.com/jboss-container-images/openjdk/raw/develop/templates/community-image-streams.json
+      - location: https://raw.githubusercontent.com/jboss-container-images/openjdk/develop/templates/community-image-streams.json
         docs: https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/paged/red_hat_java_s2i_for_openshift/
         regex: java
         suffix: ubi8

--- a/community/README.md
+++ b/community/README.md
@@ -33,12 +33,12 @@ Path: community/infinispan/templates/infinispan-persistent.json
 # java
 ## imagestreams
 ### java
-Source URL: [https://github.com/jboss-container-images/openjdk/raw/develop/templates/community-image-streams.json](https://github.com/jboss-container-images/openjdk/raw/develop/templates/community-image-streams.json )  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/openjdk/develop/templates/community-image-streams.json](https://raw.githubusercontent.com/jboss-container-images/openjdk/develop/templates/community-image-streams.json )  
 Docs: [https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/paged/red_hat_java_s2i_for_openshift/](https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/paged/red_hat_java_s2i_for_openshift/)  
 Path: community/java/imagestreams/java-ubi8.json  
 ## templates
 ### openjdk-web-basic-s2i
-Source URL: [https://raw.githubusercontent.com/jboss-container-images/openjdk/release/templates/openjdk-web-basic-s2i.json](https://raw.githubusercontent.com/jboss-container-images/openjdk/release/templates/openjdk-web-basic-s2i.json )  
+Source URL: [https://raw.githubusercontent.com/jboss-container-images/openjdk/develop/templates/openjdk-web-basic-s2i.json](https://raw.githubusercontent.com/jboss-container-images/openjdk/develop/templates/openjdk-web-basic-s2i.json )  
 Docs: [https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/paged/red_hat_java_s2i_for_openshift/](https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/paged/red_hat_java_s2i_for_openshift/)  
 Path: community/java/templates/openjdk-web-basic-s2i.json  
 # jenkins

--- a/community/index.json
+++ b/community/index.json
@@ -59,7 +59,7 @@
                 "docs": "https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/paged/red_hat_java_s2i_for_openshift/",
                 "name": "java",
                 "path": "community/java/imagestreams/java-ubi8.json",
-                "source_url": "https://github.com/jboss-container-images/openjdk/raw/develop/templates/community-image-streams.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/openjdk/develop/templates/community-image-streams.json"
             }
         ],
         "templates": [
@@ -68,7 +68,7 @@
                 "docs": "https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/paged/red_hat_java_s2i_for_openshift/",
                 "name": "openjdk-web-basic-s2i",
                 "path": "community/java/templates/openjdk-web-basic-s2i.json",
-                "source_url": "https://raw.githubusercontent.com/jboss-container-images/openjdk/release/templates/openjdk-web-basic-s2i.json"
+                "source_url": "https://raw.githubusercontent.com/jboss-container-images/openjdk/develop/templates/openjdk-web-basic-s2i.json"
             }
         ]
     },


### PR DESCRIPTION
It looks like this was probably a copy/paste error from the official.yaml file.