### PR TITLE
Improve logging and concurrency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # If no documents are specified, use these as the default
 DOCUMENTS ?= official,community
+LOGLEVEL ?= 0
 
 ifeq ($(MATCHALL),true)
 	MATCHALLTAGS=--match-all
@@ -25,7 +26,7 @@ build: ## Build the library executable. Example: make build
 .PHONY: build
 
 import: ## Run the import script. Example: make import
-	./library import --documents=$(DOCUMENTS) --tags=$(TAGS) $(MATCHALLTAGS) --dir=$(DIR)
+	./library import --documents=$(DOCUMENTS) --tags=$(TAGS) $(MATCHALLTAGS) --dir=$(DIR) -v=$(LOGLEVEL)
 .PHONY: import
 
 vendor: ## Vendor Go Dependencies. Example: make vendor

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ verify-pullrequest: ## Run pull request verification. Example: make verify-pullr
 	hack/verify-pullrequest.sh $(DOCUMENTS)
 .PHONY: verify-pullrequest
 
+verify-periodic: ## Run pull request verification. Example: make verify-pullrequest
+	hack/verify-periodic.sh
+.PHONY: verify-periodic
+
 # Using -race here since we are running concurrently
 build: ## Build the library executable. Example: make build
 	go version

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ You must build the library executable before you can run the import.
     # Imports the official.yaml and community.yaml without any
     # additional flags or filters
     $ make import
+    
+    # Increase the log level
+    # Supported levels: 0,2,5
+    $ make import LOGLEVEL=2
 
     # Imports the templates and imagestreams into some_dir
     $ make import DIR=some_dir

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You must build the library executable before you can run the import.
     $ make import
     
     # Increase the log level
-    # Supported levels: 0,2,5
+    # Supported levels: 0,2,5,8
     $ make import LOGLEVEL=2
 
     # Imports the templates and imagestreams into some_dir

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -11,11 +11,14 @@ import (
 
 	"github.com/ghodss/yaml"
 
+	"k8s.io/klog"
+
 	imageapiv1 "github.com/openshift/api/image/v1"
 	templateapiv1 "github.com/openshift/api/template/v1"
 )
 
-func writeToFile(data []byte, filePath string) error {
+func writeToFile(document string, data []byte, filePath string) error {
+	klog.V(5).Infof("[%s] Writing file %s", document, filePath)
 	if _, err := os.Stat(filepath.Dir(filePath)); os.IsNotExist(err) {
 		if err := os.MkdirAll(filepath.Dir(filePath), os.ModePerm); err != nil {
 			return fmt.Errorf("Error creating directory %q: %v", filepath.Dir(filePath), err)
@@ -24,15 +27,17 @@ func writeToFile(data []byte, filePath string) error {
 	return ioutil.WriteFile(filePath, data, os.ModePerm)
 }
 
-func replaceVariables(d *[]byte, v map[string]string) error {
+func replaceVariables(document string, d *[]byte, v map[string]string) error {
 	for k, v := range v {
+		klog.V(5).Infof("[%s] Replacing variable {%s} with %s", document, k, v)
 		*d = []byte(strings.ReplaceAll(string(*d), fmt.Sprintf("{%s}", k), fmt.Sprintf("%s", v)))
 	}
 
 	return nil
 }
 
-func fetchURL(path string) ([]byte, error) {
+func fetchURL(document string, path string) ([]byte, error) {
+	klog.V(5).Infof("[%s] Fetching %s", document, path)
 	resp, err := http.Get(path)
 	if err != nil {
 		return []byte{}, err

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"k8s.io/klog"
 
@@ -26,116 +28,129 @@ var (
 	dir      string
 	tags     []string
 	matchAll bool
-	loglevel int
-	sources  sync.Map
 )
 
 // importCmd represents the import command
 var importCmd = &cobra.Command{
 	Use:   "import",
-	Short: "Imports the imagestreams and templates defined in the YAML library documents.",
+	Short: "Imports the imagestreams and templates defined in the specified YAML documents.",
 	Long: `
 	Examples:
-	// import everything to the default location
+	// show the help, same as library import -h
 	$ library import
+	
+	// increase the log level 0, 2, 5, 8
+	$ library -v <level>
 
 	// import the data into a specific directory
 	$ library import --dir somedir
 
 	// import only the specified document(s)
+	// must be a comma separated list
 	$ library import --documents document.yaml,otherdocument.yaml
 
-	// import only imagestreams and templates that match one or more of the specified tags
+	// import only imagestreams and templates that match ANY of the specified tags
 	$ library import --tags tag1,tag2,tag3
 
-	// import only the imagestreams and templates that match ALL of the specified tags
+	// import only imagestreams and templates that match ALL of the specified tags
 	$ library import --tags tag1,tag2,tag3 --match-all-tags
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
-		errorChan := make(chan error, 1000)
 		if len(dir) != 0 {
 			if _, err := os.Stat(dir); os.IsNotExist(err) {
-				os.MkdirAll(dir, os.ModePerm)
+				if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+					klog.Errorf("unable to create output directory %q: %v", dir, err)
+					os.Exit(1)
+				}
 			}
 		}
 		var wg sync.WaitGroup
 		documents, err := rootCmd.Flags().GetStringSlice("documents")
 		if err != nil {
-			klog.Errorf("Unable to get documents: %v", err)
+			klog.Errorf("unable to get documents: %v", err)
 			os.Exit(1)
 		}
 		for _, document := range documents {
+			klog.Infof("[%s] Processing ...", document)
 			if strings.HasSuffix(document, ".yaml") {
 				document = strings.Replace(document, ".yaml", "", 1)
 			}
 
 			// Delete the old directory
-			os.RemoveAll(path.Join(dir, document))
+			if err := os.RemoveAll(path.Join(dir, document)); err != nil {
+				klog.Errorf("unable to remove directory %q: %v", path.Join(dir, document), err)
+				os.Exit(1)
+			}
 
 			// Read the YAML file
 			contents, err := ioutil.ReadFile(fmt.Sprintf("%s.yaml", document))
 			if err != nil {
-				klog.Errorf("Error reading file %s.yaml: %v", document, err)
+				klog.Errorf("[%s] unable to read specified file: %v", document, err)
 				os.Exit(1)
 			}
-
+			// Convert the YAML to JSON
+			contents, err = yaml.YAMLToJSON(contents)
+			klog.V(5).Infof("[%s] Converting yaml to json", document)
+			if err != nil {
+				klog.Errorf("[%s] unable to convert yaml to json: %v", document, err)
+				os.Exit(1)
+			}
 			// Unmarshal just the variables from the contents
 			var variables libraryapiv1.Document
-			if err = yaml.Unmarshal([]byte(contents), &variables); err != nil {
-				klog.Errorf("Error unmarshalling yaml in file %q replacement: %s", document, err)
+			if err = yaml.Unmarshal(contents, &variables); err != nil {
+				klog.Errorf("[%s] unable to unMarshal variable replacements: %s", document, err)
 				os.Exit(1)
 			}
 
 			// Replace variable keys with their values in the contents
-			if err := replaceVariables(&contents, variables.Variables); err != nil {
-				klog.Errorf("Unable to replace variables in %q, %v", document, err)
+			klog.Infof("[%s] Processing variable replacements ...", document)
+			if err := replaceVariables(document, &contents, variables.Variables); err != nil {
+				klog.Errorf("[%s] unable to replace variables: %v", document, err)
 				os.Exit(1)
 			}
 
 			// Unmarshal the data from the contents
 			documentData := libraryapiv1.DocumentData{}
-			if err = yaml.Unmarshal([]byte(contents), &documentData); err != nil {
-				klog.Errorf("Error unmarshalling yaml after variable replacement: %s", err)
+			if err = yaml.Unmarshal(contents, &documentData); err != nil {
+				klog.Errorf("[%s] unable to unMarshal yaml after variable replacement: %v", document, err)
 				os.Exit(1)
 			}
 			for folder, item := range documentData.Data {
-				// If this item has imagestreams, create the directory
+				klog.Infof("[%s] Processing folder %q", document, folder)
 				if len(item.ImageStreams) != 0 {
 					isPath := path.Join(dir, document, folder, "imagestreams")
 					wg.Add(1)
-					go processImagestreams(&wg, document, folder, isPath, item.ImageStreams, errorChan)
+					go processImagestreams(&wg, document, folder, isPath, item.ImageStreams)
 				}
-				// If this item has templates, create the directory
 				if len(item.Templates) != 0 {
 					tPath := path.Join(dir, document, folder, "templates")
 					wg.Add(1)
-					go processTemplates(&wg, document, folder, tPath, item.Templates, errorChan)
+					go processTemplates(&wg, document, folder, tPath, item.Templates)
 				}
 			}
 		}
 		wg.Wait()
-		close(errorChan)
-		for e := range errorChan {
-			klog.Errorf("%s", e)
-		}
-
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(importCmd)
 
+	klog.InitFlags(nil)
+	flag.Parse()
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+
 	importCmd.Flags().StringSliceVar(&tags, "tags", []string{}, "Select only content with at least one of the specified tag(s) to import templates/imagestreams (separated by comma ',')")
 	importCmd.Flags().BoolVar(&matchAll, "match-all-tags", false, "Select only content with all specified tags to import templates/imagestreams (separated by comma ',')")
 	importCmd.Flags().StringVar(&dir, "dir", "", "Specify a target directory for the imported content")
-	importCmd.Flags().IntVar(&loglevel, "loglevel", 0, "Specify the loglevel.")
 }
 
-func hasTag(itemTags []string, filterTags []string, matchAll bool) bool {
+func hasTag(document string, location string, itemTags []string, filterTags []string, matchAll bool) bool {
 	if len(filterTags) == 0 {
 		return true
 	}
 
+	klog.V(8).Infof("[%s] Checking Tags - MatchAll: %t, FilterTags: %#v, ItemTags: %#v, Location: %s", document, matchAll, filterTags, itemTags, location)
 	if len(filterTags) != 0 && len(itemTags) == 0 {
 		return false
 	}
@@ -150,6 +165,7 @@ func hasTag(itemTags []string, filterTags []string, matchAll bool) bool {
 
 	// If no architecture tag is present, set a default of arch_x86_64
 	if !archFound {
+		klog.V(8).Infof("[%s] No arch tag found, appending %q for %s", document, "arch_x86_64", location)
 		itemTags = append(itemTags, "arch_x86_64")
 	}
 
@@ -157,8 +173,8 @@ func hasTag(itemTags []string, filterTags []string, matchAll bool) bool {
 	// chances are we will find it faster
 	// We also need filterTags sorted for comparison with foundTags
 	// if we need to match all of the tags
-	sort.Strings(filterTags)
 	sort.Strings(itemTags)
+	sort.Strings(filterTags)
 
 	var foundTags []string
 
@@ -167,6 +183,7 @@ func hasTag(itemTags []string, filterTags []string, matchAll bool) bool {
 			if itemTag == filterTag {
 				// If we don't have to match all tags, and we find a match, return true
 				if !matchAll {
+					klog.V(8).Infof("[%s] Found matching tag %q for %s", document, filterTag, location)
 					return true
 				}
 				// If we have to match all tags, append the found tag to foundTags
@@ -178,31 +195,38 @@ func hasTag(itemTags []string, filterTags []string, matchAll bool) bool {
 	// Sort foundTags so we can compare it with filterTags
 	sort.Strings(foundTags)
 
-	return reflect.DeepEqual(foundTags, filterTags)
+	matchedAllTags := reflect.DeepEqual(foundTags, filterTags)
+	if matchedAllTags {
+		klog.V(8).Infof("[%s] MatchAllTags: %t, Included %q, ItemTags: %#v FilterTags: %#v", document, matchAll, location, itemTags, filterTags)
+	} else {
+		klog.V(8).Infof("[%s] MatchAllTags: %t, Skipped %q, ItemTags: %#v FilterTags: %#v", document, matchAll, location, itemTags, filterTags)
+	}
+	return matchedAllTags
 }
 
-func processImagestreams(wg *sync.WaitGroup, document string, folder string, isPath string, imagestreams []libraryapiv1.ItemImageStream, errorChan chan<- error) {
+func processImagestreams(wg *sync.WaitGroup, document string, folder string, isPath string, imagestreams []libraryapiv1.ItemImageStream) {
 	defer wg.Done()
 	for _, imagestream := range imagestreams {
-		if !hasTag(imagestream.Tags, tags, matchAll) {
+		if !hasTag(document, imagestream.Location, imagestream.Tags, tags, matchAll) {
+			klog.V(5).Infof("[%s] Tags do not match, skipping %s", document, imagestream.Location)
 			continue
 		}
 		foundImageStreams := make([]imageapiv1.ImageStream, 1)
-		body, err := fetchURL(imagestream.Location)
+		body, err := fetchURL(document, imagestream.Location)
 		if err != nil {
-			errorChan <- fmt.Errorf("Error fetching %s imagestream url %q: %v", document, imagestream.Location, err)
+			klog.Errorf("[%s] unable to fetch imagestream url %q: %v", document, imagestream.Location, err)
 			continue
 		}
 		is := imageapiv1.ImageStream{}
 		if err := unMarshalImageStream(body, &is); err != nil {
-			errorChan <- err
+			klog.Errorf("[%s] unable to unMarshal imagestream %q: %v", imagestream.Location, err)
 		}
 		if is.Kind == "ImageStream" {
 			foundImageStreams = append(foundImageStreams, is)
 		} else if is.Kind == "List" || is.Kind == "ImageStreamList" {
 			isl := imageapiv1.ImageStreamList{}
 			if err := unMarshalImageStreamList(body, &isl); err != nil {
-				errorChan <- err
+				klog.Errorf("[%s] unable to unMarshal imagestream list: %v:", document, err)
 			}
 			for _, item := range isl.Items {
 				foundImageStreams = append(foundImageStreams, item)
@@ -214,6 +238,7 @@ func processImagestreams(wg *sync.WaitGroup, document string, folder string, isP
 				match, _ = regexp.MatchString(imagestream.Regex, stream.Name)
 			}
 			if len(stream.Name) != 0 && (match || len(imagestream.Regex) == 0) {
+				klog.Infof("[%s] Processing imagestream %q", document, stream.Name)
 				fileName := stream.Name
 				if len(imagestream.Suffix) != 0 {
 					fileName = fmt.Sprintf("%s-%s", stream.Name, imagestream.Suffix)
@@ -221,40 +246,39 @@ func processImagestreams(wg *sync.WaitGroup, document string, folder string, isP
 				imageStreamPath := path.Join(isPath, fmt.Sprintf("%s.json", fileName))
 				data, err := json.MarshalIndent(stream, "", "\t")
 				if err != nil {
-					errorChan <- fmt.Errorf("Error marshaling imagestream %q to json: %v", stream.Name, err)
+					klog.Errorf("[%s] unable to marshal imagestream %q to json: %v", document, stream.Name, err)
 				}
-				if err := writeToFile(data, imageStreamPath); err != nil {
-					errorChan <- err
+				if err := writeToFile(document, data, imageStreamPath); err != nil {
+					klog.Errorf("[%s] unable to write data for %q to file: %v", document, stream.Name, err)
 				}
 			}
 		}
 	}
 }
 
-func processTemplates(wg *sync.WaitGroup, document string, folder string, tPath string, templates []libraryapiv1.ItemTemplate, errorChan chan<- error) {
+func processTemplates(wg *sync.WaitGroup, document string, folder string, tPath string, templates []libraryapiv1.ItemTemplate) {
 	defer wg.Done()
 	for _, template := range templates {
-		if !hasTag(template.Tags, tags, matchAll) {
+		if !hasTag(document, template.Location, template.Tags, tags, matchAll) {
+			klog.V(5).Infof("[%s] Tags do not match, skipping %s", document, template.Location)
 			continue
 		}
 
-		body, err := fetchURL(template.Location)
+		body, err := fetchURL(document, template.Location)
 		if err != nil {
-			errorChan <- fmt.Errorf("Error fetching %s template url %q: %v", document, template.Location, err)
+			klog.Errorf("[%s] unable to fetch template url %q: %v", document, template.Location, err)
 			continue
 		}
 		t := templateapiv1.Template{}
 		if err := unMarshalTemplate(body, &t); err != nil {
-			errorChan <- err
+			klog.Errorf("[%s] unable to unMarshal template %q: %v", template.Location, err)
 		}
 		var match bool
 		if len(template.Regex) != 0 {
 			match, _ = regexp.MatchString(template.Regex, t.Name)
 		}
-		if len(t.Name) == 0 {
-			errorChan <- fmt.Errorf("Template location: %#v", template.Location)
-		}
 		if len(t.Name) != 0 && (match || len(template.Regex) == 0) {
+			klog.Infof("[%s] Processing template %q", document, t.Name)
 			fileName := t.Name
 			if len(template.Suffix) != 0 {
 				fileName = fmt.Sprintf("%s-%s", t.Name, template.Suffix)
@@ -262,10 +286,10 @@ func processTemplates(wg *sync.WaitGroup, document string, folder string, tPath 
 			templatePath := path.Join(tPath, fmt.Sprintf("%s.json", fileName))
 			data, err := json.MarshalIndent(t, "", "\t")
 			if err != nil {
-				errorChan <- fmt.Errorf("Error marshaling template %q to json: %v", t.Name, err)
+				klog.Errorf("[%s] unable to marshal template %q to json: %v", document, t.Name, err)
 			}
-			if err := writeToFile(data, templatePath); err != nil {
-				errorChan <- err
+			if err := writeToFile(document, data, templatePath); err != nil {
+				klog.Errorf("[%s] unable to write data for %q to file: %v", document, t.Name, err)
 			}
 		}
 	}

--- a/hack/verify-periodic.sh
+++ b/hack/verify-periodic.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+start=`date +%s`
+
+echo "Creating data to check against"
+./library import --documents official,community --tags arch_x86_64 --dir _output/arch/x86_64
+./library import --documents official,community --tags arch_ppc64le --dir _output/arch/ppc64le
+./library import --documents official,community --tags arch_s390x --dir _output/arch/s390x
+./library import --documents official,community --tags okd,arch_x86_64 --dir _output/operator/okd-x86_64 --match-all-tags
+./library import --documents official,community --tags ocp,arch_x86_64 --dir _output/operator/ocp-x86_64 --match-all-tags
+./library import --documents official,community --tags ocp,arch_ppc64le --dir _output/operator/ocp-ppc64le --match-all-tags
+./library import --documents official,community --tags ocp,arch_s390x --dir _output/operator/ocp-s390x --match-all-tags
+./library import --documents official,community --tags online-starter,arch_x86_64 --dir _output/online/starter/x86_64 --match-all-tags
+./library import --documents official,community --tags online-professional,arch_x86_64 --dir _output/online/professional/x86_64 --match-all-tags
+./library import --documents official,community --dir _output
+
+DOCUMENTS=($(echo "official,community,arch,operator,online" | tr ',' '\n'))
+for document in "${DOCUMENTS[@]}"
+do
+  echo "Comparing current ${document} directory and freshly generated ${document} directory"
+  ret=0
+  diff -Naupr "${document}" "_output/${document}" || ret=$?
+  if [[ $ret -eq 0 ]]
+  then
+    echo "SUCCESS: ${document} directory up to date."
+  else
+    echo "FAILURE: ${document} directory out of date. Please run make import"
+    exit 1
+  fi
+done
+
+echo "Cleaning up"
+rm -rf _output
+
+echo "Verification ran in $((`date +%s`-start)) seconds"

--- a/hack/verify-pullrequest.sh
+++ b/hack/verify-pullrequest.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+start=`date +%s`
+
 echo "Creating data to check against"
 make import DIR=_output
 
@@ -20,3 +22,5 @@ done
 
 echo "Cleaning up"
 rm -rf _output
+
+echo "Verification ran in $((`date +%s`-start)) seconds"


### PR DESCRIPTION
 - Remove error channel and log to stdout/stderr
 - Add loglevel support (make import LOGLEVEL=<level>
 - Add additional error handling for previously missed errors
 - Add klog.Info which outputs progress
 - Add more concurrency, runs in 2.5 - 2.7 seconds consistently on my laptop for the standard `make import`