### PR TITLE
Image streams 5.30 for perl

### DIFF
--- a/official/perl/imagestreams/perl-rhel7.json
+++ b/official/perl/imagestreams/perl-rhel7.json
@@ -16,7 +16,7 @@
 			{
 				"name": "latest",
 				"annotations": {
-					"description": "Build and run Perl applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.26/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Perl available on OpenShift, including major version updates.",
+					"description": "Build and run Perl applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.30/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Perl available on OpenShift, including major version updates.",
 					"iconClass": "icon-perl",
 					"openshift.io/display-name": "Perl (Latest)",
 					"openshift.io/provider-display-name": "Red Hat, Inc.",
@@ -26,7 +26,29 @@
 				},
 				"from": {
 					"kind": "ImageStreamTag",
-					"name": "5.26"
+					"name": "5.30"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "5.30",
+				"annotations": {
+					"description": "Build and run Perl 5.30 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-perl-container/blob/master/5.30/README.md.",
+					"iconClass": "icon-perl",
+					"openshift.io/display-name": "Perl 5.30",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"sampleRepo": "https://github.com/sclorg/dancer-ex.git",
+					"supports": "perl:5.30,perl",
+					"tags": "builder,perl",
+					"version": "5.30"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/rhscl/perl-530-rhel7:latest"
 				},
 				"generation": null,
 				"importPolicy": {},


### PR DESCRIPTION
This commit adds image streams 5.30 for perl.
As for CentOS7 as for RHEL-7.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>