### PR TITLE
[KEYCLOAK-13513] Update RH-SSO 7.4 on OpenJDK to v7.4.1.GA [KEYCLOAK-14462] Introduce RH-SSO 7.4 on OpenJ9 release stream

### DIFF
--- a/official.yaml
+++ b/official.yaml
@@ -7,7 +7,7 @@ variables:
   rhsso72_zstream_version: v7.2.6.GA
   rhsso_tpcd_version: sso-cd-dev
   rhsso73_zstream_version: v7.3.8.GA-RHBZ-1813894-fix
-  rhsso74_zstream_version: v7.4.0.GA-RHBZ-1813894-fix
+  rhsso74_zstream_version: v7.4.1.GA
   webserver_version: ose-v1.4.17
   webserver3_version: jws31-v1.4
   webserver5_version: jws53-v1.0

--- a/official.yaml
+++ b/official.yaml
@@ -7,7 +7,8 @@ variables:
   rhsso72_zstream_version: v7.2.6.GA
   rhsso_tpcd_version: sso-cd-dev
   rhsso73_zstream_version: v7.3.8.GA-RHBZ-1813894-fix
-  rhsso74_zstream_version: v7.4.1.GA
+  rhsso74_openjdk_version: v7.4.1.GA
+  rhsso74_openj9_version: v7.4.1.GA
   webserver_version: ose-v1.4.17
   webserver3_version: jws31-v1.4
   webserver5_version: jws53-v1.0
@@ -1024,26 +1025,58 @@ data:
         tags:
           - ocp
       # List templates for RH-SSO 7.4.x on OpenJDK stable / zstream images stream below
-      - location: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/{rhsso74_zstream_version}/templates/sso74-https.json
-        docs: https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/{rhsso74_zstream_version}/docs/templates/sso74-https.adoc
+      - location: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/{rhsso74_openjdk_version}/templates/sso74-https.json
+        docs: https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/{rhsso74_openjdk_version}/docs/templates/sso74-https.adoc
         tags:
           - ocp
-      - location: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/{rhsso74_zstream_version}/templates/sso74-postgresql-persistent.json
-        docs: https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/{rhsso74_zstream_version}/docs/templates/sso74-postgresql-persistent.adoc
+          - arch_x86_64
+      - location: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/{rhsso74_openjdk_version}/templates/sso74-postgresql-persistent.json
+        docs: https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/{rhsso74_openjdk_version}/docs/templates/sso74-postgresql-persistent.adoc
         tags:
           - ocp
-      - location: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/{rhsso74_zstream_version}/templates/sso74-postgresql.json
-        docs: https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/{rhsso74_zstream_version}/docs/templates/sso74-postgresql.adoc
+          - arch_x86_64
+      - location: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/{rhsso74_openjdk_version}/templates/sso74-postgresql.json
+        docs: https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/{rhsso74_openjdk_version}/docs/templates/sso74-postgresql.adoc
         tags:
           - ocp
-      - location: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/{rhsso74_zstream_version}/templates/sso74-ocp4-x509-https.json
-        docs: https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/{rhsso74_zstream_version}/docs/templates/sso74-ocp4-x509-https.adoc
+          - arch_x86_64
+      - location: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/{rhsso74_openjdk_version}/templates/sso74-ocp4-x509-https.json
+        docs: https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/{rhsso74_openjdk_version}/docs/templates/sso74-ocp4-x509-https.adoc
         tags:
           - ocp
-      - location: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/{rhsso74_zstream_version}/templates/sso74-ocp4-x509-postgresql-persistent.json
-        docs: https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/{rhsso74_zstream_version}/docs/templates/sso74-ocp4-x509-postgresql-persistent.adoc
+          - arch_x86_64
+      - location: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/{rhsso74_openjdk_version}/templates/sso74-ocp4-x509-postgresql-persistent.json
+        docs: https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/{rhsso74_openjdk_version}/docs/templates/sso74-ocp4-x509-postgresql-persistent.adoc
         tags:
           - ocp
+          - arch_x86_64
+      # List templates for RH-SSO 7.4.x on OpenJ9 stable / zstream images stream below
+      - location: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/{rhsso74_openj9_version}/templates/openj9/sso74-openj9-https.json
+        docs: https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/{rhsso74_openj9_version}/docs/templates/openj9/sso74-openj9-https.adoc
+        tags:
+          - ocp
+          - arch_s390x
+      - location: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/{rhsso74_openj9_version}/templates/openj9/sso74-openj9-postgresql-persistent.json
+        docs: https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/{rhsso74_openj9_version}/docs/templates/openj9/sso74-openj9-postgresql-persistent.adoc
+        tags:
+          - ocp
+          - arch_s390x
+      - location: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/{rhsso74_openj9_version}/templates/openj9/sso74-openj9-postgresql.json
+        docs: https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/{rhsso74_openj9_version}/docs/templates/openj9/sso74-openj9-postgresql.adoc
+        tags:
+          - ocp
+          - arch_s390x
+      - location: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/{rhsso74_openj9_version}/templates/openj9/sso74-openj9-ocp4-x509-https.json
+        docs: https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/{rhsso74_openj9_version}/docs/templates/openj9/sso74-openj9-ocp4-x509-https.adoc
+        tags:
+          - ocp
+          - arch_s390x
+      - location: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/{rhsso74_openj9_version}/templates/openj9/sso74-openj9-ocp4-x509-postgresql-persistent.json
+        docs: https://github.com/jboss-container-images/redhat-sso-7-openshift-image/blob/{rhsso74_openj9_version}/docs/templates/openj9/sso74-openj9-ocp4-x509-postgresql-persistent.adoc
+        tags:
+          - ocp
+          - arch_s390x
+
     imagestreams:
       # List imagestreams for RH-SSO 7.0, 7.1, 7.2 stable / zstream images stream below
       - location: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/{rhsso72_zstream_version}/templates/sso70-image-stream.json
@@ -1079,10 +1112,17 @@ data:
           - online-professional
         suffix: rhel7
       # List imagestream for RH-SSO 7.4.x on OpenJDK stable / zstream images stream below
-      - location: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/{rhsso74_zstream_version}/templates/sso74-image-stream.json
+      - location: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/{rhsso74_openjdk_version}/templates/sso74-image-stream.json
         docs: https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.4/html-single/red_hat_single_sign-on_for_openshift/
         tags:
           - ocp
+          - arch_x86_64
+      # List imagestream for RH-SSO 7.4.x on OpenJ9 stable / zstream images stream below
+      - location: https://raw.githubusercontent.com/jboss-container-images/redhat-sso-7-openshift-image/{rhsso74_openj9_version}/templates/openj9/sso74-openj9-image-stream.json
+        docs: https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.4/html-single/red_hat_single_sign-on_for_openshift_on_openj9/
+        tags:
+          - ocp
+          - arch_s390x
   webserver:
     templates:
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-3-openshift-image/{webserver3_version}/templates/jws31-tomcat7-basic-s2i.json

--- a/official/sso/imagestreams/sso74-openj9-openshift-rhel8.json
+++ b/official/sso/imagestreams/sso74-openj9-openshift-rhel8.json
@@ -1,0 +1,57 @@
+{
+	"kind": "ImageStream",
+	"apiVersion": "v1",
+	"metadata": {
+		"name": "sso74-openj9-openshift-rhel8",
+		"creationTimestamp": null,
+		"annotations": {
+			"description": "Red Hat Single Sign-On 7.4 on OpenJ9",
+			"openshift.io/display-name": "Red Hat Single Sign-On 7.4 on OpenJ9",
+			"openshift.io/provider-display-name": "Red Hat, Inc.",
+			"version": "7.4.1.GA"
+		}
+	},
+	"spec": {
+		"lookupPolicy": {
+			"local": false
+		},
+		"tags": [
+			{
+				"name": "latest",
+				"annotations": null,
+				"from": {
+					"kind": "ImageStreamTag",
+					"name": "7.4"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": ""
+				}
+			},
+			{
+				"name": "7.4",
+				"annotations": {
+					"description": "Red Hat Single Sign-On 7.4 on OpenJ9 image",
+					"iconClass": "icon-sso",
+					"openshift.io/display-name": "Red Hat Single Sign-On 7.4 on OpenJ9",
+					"supports": "sso:7.4",
+					"tags": "sso,keycloak,redhat,hidden",
+					"version": "1.0"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/rh-sso-7/sso74-openj9-openshift-rhel8:7.4"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			}
+		]
+	},
+	"status": {
+		"dockerImageRepository": ""
+	}
+}

--- a/official/sso/imagestreams/sso74-openshift-rhel8.json
+++ b/official/sso/imagestreams/sso74-openshift-rhel8.json
@@ -8,7 +8,7 @@
 			"description": "Red Hat Single Sign-On 7.4 on OpenJDK",
 			"openshift.io/display-name": "Red Hat Single Sign-On 7.4 on OpenJDK",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
-			"version": "7.4.0.GA"
+			"version": "7.4.1.GA"
 		}
 	},
 	"spec": {

--- a/official/sso/templates/sso74-https.json
+++ b/official/sso/templates/sso74-https.json
@@ -13,7 +13,7 @@
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
 			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.4 on OpenJDK server based deployment, securing RH-SSO communication using passthrough TLS.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "7.4.0.GA"
+			"version": "7.4.1.GA"
 		}
 	},
 	"message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
@@ -539,7 +539,7 @@
 		}
 	],
 	"labels": {
-		"rhsso": "7.4.0.GA",
+		"rhsso": "7.4.1.GA",
 		"template": "sso74-https"
 	}
 }

--- a/official/sso/templates/sso74-ocp4-x509-https.json
+++ b/official/sso/templates/sso74-ocp4-x509-https.json
@@ -13,7 +13,7 @@
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
 			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.4 on OpenJDK server based deployment, securing RH-SSO communication using re-encrypt TLS.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "7.4.0.GA"
+			"version": "7.4.1.GA"
 		}
 	},
 	"message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
@@ -387,7 +387,7 @@
 		}
 	],
 	"labels": {
-		"rhsso": "7.4.0.GA",
+		"rhsso": "7.4.1.GA",
 		"template": "sso74-ocp4-x509-https"
 	}
 }

--- a/official/sso/templates/sso74-ocp4-x509-postgresql-persistent.json
+++ b/official/sso/templates/sso74-ocp4-x509-postgresql-persistent.json
@@ -13,7 +13,7 @@
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
 			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.4 on OpenJDK server based deployment, deployment configuration for PostgreSQL using persistence, and securing RH-SSO communication using re-encrypt TLS.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "7.4.0.GA"
+			"version": "7.4.1.GA"
 		}
 	},
 	"message": "A new persistent RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
@@ -635,7 +635,7 @@
 		}
 	],
 	"labels": {
-		"rhsso": "7.4.0.GA",
+		"rhsso": "7.4.1.GA",
 		"template": "sso74-ocp4-x509-postgresql-persistent"
 	}
 }

--- a/official/sso/templates/sso74-openj9-https.json
+++ b/official/sso/templates/sso74-openj9-https.json
@@ -1,0 +1,545 @@
+{
+	"kind": "Template",
+	"apiVersion": "v1",
+	"metadata": {
+		"name": "sso74-openj9-https",
+		"creationTimestamp": null,
+		"annotations": {
+			"description": "An example application based on RH-SSO 7.4 on OpenJ9 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/tree/sso74-dev/docs.",
+			"iconClass": "icon-sso",
+			"openshift.io/display-name": "Red Hat Single Sign-On 7.4 on OpenJ9 (Ephemeral with passthrough TLS)",
+			"openshift.io/provider-display-name": "Red Hat, Inc.",
+			"tags": "sso,keycloak,jboss,hidden",
+			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
+			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.4 on OpenJ9 server based deployment, securing RH-SSO communication using passthrough TLS.",
+			"template.openshift.io/support-url": "https://access.redhat.com",
+			"version": "7.4.1.GA"
+		}
+	},
+	"message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
+	"objects": [
+		{
+			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"description": "The web server's http port."
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}"
+			},
+			"spec": {
+				"ports": [
+					{
+						"port": 8080,
+						"targetPort": 8080
+					}
+				],
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"description": "The web server's https port."
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "secure-${APPLICATION_NAME}"
+			},
+			"spec": {
+				"ports": [
+					{
+						"port": 8443,
+						"targetPort": 8443
+					}
+				],
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"description": "The JGroups ping port for clustering.",
+					"service.alpha.kubernetes.io/tolerate-unready-endpoints": "true"
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}-ping"
+			},
+			"spec": {
+				"clusterIP": "None",
+				"ports": [
+					{
+						"name": "ping",
+						"port": 8888
+					}
+				],
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"id": "${APPLICATION_NAME}-http",
+			"kind": "Route",
+			"metadata": {
+				"annotations": {
+					"description": "Route for application's http service."
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}"
+			},
+			"spec": {
+				"host": "${HOSTNAME_HTTP}",
+				"to": {
+					"name": "${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"id": "${APPLICATION_NAME}-https",
+			"kind": "Route",
+			"metadata": {
+				"annotations": {
+					"description": "Route for application's https service."
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "secure-${APPLICATION_NAME}"
+			},
+			"spec": {
+				"host": "${HOSTNAME_HTTPS}",
+				"tls": {
+					"termination": "passthrough"
+				},
+				"to": {
+					"name": "secure-${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "DeploymentConfig",
+			"metadata": {
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}"
+			},
+			"spec": {
+				"replicas": 1,
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}"
+				},
+				"strategy": {
+					"type": "Recreate"
+				},
+				"template": {
+					"metadata": {
+						"labels": {
+							"application": "${APPLICATION_NAME}",
+							"deploymentConfig": "${APPLICATION_NAME}"
+						},
+						"name": "${APPLICATION_NAME}"
+					},
+					"spec": {
+						"containers": [
+							{
+								"env": [
+									{
+										"name": "SSO_HOSTNAME",
+										"value": "${SSO_HOSTNAME}"
+									},
+									{
+										"name": "DB_MIN_POOL_SIZE",
+										"value": "${DB_MIN_POOL_SIZE}"
+									},
+									{
+										"name": "DB_MAX_POOL_SIZE",
+										"value": "${DB_MAX_POOL_SIZE}"
+									},
+									{
+										"name": "DB_TX_ISOLATION",
+										"value": "${DB_TX_ISOLATION}"
+									},
+									{
+										"name": "JGROUPS_PING_PROTOCOL",
+										"value": "openshift.DNS_PING"
+									},
+									{
+										"name": "OPENSHIFT_DNS_PING_SERVICE_NAME",
+										"value": "${APPLICATION_NAME}-ping"
+									},
+									{
+										"name": "OPENSHIFT_DNS_PING_SERVICE_PORT",
+										"value": "8888"
+									},
+									{
+										"name": "HTTPS_KEYSTORE_DIR",
+										"value": "/etc/eap-secret-volume"
+									},
+									{
+										"name": "HTTPS_KEYSTORE",
+										"value": "${HTTPS_KEYSTORE}"
+									},
+									{
+										"name": "HTTPS_KEYSTORE_TYPE",
+										"value": "${HTTPS_KEYSTORE_TYPE}"
+									},
+									{
+										"name": "HTTPS_NAME",
+										"value": "${HTTPS_NAME}"
+									},
+									{
+										"name": "HTTPS_PASSWORD",
+										"value": "${HTTPS_PASSWORD}"
+									},
+									{
+										"name": "JGROUPS_ENCRYPT_SECRET",
+										"value": "${JGROUPS_ENCRYPT_SECRET}"
+									},
+									{
+										"name": "JGROUPS_ENCRYPT_KEYSTORE_DIR",
+										"value": "/etc/jgroups-encrypt-secret-volume"
+									},
+									{
+										"name": "JGROUPS_ENCRYPT_KEYSTORE",
+										"value": "${JGROUPS_ENCRYPT_KEYSTORE}"
+									},
+									{
+										"name": "JGROUPS_ENCRYPT_NAME",
+										"value": "${JGROUPS_ENCRYPT_NAME}"
+									},
+									{
+										"name": "JGROUPS_ENCRYPT_PASSWORD",
+										"value": "${JGROUPS_ENCRYPT_PASSWORD}"
+									},
+									{
+										"name": "JGROUPS_CLUSTER_PASSWORD",
+										"value": "${JGROUPS_CLUSTER_PASSWORD}"
+									},
+									{
+										"name": "SSO_ADMIN_USERNAME",
+										"value": "${SSO_ADMIN_USERNAME}"
+									},
+									{
+										"name": "SSO_ADMIN_PASSWORD",
+										"value": "${SSO_ADMIN_PASSWORD}"
+									},
+									{
+										"name": "SSO_REALM",
+										"value": "${SSO_REALM}"
+									},
+									{
+										"name": "SSO_SERVICE_USERNAME",
+										"value": "${SSO_SERVICE_USERNAME}"
+									},
+									{
+										"name": "SSO_SERVICE_PASSWORD",
+										"value": "${SSO_SERVICE_PASSWORD}"
+									},
+									{
+										"name": "SSO_TRUSTSTORE",
+										"value": "${SSO_TRUSTSTORE}"
+									},
+									{
+										"name": "SSO_TRUSTSTORE_DIR",
+										"value": "/etc/sso-secret-volume"
+									},
+									{
+										"name": "SSO_TRUSTSTORE_PASSWORD",
+										"value": "${SSO_TRUSTSTORE_PASSWORD}"
+									}
+								],
+								"image": "${APPLICATION_NAME}",
+								"imagePullPolicy": "Always",
+								"livenessProbe": {
+									"exec": {
+										"command": [
+											"/bin/bash",
+											"-c",
+											"/opt/eap/bin/livenessProbe.sh"
+										]
+									},
+									"initialDelaySeconds": 60
+								},
+								"name": "${APPLICATION_NAME}",
+								"ports": [
+									{
+										"containerPort": 8778,
+										"name": "jolokia",
+										"protocol": "TCP"
+									},
+									{
+										"containerPort": 8080,
+										"name": "http",
+										"protocol": "TCP"
+									},
+									{
+										"containerPort": 8443,
+										"name": "https",
+										"protocol": "TCP"
+									},
+									{
+										"containerPort": 8888,
+										"name": "ping",
+										"protocol": "TCP"
+									}
+								],
+								"readinessProbe": {
+									"exec": {
+										"command": [
+											"/bin/bash",
+											"-c",
+											"/opt/eap/bin/readinessProbe.sh"
+										]
+									}
+								},
+								"resources": {
+									"limits": {
+										"memory": "${MEMORY_LIMIT}"
+									}
+								},
+								"volumeMounts": [
+									{
+										"mountPath": "/etc/eap-secret-volume",
+										"name": "eap-keystore-volume",
+										"readOnly": true
+									},
+									{
+										"mountPath": "/etc/jgroups-encrypt-secret-volume",
+										"name": "eap-jgroups-keystore-volume",
+										"readOnly": true
+									},
+									{
+										"mountPath": "/etc/sso-secret-volume",
+										"name": "sso-truststore-volume",
+										"readOnly": true
+									}
+								]
+							}
+						],
+						"terminationGracePeriodSeconds": 75,
+						"volumes": [
+							{
+								"name": "eap-keystore-volume",
+								"secret": {
+									"secretName": "${HTTPS_SECRET}"
+								}
+							},
+							{
+								"name": "eap-jgroups-keystore-volume",
+								"secret": {
+									"secretName": "${JGROUPS_ENCRYPT_SECRET}"
+								}
+							},
+							{
+								"name": "sso-truststore-volume",
+								"secret": {
+									"secretName": "${SSO_TRUSTSTORE_SECRET}"
+								}
+							}
+						]
+					}
+				},
+				"triggers": [
+					{
+						"imageChangeParams": {
+							"automatic": true,
+							"containerNames": [
+								"${APPLICATION_NAME}"
+							],
+							"from": {
+								"kind": "ImageStreamTag",
+								"name": "sso74-openj9-openshift-rhel8:7.4",
+								"namespace": "${IMAGE_STREAM_NAMESPACE}"
+							}
+						},
+						"type": "ImageChange"
+					},
+					{
+						"type": "ConfigChange"
+					}
+				]
+			}
+		}
+	],
+	"parameters": [
+		{
+			"name": "APPLICATION_NAME",
+			"displayName": "Application Name",
+			"description": "The name for the application.",
+			"value": "sso",
+			"required": true
+		},
+		{
+			"name": "HOSTNAME_HTTP",
+			"displayName": "Custom http Route Hostname",
+			"description": "Custom hostname for http service route. Leave blank for default hostname, e.g.: \u003capplication-name\u003e.\u003cproject\u003e.\u003cdefault-domain-suffix\u003e"
+		},
+		{
+			"name": "HOSTNAME_HTTPS",
+			"displayName": "Custom https Route Hostname",
+			"description": "Custom hostname for https service route. Leave blank for default hostname, e.g.: \u003capplication-name\u003e.\u003cproject\u003e.\u003cdefault-domain-suffix\u003e"
+		},
+		{
+			"name": "SSO_HOSTNAME",
+			"displayName": "Custom RH-SSO Server Hostname",
+			"description": "Custom hostname for the RH-SSO server."
+		},
+		{
+			"name": "HTTPS_SECRET",
+			"displayName": "Server Keystore Secret Name",
+			"description": "The name of the secret containing the keystore file",
+			"value": "sso-app-secret"
+		},
+		{
+			"name": "HTTPS_KEYSTORE",
+			"displayName": "Server Keystore Filename",
+			"description": "The name of the keystore file within the secret",
+			"value": "keystore.jks"
+		},
+		{
+			"name": "HTTPS_KEYSTORE_TYPE",
+			"displayName": "Server Keystore Type",
+			"description": "The type of the keystore file (JKS or JCEKS)"
+		},
+		{
+			"name": "HTTPS_NAME",
+			"displayName": "Server Certificate Name",
+			"description": "The name associated with the server certificate (e.g. jboss)"
+		},
+		{
+			"name": "HTTPS_PASSWORD",
+			"displayName": "Server Keystore Password",
+			"description": "The password for the keystore and certificate (e.g. mykeystorepass)"
+		},
+		{
+			"name": "DB_MIN_POOL_SIZE",
+			"displayName": "Datasource Minimum Pool Size",
+			"description": "Sets xa-pool/min-pool-size for the configured datasource."
+		},
+		{
+			"name": "DB_MAX_POOL_SIZE",
+			"displayName": "Datasource Maximum Pool Size",
+			"description": "Sets xa-pool/max-pool-size for the configured datasource."
+		},
+		{
+			"name": "DB_TX_ISOLATION",
+			"displayName": "Datasource Transaction Isolation",
+			"description": "Sets transaction-isolation for the configured datasource."
+		},
+		{
+			"name": "JGROUPS_ENCRYPT_SECRET",
+			"displayName": "JGroups Secret Name",
+			"description": "The name of the secret containing the keystore file",
+			"value": "sso-app-secret"
+		},
+		{
+			"name": "JGROUPS_ENCRYPT_KEYSTORE",
+			"displayName": "JGroups Keystore Filename",
+			"description": "The name of the keystore file within the secret",
+			"value": "jgroups.jceks"
+		},
+		{
+			"name": "JGROUPS_ENCRYPT_NAME",
+			"displayName": "JGroups Certificate Name",
+			"description": "The name associated with the server certificate (e.g. secret-key)"
+		},
+		{
+			"name": "JGROUPS_ENCRYPT_PASSWORD",
+			"displayName": "JGroups Keystore Password",
+			"description": "The password for the keystore and certificate (e.g. password)"
+		},
+		{
+			"name": "JGROUPS_CLUSTER_PASSWORD",
+			"displayName": "JGroups Cluster Password",
+			"description": "JGroups cluster password",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "IMAGE_STREAM_NAMESPACE",
+			"displayName": "ImageStream Namespace",
+			"description": "Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.",
+			"value": "openshift",
+			"required": true
+		},
+		{
+			"name": "SSO_ADMIN_USERNAME",
+			"displayName": "RH-SSO Administrator Username",
+			"description": "RH-SSO Server administrator username",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "SSO_ADMIN_PASSWORD",
+			"displayName": "RH-SSO Administrator Password",
+			"description": "RH-SSO Server administrator password",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "SSO_REALM",
+			"displayName": "RH-SSO Realm",
+			"description": "Realm to be created in the RH-SSO server (e.g. demorealm)."
+		},
+		{
+			"name": "SSO_SERVICE_USERNAME",
+			"displayName": "RH-SSO Service Username",
+			"description": "The username used to access the RH-SSO service. This is used by clients to create the appliction client(s) within the specified RH-SSO realm."
+		},
+		{
+			"name": "SSO_SERVICE_PASSWORD",
+			"displayName": "RH-SSO Service Password",
+			"description": "The password for the RH-SSO service user."
+		},
+		{
+			"name": "SSO_TRUSTSTORE",
+			"displayName": "RH-SSO Trust Store",
+			"description": "The name of the truststore file within the secret (e.g. truststore.jks)"
+		},
+		{
+			"name": "SSO_TRUSTSTORE_PASSWORD",
+			"displayName": "RH-SSO Trust Store Password",
+			"description": "The password for the truststore and certificate (e.g. mykeystorepass)"
+		},
+		{
+			"name": "SSO_TRUSTSTORE_SECRET",
+			"displayName": "RH-SSO Trust Store Secret",
+			"description": "The name of the secret containing the truststore file (e.g. truststore-secret). Used for volume secretName",
+			"value": "sso-app-secret"
+		},
+		{
+			"name": "MEMORY_LIMIT",
+			"displayName": "Container Memory Limit",
+			"description": "Container memory limit.",
+			"value": "1Gi"
+		}
+	],
+	"labels": {
+		"rhsso": "7.4.1.GA",
+		"template": "sso74-openj9-https"
+	}
+}

--- a/official/sso/templates/sso74-openj9-ocp4-x509-https.json
+++ b/official/sso/templates/sso74-openj9-ocp4-x509-https.json
@@ -1,0 +1,393 @@
+{
+	"kind": "Template",
+	"apiVersion": "v1",
+	"metadata": {
+		"name": "sso74-openj9-ocp4-x509-https",
+		"creationTimestamp": null,
+		"annotations": {
+			"description": "An example application based on RH-SSO 7.4 on OpenJ9 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/tree/sso74-dev/docs.",
+			"iconClass": "icon-sso",
+			"openshift.io/display-name": "Red Hat Single Sign-On 7.4 on OpenJ9 (Ephemeral)",
+			"openshift.io/provider-display-name": "Red Hat, Inc.",
+			"tags": "sso,keycloak,jboss",
+			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
+			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.4 on OpenJ9 server based deployment, securing RH-SSO communication using re-encrypt TLS.",
+			"template.openshift.io/support-url": "https://access.redhat.com",
+			"version": "7.4.1.GA"
+		}
+	},
+	"message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
+	"objects": [
+		{
+			"apiVersion": "v1",
+			"kind": "ConfigMap",
+			"metadata": {
+				"annotations": {
+					"description": "ConfigMap providing service ca bundle.",
+					"service.beta.openshift.io/inject-cabundle": "true"
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}-service-ca"
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"description": "The web server's https port.",
+					"service.alpha.openshift.io/serving-cert-secret-name": "sso-x509-https-secret"
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}"
+			},
+			"spec": {
+				"ports": [
+					{
+						"port": 8443,
+						"targetPort": 8443
+					}
+				],
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"description": "The JGroups ping port for clustering.",
+					"service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
+					"service.alpha.openshift.io/serving-cert-secret-name": "sso-x509-jgroups-secret"
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}-ping"
+			},
+			"spec": {
+				"clusterIP": "None",
+				"ports": [
+					{
+						"name": "ping",
+						"port": 8888
+					}
+				],
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"id": "${APPLICATION_NAME}-https",
+			"kind": "Route",
+			"metadata": {
+				"annotations": {
+					"description": "Route for application's https service."
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}"
+			},
+			"spec": {
+				"tls": {
+					"termination": "reencrypt"
+				},
+				"to": {
+					"name": "${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "DeploymentConfig",
+			"metadata": {
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}"
+			},
+			"spec": {
+				"replicas": 1,
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}"
+				},
+				"strategy": {
+					"type": "Recreate"
+				},
+				"template": {
+					"metadata": {
+						"labels": {
+							"application": "${APPLICATION_NAME}",
+							"deploymentConfig": "${APPLICATION_NAME}"
+						},
+						"name": "${APPLICATION_NAME}"
+					},
+					"spec": {
+						"containers": [
+							{
+								"env": [
+									{
+										"name": "SSO_HOSTNAME",
+										"value": "${SSO_HOSTNAME}"
+									},
+									{
+										"name": "DB_MIN_POOL_SIZE",
+										"value": "${DB_MIN_POOL_SIZE}"
+									},
+									{
+										"name": "DB_MAX_POOL_SIZE",
+										"value": "${DB_MAX_POOL_SIZE}"
+									},
+									{
+										"name": "DB_TX_ISOLATION",
+										"value": "${DB_TX_ISOLATION}"
+									},
+									{
+										"name": "JGROUPS_PING_PROTOCOL",
+										"value": "openshift.DNS_PING"
+									},
+									{
+										"name": "OPENSHIFT_DNS_PING_SERVICE_NAME",
+										"value": "${APPLICATION_NAME}-ping"
+									},
+									{
+										"name": "OPENSHIFT_DNS_PING_SERVICE_PORT",
+										"value": "8888"
+									},
+									{
+										"name": "X509_CA_BUNDLE",
+										"value": "/var/run/configmaps/service-ca/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+									},
+									{
+										"name": "JGROUPS_CLUSTER_PASSWORD",
+										"value": "${JGROUPS_CLUSTER_PASSWORD}"
+									},
+									{
+										"name": "SSO_ADMIN_USERNAME",
+										"value": "${SSO_ADMIN_USERNAME}"
+									},
+									{
+										"name": "SSO_ADMIN_PASSWORD",
+										"value": "${SSO_ADMIN_PASSWORD}"
+									},
+									{
+										"name": "SSO_REALM",
+										"value": "${SSO_REALM}"
+									},
+									{
+										"name": "SSO_SERVICE_USERNAME",
+										"value": "${SSO_SERVICE_USERNAME}"
+									},
+									{
+										"name": "SSO_SERVICE_PASSWORD",
+										"value": "${SSO_SERVICE_PASSWORD}"
+									}
+								],
+								"image": "${APPLICATION_NAME}",
+								"imagePullPolicy": "Always",
+								"livenessProbe": {
+									"exec": {
+										"command": [
+											"/bin/bash",
+											"-c",
+											"/opt/eap/bin/livenessProbe.sh"
+										]
+									},
+									"initialDelaySeconds": 60
+								},
+								"name": "${APPLICATION_NAME}",
+								"ports": [
+									{
+										"containerPort": 8778,
+										"name": "jolokia",
+										"protocol": "TCP"
+									},
+									{
+										"containerPort": 8080,
+										"name": "http",
+										"protocol": "TCP"
+									},
+									{
+										"containerPort": 8443,
+										"name": "https",
+										"protocol": "TCP"
+									},
+									{
+										"containerPort": 8888,
+										"name": "ping",
+										"protocol": "TCP"
+									}
+								],
+								"readinessProbe": {
+									"exec": {
+										"command": [
+											"/bin/bash",
+											"-c",
+											"/opt/eap/bin/readinessProbe.sh"
+										]
+									}
+								},
+								"resources": {
+									"limits": {
+										"memory": "${MEMORY_LIMIT}"
+									}
+								},
+								"volumeMounts": [
+									{
+										"mountPath": "/etc/x509/https",
+										"name": "sso-x509-https-volume",
+										"readOnly": true
+									},
+									{
+										"mountPath": "/etc/x509/jgroups",
+										"name": "sso-x509-jgroups-volume",
+										"readOnly": true
+									},
+									{
+										"mountPath": "/var/run/configmaps/service-ca",
+										"name": "service-ca",
+										"readOnly": true
+									}
+								]
+							}
+						],
+						"terminationGracePeriodSeconds": 75,
+						"volumes": [
+							{
+								"name": "sso-x509-https-volume",
+								"secret": {
+									"secretName": "sso-x509-https-secret"
+								}
+							},
+							{
+								"name": "sso-x509-jgroups-volume",
+								"secret": {
+									"secretName": "sso-x509-jgroups-secret"
+								}
+							},
+							{
+								"configMap": {
+									"name": "${APPLICATION_NAME}-service-ca"
+								},
+								"name": "service-ca"
+							}
+						]
+					}
+				},
+				"triggers": [
+					{
+						"imageChangeParams": {
+							"automatic": true,
+							"containerNames": [
+								"${APPLICATION_NAME}"
+							],
+							"from": {
+								"kind": "ImageStreamTag",
+								"name": "sso74-openj9-openshift-rhel8:7.4",
+								"namespace": "${IMAGE_STREAM_NAMESPACE}"
+							}
+						},
+						"type": "ImageChange"
+					},
+					{
+						"type": "ConfigChange"
+					}
+				]
+			}
+		}
+	],
+	"parameters": [
+		{
+			"name": "APPLICATION_NAME",
+			"displayName": "Application Name",
+			"description": "The name for the application.",
+			"value": "sso",
+			"required": true
+		},
+		{
+			"name": "SSO_HOSTNAME",
+			"displayName": "Custom RH-SSO Server Hostname",
+			"description": "Custom hostname for the RH-SSO server."
+		},
+		{
+			"name": "JGROUPS_CLUSTER_PASSWORD",
+			"displayName": "JGroups Cluster Password",
+			"description": "The password for the JGroups cluster.",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{32}",
+			"required": true
+		},
+		{
+			"name": "DB_MIN_POOL_SIZE",
+			"displayName": "Datasource Minimum Pool Size",
+			"description": "Sets xa-pool/min-pool-size for the configured datasource."
+		},
+		{
+			"name": "DB_MAX_POOL_SIZE",
+			"displayName": "Datasource Maximum Pool Size",
+			"description": "Sets xa-pool/max-pool-size for the configured datasource."
+		},
+		{
+			"name": "DB_TX_ISOLATION",
+			"displayName": "Datasource Transaction Isolation",
+			"description": "Sets transaction-isolation for the configured datasource."
+		},
+		{
+			"name": "IMAGE_STREAM_NAMESPACE",
+			"displayName": "ImageStream Namespace",
+			"description": "Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.",
+			"value": "openshift",
+			"required": true
+		},
+		{
+			"name": "SSO_ADMIN_USERNAME",
+			"displayName": "RH-SSO Administrator Username",
+			"description": "RH-SSO Server administrator username",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "SSO_ADMIN_PASSWORD",
+			"displayName": "RH-SSO Administrator Password",
+			"description": "RH-SSO Server admininistrator password",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{32}",
+			"required": true
+		},
+		{
+			"name": "SSO_REALM",
+			"displayName": "RH-SSO Realm",
+			"description": "Realm to be created in the RH-SSO server (e.g. demorealm)."
+		},
+		{
+			"name": "SSO_SERVICE_USERNAME",
+			"displayName": "RH-SSO Service Username",
+			"description": "The username used to access the RH-SSO service. This is used by clients to create the appliction client(s) within the specified RH-SSO realm."
+		},
+		{
+			"name": "SSO_SERVICE_PASSWORD",
+			"displayName": "RH-SSO Service Password",
+			"description": "The password for the RH-SSO service user."
+		},
+		{
+			"name": "MEMORY_LIMIT",
+			"displayName": "Container Memory Limit",
+			"description": "Container memory limit.",
+			"value": "1Gi"
+		}
+	],
+	"labels": {
+		"rhsso": "7.4.1.GA",
+		"template": "sso74-openj9-ocp4-x509-https"
+	}
+}

--- a/official/sso/templates/sso74-openj9-ocp4-x509-postgresql-persistent.json
+++ b/official/sso/templates/sso74-openj9-ocp4-x509-postgresql-persistent.json
@@ -1,0 +1,641 @@
+{
+	"kind": "Template",
+	"apiVersion": "v1",
+	"metadata": {
+		"name": "sso74-openj9-ocp4-x509-postgresql-persistent",
+		"creationTimestamp": null,
+		"annotations": {
+			"description": "An example application based on RH-SSO 7.4 on OpenJ9 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/tree/sso74-dev/docs.",
+			"iconClass": "icon-sso",
+			"openshift.io/display-name": "Red Hat Single Sign-On 7.4 on OpenJ9 + PostgreSQL (Persistent)",
+			"openshift.io/provider-display-name": "Red Hat, Inc.",
+			"tags": "sso,keycloak,jboss",
+			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
+			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.4 on OpenJ9 server based deployment, deployment configuration for PostgreSQL using persistence, and securing RH-SSO communication using re-encrypt TLS.",
+			"template.openshift.io/support-url": "https://access.redhat.com",
+			"version": "7.4.1.GA"
+		}
+	},
+	"message": "A new persistent RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
+	"objects": [
+		{
+			"apiVersion": "v1",
+			"kind": "ConfigMap",
+			"metadata": {
+				"annotations": {
+					"description": "ConfigMap providing service ca bundle.",
+					"service.beta.openshift.io/inject-cabundle": "true"
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}-service-ca"
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"description": "The web server's https port.",
+					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-postgresql\", \"kind\": \"Service\"}]",
+					"service.alpha.openshift.io/serving-cert-secret-name": "sso-x509-https-secret"
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}"
+			},
+			"spec": {
+				"ports": [
+					{
+						"port": 8443,
+						"targetPort": 8443
+					}
+				],
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"description": "The database server's port."
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}-postgresql"
+			},
+			"spec": {
+				"ports": [
+					{
+						"port": 5432,
+						"targetPort": 5432
+					}
+				],
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"description": "The JGroups ping port for clustering.",
+					"service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
+					"service.alpha.openshift.io/serving-cert-secret-name": "sso-x509-jgroups-secret"
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}-ping"
+			},
+			"spec": {
+				"clusterIP": "None",
+				"ports": [
+					{
+						"name": "ping",
+						"port": 8888
+					}
+				],
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"id": "${APPLICATION_NAME}-https",
+			"kind": "Route",
+			"metadata": {
+				"annotations": {
+					"description": "Route for application's https service."
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}"
+			},
+			"spec": {
+				"tls": {
+					"termination": "reencrypt"
+				},
+				"to": {
+					"name": "${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "DeploymentConfig",
+			"metadata": {
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}"
+			},
+			"spec": {
+				"replicas": 1,
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}"
+				},
+				"strategy": {
+					"type": "Recreate"
+				},
+				"template": {
+					"metadata": {
+						"labels": {
+							"application": "${APPLICATION_NAME}",
+							"deploymentConfig": "${APPLICATION_NAME}"
+						},
+						"name": "${APPLICATION_NAME}"
+					},
+					"spec": {
+						"containers": [
+							{
+								"env": [
+									{
+										"name": "SSO_HOSTNAME",
+										"value": "${SSO_HOSTNAME}"
+									},
+									{
+										"name": "DB_SERVICE_PREFIX_MAPPING",
+										"value": "${APPLICATION_NAME}-postgresql=DB"
+									},
+									{
+										"name": "DB_JNDI",
+										"value": "${DB_JNDI}"
+									},
+									{
+										"name": "DB_USERNAME",
+										"value": "${DB_USERNAME}"
+									},
+									{
+										"name": "DB_PASSWORD",
+										"value": "${DB_PASSWORD}"
+									},
+									{
+										"name": "DB_DATABASE",
+										"value": "${DB_DATABASE}"
+									},
+									{
+										"name": "TX_DATABASE_PREFIX_MAPPING",
+										"value": "${APPLICATION_NAME}-postgresql=DB"
+									},
+									{
+										"name": "DB_MIN_POOL_SIZE",
+										"value": "${DB_MIN_POOL_SIZE}"
+									},
+									{
+										"name": "DB_MAX_POOL_SIZE",
+										"value": "${DB_MAX_POOL_SIZE}"
+									},
+									{
+										"name": "DB_TX_ISOLATION",
+										"value": "${DB_TX_ISOLATION}"
+									},
+									{
+										"name": "JGROUPS_PING_PROTOCOL",
+										"value": "openshift.DNS_PING"
+									},
+									{
+										"name": "OPENSHIFT_DNS_PING_SERVICE_NAME",
+										"value": "${APPLICATION_NAME}-ping"
+									},
+									{
+										"name": "OPENSHIFT_DNS_PING_SERVICE_PORT",
+										"value": "8888"
+									},
+									{
+										"name": "X509_CA_BUNDLE",
+										"value": "/var/run/configmaps/service-ca/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+									},
+									{
+										"name": "JGROUPS_CLUSTER_PASSWORD",
+										"value": "${JGROUPS_CLUSTER_PASSWORD}"
+									},
+									{
+										"name": "SSO_ADMIN_USERNAME",
+										"value": "${SSO_ADMIN_USERNAME}"
+									},
+									{
+										"name": "SSO_ADMIN_PASSWORD",
+										"value": "${SSO_ADMIN_PASSWORD}"
+									},
+									{
+										"name": "SSO_REALM",
+										"value": "${SSO_REALM}"
+									},
+									{
+										"name": "SSO_SERVICE_USERNAME",
+										"value": "${SSO_SERVICE_USERNAME}"
+									},
+									{
+										"name": "SSO_SERVICE_PASSWORD",
+										"value": "${SSO_SERVICE_PASSWORD}"
+									}
+								],
+								"image": "${APPLICATION_NAME}",
+								"imagePullPolicy": "Always",
+								"livenessProbe": {
+									"exec": {
+										"command": [
+											"/bin/bash",
+											"-c",
+											"/opt/eap/bin/livenessProbe.sh"
+										]
+									},
+									"initialDelaySeconds": 60
+								},
+								"name": "${APPLICATION_NAME}",
+								"ports": [
+									{
+										"containerPort": 8778,
+										"name": "jolokia",
+										"protocol": "TCP"
+									},
+									{
+										"containerPort": 8080,
+										"name": "http",
+										"protocol": "TCP"
+									},
+									{
+										"containerPort": 8443,
+										"name": "https",
+										"protocol": "TCP"
+									},
+									{
+										"containerPort": 8888,
+										"name": "ping",
+										"protocol": "TCP"
+									}
+								],
+								"readinessProbe": {
+									"exec": {
+										"command": [
+											"/bin/bash",
+											"-c",
+											"/opt/eap/bin/readinessProbe.sh"
+										]
+									}
+								},
+								"resources": {
+									"limits": {
+										"memory": "${MEMORY_LIMIT}"
+									}
+								},
+								"volumeMounts": [
+									{
+										"mountPath": "/etc/x509/https",
+										"name": "sso-x509-https-volume",
+										"readOnly": true
+									},
+									{
+										"mountPath": "/etc/x509/jgroups",
+										"name": "sso-x509-jgroups-volume",
+										"readOnly": true
+									},
+									{
+										"mountPath": "/var/run/configmaps/service-ca",
+										"name": "service-ca",
+										"readOnly": true
+									}
+								]
+							}
+						],
+						"terminationGracePeriodSeconds": 75,
+						"volumes": [
+							{
+								"name": "sso-x509-https-volume",
+								"secret": {
+									"secretName": "sso-x509-https-secret"
+								}
+							},
+							{
+								"name": "sso-x509-jgroups-volume",
+								"secret": {
+									"secretName": "sso-x509-jgroups-secret"
+								}
+							},
+							{
+								"configMap": {
+									"name": "${APPLICATION_NAME}-service-ca"
+								},
+								"name": "service-ca"
+							}
+						]
+					}
+				},
+				"triggers": [
+					{
+						"imageChangeParams": {
+							"automatic": true,
+							"containerNames": [
+								"${APPLICATION_NAME}"
+							],
+							"from": {
+								"kind": "ImageStreamTag",
+								"name": "sso74-openj9-openshift-rhel8:7.4",
+								"namespace": "${IMAGE_STREAM_NAMESPACE}"
+							}
+						},
+						"type": "ImageChange"
+					},
+					{
+						"type": "ConfigChange"
+					}
+				]
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "DeploymentConfig",
+			"metadata": {
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}-postgresql"
+			},
+			"spec": {
+				"replicas": 1,
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+				},
+				"strategy": {
+					"type": "Recreate"
+				},
+				"template": {
+					"metadata": {
+						"labels": {
+							"application": "${APPLICATION_NAME}",
+							"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+						},
+						"name": "${APPLICATION_NAME}-postgresql"
+					},
+					"spec": {
+						"containers": [
+							{
+								"env": [
+									{
+										"name": "POSTGRESQL_USER",
+										"value": "${DB_USERNAME}"
+									},
+									{
+										"name": "POSTGRESQL_PASSWORD",
+										"value": "${DB_PASSWORD}"
+									},
+									{
+										"name": "POSTGRESQL_DATABASE",
+										"value": "${DB_DATABASE}"
+									},
+									{
+										"name": "POSTGRESQL_MAX_CONNECTIONS",
+										"value": "${POSTGRESQL_MAX_CONNECTIONS}"
+									},
+									{
+										"name": "POSTGRESQL_MAX_PREPARED_TRANSACTIONS",
+										"value": "${POSTGRESQL_MAX_CONNECTIONS}"
+									},
+									{
+										"name": "POSTGRESQL_SHARED_BUFFERS",
+										"value": "${POSTGRESQL_SHARED_BUFFERS}"
+									}
+								],
+								"image": "postgresql",
+								"imagePullPolicy": "Always",
+								"livenessProbe": {
+									"failureThreshold": 3,
+									"initialDelaySeconds": 90,
+									"successThreshold:": 1,
+									"tcpSocket": {
+										"port": 5432
+									},
+									"timeoutSeconds": 10
+								},
+								"name": "${APPLICATION_NAME}-postgresql",
+								"ports": [
+									{
+										"containerPort": 5432,
+										"protocol": "TCP"
+									}
+								],
+								"readinessProbe": {
+									"exec": {
+										"command": [
+											"/bin/sh",
+											"-i",
+											"-c",
+											"psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'"
+										]
+									},
+									"failureThreshold": 3,
+									"initialDelaySeconds": 90,
+									"successThreshold:": 1,
+									"timeoutSeconds": 10
+								},
+								"volumeMounts": [
+									{
+										"mountPath": "/var/lib/pgsql/data",
+										"name": "${APPLICATION_NAME}-postgresql-pvol"
+									}
+								]
+							}
+						],
+						"terminationGracePeriodSeconds": 60,
+						"volumes": [
+							{
+								"name": "${APPLICATION_NAME}-postgresql-pvol",
+								"persistentVolumeClaim": {
+									"claimName": "${APPLICATION_NAME}-postgresql-claim"
+								}
+							}
+						]
+					}
+				},
+				"triggers": [
+					{
+						"imageChangeParams": {
+							"automatic": true,
+							"containerNames": [
+								"${APPLICATION_NAME}-postgresql"
+							],
+							"from": {
+								"kind": "ImageStreamTag",
+								"name": "postgresql:${POSTGRESQL_IMAGE_STREAM_TAG}",
+								"namespace": "${IMAGE_STREAM_NAMESPACE}"
+							}
+						},
+						"type": "ImageChange"
+					},
+					{
+						"type": "ConfigChange"
+					}
+				]
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "PersistentVolumeClaim",
+			"metadata": {
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}-postgresql-claim"
+			},
+			"spec": {
+				"accessModes": [
+					"ReadWriteOnce"
+				],
+				"resources": {
+					"requests": {
+						"storage": "${VOLUME_CAPACITY}"
+					}
+				}
+			}
+		}
+	],
+	"parameters": [
+		{
+			"name": "APPLICATION_NAME",
+			"displayName": "Application Name",
+			"description": "The name for the application.",
+			"value": "sso",
+			"required": true
+		},
+		{
+			"name": "SSO_HOSTNAME",
+			"displayName": "Custom RH-SSO Server Hostname",
+			"description": "Custom hostname for the RH-SSO server."
+		},
+		{
+			"name": "JGROUPS_CLUSTER_PASSWORD",
+			"displayName": "JGroups Cluster Password",
+			"description": "The password for the JGroups cluster.",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{32}",
+			"required": true
+		},
+		{
+			"name": "DB_JNDI",
+			"displayName": "Database JNDI Name",
+			"description": "Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/postgresql",
+			"value": "java:jboss/datasources/KeycloakDS"
+		},
+		{
+			"name": "DB_DATABASE",
+			"displayName": "Database Name",
+			"description": "Database name",
+			"value": "root",
+			"required": true
+		},
+		{
+			"name": "DB_MIN_POOL_SIZE",
+			"displayName": "Datasource Minimum Pool Size",
+			"description": "Sets xa-pool/min-pool-size for the configured datasource."
+		},
+		{
+			"name": "DB_MAX_POOL_SIZE",
+			"displayName": "Datasource Maximum Pool Size",
+			"description": "Sets xa-pool/max-pool-size for the configured datasource."
+		},
+		{
+			"name": "DB_TX_ISOLATION",
+			"displayName": "Datasource Transaction Isolation",
+			"description": "Sets transaction-isolation for the configured datasource."
+		},
+		{
+			"name": "POSTGRESQL_MAX_CONNECTIONS",
+			"displayName": "PostgreSQL Maximum number of connections",
+			"description": "The maximum number of client connections allowed. This also sets the maximum number of prepared transactions."
+		},
+		{
+			"name": "POSTGRESQL_SHARED_BUFFERS",
+			"displayName": "PostgreSQL Shared Buffers",
+			"description": "Configures how much memory is dedicated to PostgreSQL for caching data."
+		},
+		{
+			"name": "DB_USERNAME",
+			"displayName": "Database Username",
+			"description": "Database user name",
+			"generate": "expression",
+			"from": "user[a-zA-Z0-9]{3}",
+			"required": true
+		},
+		{
+			"name": "DB_PASSWORD",
+			"displayName": "Database Password",
+			"description": "Database user password",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{32}",
+			"required": true
+		},
+		{
+			"name": "VOLUME_CAPACITY",
+			"displayName": "Database Volume Capacity",
+			"description": "Size of persistent storage for database volume.",
+			"value": "1Gi",
+			"required": true
+		},
+		{
+			"name": "IMAGE_STREAM_NAMESPACE",
+			"displayName": "ImageStream Namespace",
+			"description": "Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.",
+			"value": "openshift",
+			"required": true
+		},
+		{
+			"name": "SSO_ADMIN_USERNAME",
+			"displayName": "RH-SSO Administrator Username",
+			"description": "RH-SSO Server administrator username",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "SSO_ADMIN_PASSWORD",
+			"displayName": "RH-SSO Administrator Password",
+			"description": "RH-SSO Server administrator password",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{32}",
+			"required": true
+		},
+		{
+			"name": "SSO_REALM",
+			"displayName": "RH-SSO Realm",
+			"description": "Realm to be created in the RH-SSO server (e.g. demorealm)."
+		},
+		{
+			"name": "SSO_SERVICE_USERNAME",
+			"displayName": "RH-SSO Service Username",
+			"description": "The username used to access the RH-SSO service. This is used by clients to create the appliction client(s) within the specified RH-SSO realm."
+		},
+		{
+			"name": "SSO_SERVICE_PASSWORD",
+			"displayName": "RH-SSO Service Password",
+			"description": "The password for the RH-SSO service user."
+		},
+		{
+			"name": "POSTGRESQL_IMAGE_STREAM_TAG",
+			"displayName": "PostgreSQL Image Stream Tag",
+			"description": "The tag to use for the \"postgresql\" image stream.  Typically, this aligns with the major.minor version of PostgreSQL.",
+			"value": "10",
+			"required": true
+		},
+		{
+			"name": "MEMORY_LIMIT",
+			"displayName": "Container Memory Limit",
+			"description": "Container memory limit.",
+			"value": "1Gi"
+		}
+	],
+	"labels": {
+		"rhsso": "7.4.1.GA",
+		"template": "sso74-openj9-ocp4-x509-postgresql-persistent"
+	}
+}

--- a/official/sso/templates/sso74-openj9-postgresql-persistent.json
+++ b/official/sso/templates/sso74-openj9-postgresql-persistent.json
@@ -1,0 +1,794 @@
+{
+	"kind": "Template",
+	"apiVersion": "v1",
+	"metadata": {
+		"name": "sso74-openj9-postgresql-persistent",
+		"creationTimestamp": null,
+		"annotations": {
+			"description": "An example application based on RH-SSO 7.4 on OpenJ9 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/tree/sso74-dev/docs.",
+			"iconClass": "icon-sso",
+			"openshift.io/display-name": "Red Hat Single Sign-On 7.4 on OpenJ9 + PostgreSQL (Persistent with passthrough TLS)",
+			"openshift.io/provider-display-name": "Red Hat, Inc.",
+			"tags": "sso,keycloak,jboss,hidden",
+			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
+			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.4 on OpenJ9 server based deployment, deployment configuration for PostgreSQL using persistence, and securing RH-SSO communication using passthrough TLS.",
+			"template.openshift.io/support-url": "https://access.redhat.com",
+			"version": "7.4.1.GA"
+		}
+	},
+	"message": "A new persistent RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
+	"objects": [
+		{
+			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"description": "The web server's http port.",
+					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-postgresql\", \"kind\": \"Service\"}]"
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}"
+			},
+			"spec": {
+				"ports": [
+					{
+						"port": 8080,
+						"targetPort": 8080
+					}
+				],
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"description": "The web server's https port.",
+					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-postgresql\", \"kind\": \"Service\"}]"
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "secure-${APPLICATION_NAME}"
+			},
+			"spec": {
+				"ports": [
+					{
+						"port": 8443,
+						"targetPort": 8443
+					}
+				],
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"description": "The database server's port."
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}-postgresql"
+			},
+			"spec": {
+				"ports": [
+					{
+						"port": 5432,
+						"targetPort": 5432
+					}
+				],
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"description": "The JGroups ping port for clustering.",
+					"service.alpha.kubernetes.io/tolerate-unready-endpoints": "true"
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}-ping"
+			},
+			"spec": {
+				"clusterIP": "None",
+				"ports": [
+					{
+						"name": "ping",
+						"port": 8888
+					}
+				],
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"id": "${APPLICATION_NAME}-http",
+			"kind": "Route",
+			"metadata": {
+				"annotations": {
+					"description": "Route for application's http service."
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}"
+			},
+			"spec": {
+				"host": "${HOSTNAME_HTTP}",
+				"to": {
+					"name": "${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"id": "${APPLICATION_NAME}-https",
+			"kind": "Route",
+			"metadata": {
+				"annotations": {
+					"description": "Route for application's https service."
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "secure-${APPLICATION_NAME}"
+			},
+			"spec": {
+				"host": "${HOSTNAME_HTTPS}",
+				"tls": {
+					"termination": "passthrough"
+				},
+				"to": {
+					"name": "secure-${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "DeploymentConfig",
+			"metadata": {
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}"
+			},
+			"spec": {
+				"replicas": 1,
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}"
+				},
+				"strategy": {
+					"type": "Recreate"
+				},
+				"template": {
+					"metadata": {
+						"labels": {
+							"application": "${APPLICATION_NAME}",
+							"deploymentConfig": "${APPLICATION_NAME}"
+						},
+						"name": "${APPLICATION_NAME}"
+					},
+					"spec": {
+						"containers": [
+							{
+								"env": [
+									{
+										"name": "SSO_HOSTNAME",
+										"value": "${SSO_HOSTNAME}"
+									},
+									{
+										"name": "DB_SERVICE_PREFIX_MAPPING",
+										"value": "${APPLICATION_NAME}-postgresql=DB"
+									},
+									{
+										"name": "DB_JNDI",
+										"value": "${DB_JNDI}"
+									},
+									{
+										"name": "DB_USERNAME",
+										"value": "${DB_USERNAME}"
+									},
+									{
+										"name": "DB_PASSWORD",
+										"value": "${DB_PASSWORD}"
+									},
+									{
+										"name": "DB_DATABASE",
+										"value": "${DB_DATABASE}"
+									},
+									{
+										"name": "TX_DATABASE_PREFIX_MAPPING",
+										"value": "${APPLICATION_NAME}-postgresql=DB"
+									},
+									{
+										"name": "DB_MIN_POOL_SIZE",
+										"value": "${DB_MIN_POOL_SIZE}"
+									},
+									{
+										"name": "DB_MAX_POOL_SIZE",
+										"value": "${DB_MAX_POOL_SIZE}"
+									},
+									{
+										"name": "DB_TX_ISOLATION",
+										"value": "${DB_TX_ISOLATION}"
+									},
+									{
+										"name": "JGROUPS_PING_PROTOCOL",
+										"value": "openshift.DNS_PING"
+									},
+									{
+										"name": "OPENSHIFT_DNS_PING_SERVICE_NAME",
+										"value": "${APPLICATION_NAME}-ping"
+									},
+									{
+										"name": "OPENSHIFT_DNS_PING_SERVICE_PORT",
+										"value": "8888"
+									},
+									{
+										"name": "HTTPS_KEYSTORE_DIR",
+										"value": "/etc/eap-secret-volume"
+									},
+									{
+										"name": "HTTPS_KEYSTORE",
+										"value": "${HTTPS_KEYSTORE}"
+									},
+									{
+										"name": "HTTPS_KEYSTORE_TYPE",
+										"value": "${HTTPS_KEYSTORE_TYPE}"
+									},
+									{
+										"name": "HTTPS_NAME",
+										"value": "${HTTPS_NAME}"
+									},
+									{
+										"name": "HTTPS_PASSWORD",
+										"value": "${HTTPS_PASSWORD}"
+									},
+									{
+										"name": "JGROUPS_ENCRYPT_SECRET",
+										"value": "${JGROUPS_ENCRYPT_SECRET}"
+									},
+									{
+										"name": "JGROUPS_ENCRYPT_KEYSTORE_DIR",
+										"value": "/etc/jgroups-encrypt-secret-volume"
+									},
+									{
+										"name": "JGROUPS_ENCRYPT_KEYSTORE",
+										"value": "${JGROUPS_ENCRYPT_KEYSTORE}"
+									},
+									{
+										"name": "JGROUPS_ENCRYPT_NAME",
+										"value": "${JGROUPS_ENCRYPT_NAME}"
+									},
+									{
+										"name": "JGROUPS_ENCRYPT_PASSWORD",
+										"value": "${JGROUPS_ENCRYPT_PASSWORD}"
+									},
+									{
+										"name": "JGROUPS_CLUSTER_PASSWORD",
+										"value": "${JGROUPS_CLUSTER_PASSWORD}"
+									},
+									{
+										"name": "SSO_ADMIN_USERNAME",
+										"value": "${SSO_ADMIN_USERNAME}"
+									},
+									{
+										"name": "SSO_ADMIN_PASSWORD",
+										"value": "${SSO_ADMIN_PASSWORD}"
+									},
+									{
+										"name": "SSO_REALM",
+										"value": "${SSO_REALM}"
+									},
+									{
+										"name": "SSO_SERVICE_USERNAME",
+										"value": "${SSO_SERVICE_USERNAME}"
+									},
+									{
+										"name": "SSO_SERVICE_PASSWORD",
+										"value": "${SSO_SERVICE_PASSWORD}"
+									},
+									{
+										"name": "SSO_TRUSTSTORE",
+										"value": "${SSO_TRUSTSTORE}"
+									},
+									{
+										"name": "SSO_TRUSTSTORE_DIR",
+										"value": "/etc/sso-secret-volume"
+									},
+									{
+										"name": "SSO_TRUSTSTORE_PASSWORD",
+										"value": "${SSO_TRUSTSTORE_PASSWORD}"
+									}
+								],
+								"image": "${APPLICATION_NAME}",
+								"imagePullPolicy": "Always",
+								"livenessProbe": {
+									"exec": {
+										"command": [
+											"/bin/bash",
+											"-c",
+											"/opt/eap/bin/livenessProbe.sh"
+										]
+									},
+									"initialDelaySeconds": 60
+								},
+								"name": "${APPLICATION_NAME}",
+								"ports": [
+									{
+										"containerPort": 8778,
+										"name": "jolokia",
+										"protocol": "TCP"
+									},
+									{
+										"containerPort": 8080,
+										"name": "http",
+										"protocol": "TCP"
+									},
+									{
+										"containerPort": 8443,
+										"name": "https",
+										"protocol": "TCP"
+									},
+									{
+										"containerPort": 8888,
+										"name": "ping",
+										"protocol": "TCP"
+									}
+								],
+								"readinessProbe": {
+									"exec": {
+										"command": [
+											"/bin/bash",
+											"-c",
+											"/opt/eap/bin/readinessProbe.sh"
+										]
+									}
+								},
+								"resources": {
+									"limits": {
+										"memory": "${MEMORY_LIMIT}"
+									}
+								},
+								"volumeMounts": [
+									{
+										"mountPath": "/etc/eap-secret-volume",
+										"name": "eap-keystore-volume",
+										"readOnly": true
+									},
+									{
+										"mountPath": "/etc/jgroups-encrypt-secret-volume",
+										"name": "eap-jgroups-keystore-volume",
+										"readOnly": true
+									},
+									{
+										"mountPath": "/etc/sso-secret-volume",
+										"name": "sso-truststore-volume",
+										"readOnly": true
+									}
+								]
+							}
+						],
+						"terminationGracePeriodSeconds": 75,
+						"volumes": [
+							{
+								"name": "eap-keystore-volume",
+								"secret": {
+									"secretName": "${HTTPS_SECRET}"
+								}
+							},
+							{
+								"name": "eap-jgroups-keystore-volume",
+								"secret": {
+									"secretName": "${JGROUPS_ENCRYPT_SECRET}"
+								}
+							},
+							{
+								"name": "sso-truststore-volume",
+								"secret": {
+									"secretName": "${SSO_TRUSTSTORE_SECRET}"
+								}
+							}
+						]
+					}
+				},
+				"triggers": [
+					{
+						"imageChangeParams": {
+							"automatic": true,
+							"containerNames": [
+								"${APPLICATION_NAME}"
+							],
+							"from": {
+								"kind": "ImageStreamTag",
+								"name": "sso74-openj9-openshift-rhel8:7.4",
+								"namespace": "${IMAGE_STREAM_NAMESPACE}"
+							}
+						},
+						"type": "ImageChange"
+					},
+					{
+						"type": "ConfigChange"
+					}
+				]
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "DeploymentConfig",
+			"metadata": {
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}-postgresql"
+			},
+			"spec": {
+				"replicas": 1,
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+				},
+				"strategy": {
+					"type": "Recreate"
+				},
+				"template": {
+					"metadata": {
+						"labels": {
+							"application": "${APPLICATION_NAME}",
+							"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+						},
+						"name": "${APPLICATION_NAME}-postgresql"
+					},
+					"spec": {
+						"containers": [
+							{
+								"env": [
+									{
+										"name": "POSTGRESQL_USER",
+										"value": "${DB_USERNAME}"
+									},
+									{
+										"name": "POSTGRESQL_PASSWORD",
+										"value": "${DB_PASSWORD}"
+									},
+									{
+										"name": "POSTGRESQL_DATABASE",
+										"value": "${DB_DATABASE}"
+									},
+									{
+										"name": "POSTGRESQL_MAX_CONNECTIONS",
+										"value": "${POSTGRESQL_MAX_CONNECTIONS}"
+									},
+									{
+										"name": "POSTGRESQL_MAX_PREPARED_TRANSACTIONS",
+										"value": "${POSTGRESQL_MAX_CONNECTIONS}"
+									},
+									{
+										"name": "POSTGRESQL_SHARED_BUFFERS",
+										"value": "${POSTGRESQL_SHARED_BUFFERS}"
+									}
+								],
+								"image": "postgresql",
+								"imagePullPolicy": "Always",
+								"livenessProbe": {
+									"failureThreshold": 3,
+									"initialDelaySeconds": 90,
+									"successThreshold:": 1,
+									"tcpSocket": {
+										"port": 5432
+									},
+									"timeoutSeconds": 10
+								},
+								"name": "${APPLICATION_NAME}-postgresql",
+								"ports": [
+									{
+										"containerPort": 5432,
+										"protocol": "TCP"
+									}
+								],
+								"readinessProbe": {
+									"exec": {
+										"command": [
+											"/bin/sh",
+											"-i",
+											"-c",
+											"psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'"
+										]
+									},
+									"failureThreshold": 3,
+									"initialDelaySeconds": 90,
+									"successThreshold:": 1,
+									"timeoutSeconds": 10
+								},
+								"volumeMounts": [
+									{
+										"mountPath": "/var/lib/pgsql/data",
+										"name": "${APPLICATION_NAME}-postgresql-pvol"
+									}
+								]
+							}
+						],
+						"terminationGracePeriodSeconds": 60,
+						"volumes": [
+							{
+								"name": "${APPLICATION_NAME}-postgresql-pvol",
+								"persistentVolumeClaim": {
+									"claimName": "${APPLICATION_NAME}-postgresql-claim"
+								}
+							}
+						]
+					}
+				},
+				"triggers": [
+					{
+						"imageChangeParams": {
+							"automatic": true,
+							"containerNames": [
+								"${APPLICATION_NAME}-postgresql"
+							],
+							"from": {
+								"kind": "ImageStreamTag",
+								"name": "postgresql:${POSTGRESQL_IMAGE_STREAM_TAG}",
+								"namespace": "${IMAGE_STREAM_NAMESPACE}"
+							}
+						},
+						"type": "ImageChange"
+					},
+					{
+						"type": "ConfigChange"
+					}
+				]
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "PersistentVolumeClaim",
+			"metadata": {
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}-postgresql-claim"
+			},
+			"spec": {
+				"accessModes": [
+					"ReadWriteOnce"
+				],
+				"resources": {
+					"requests": {
+						"storage": "${VOLUME_CAPACITY}"
+					}
+				}
+			}
+		}
+	],
+	"parameters": [
+		{
+			"name": "APPLICATION_NAME",
+			"displayName": "Application Name",
+			"description": "The name for the application.",
+			"value": "sso",
+			"required": true
+		},
+		{
+			"name": "HOSTNAME_HTTP",
+			"displayName": "Custom http Route Hostname",
+			"description": "Custom hostname for http service route. Leave blank for default hostname, e.g.: \u003capplication-name\u003e.\u003cproject\u003e.\u003cdefault-domain-suffix\u003e"
+		},
+		{
+			"name": "HOSTNAME_HTTPS",
+			"displayName": "Custom https Route Hostname",
+			"description": "Custom hostname for https service route. Leave blank for default hostname, e.g.: \u003capplication-name\u003e.\u003cproject\u003e.\u003cdefault-domain-suffix\u003e"
+		},
+		{
+			"name": "SSO_HOSTNAME",
+			"displayName": "Custom RH-SSO Server Hostname",
+			"description": "Custom hostname for the RH-SSO server."
+		},
+		{
+			"name": "DB_JNDI",
+			"displayName": "Database JNDI Name",
+			"description": "Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/postgresql",
+			"value": "java:jboss/datasources/KeycloakDS"
+		},
+		{
+			"name": "DB_DATABASE",
+			"displayName": "Database Name",
+			"description": "Database name",
+			"value": "root",
+			"required": true
+		},
+		{
+			"name": "HTTPS_SECRET",
+			"displayName": "Server Keystore Secret Name",
+			"description": "The name of the secret containing the keystore file",
+			"value": "sso-app-secret"
+		},
+		{
+			"name": "HTTPS_KEYSTORE",
+			"displayName": "Server Keystore Filename",
+			"description": "The name of the keystore file within the secret",
+			"value": "keystore.jks"
+		},
+		{
+			"name": "HTTPS_KEYSTORE_TYPE",
+			"displayName": "Server Keystore Type",
+			"description": "The type of the keystore file (JKS or JCEKS)"
+		},
+		{
+			"name": "HTTPS_NAME",
+			"displayName": "Server Certificate Name",
+			"description": "The name associated with the server certificate (e.g. jboss)"
+		},
+		{
+			"name": "HTTPS_PASSWORD",
+			"displayName": "Server Keystore Password",
+			"description": "The password for the keystore and certificate (e.g. mykeystorepass)"
+		},
+		{
+			"name": "DB_MIN_POOL_SIZE",
+			"displayName": "Datasource Minimum Pool Size",
+			"description": "Sets xa-pool/min-pool-size for the configured datasource."
+		},
+		{
+			"name": "DB_MAX_POOL_SIZE",
+			"displayName": "Datasource Maximum Pool Size",
+			"description": "Sets xa-pool/max-pool-size for the configured datasource."
+		},
+		{
+			"name": "DB_TX_ISOLATION",
+			"displayName": "Datasource Transaction Isolation",
+			"description": "Sets transaction-isolation for the configured datasource."
+		},
+		{
+			"name": "POSTGRESQL_MAX_CONNECTIONS",
+			"displayName": "PostgreSQL Maximum number of connections",
+			"description": "The maximum number of client connections allowed. This also sets the maximum number of prepared transactions."
+		},
+		{
+			"name": "POSTGRESQL_SHARED_BUFFERS",
+			"displayName": "PostgreSQL Shared Buffers",
+			"description": "Configures how much memory is dedicated to PostgreSQL for caching data."
+		},
+		{
+			"name": "DB_USERNAME",
+			"displayName": "Database Username",
+			"description": "Database user name",
+			"generate": "expression",
+			"from": "user[a-zA-Z0-9]{3}",
+			"required": true
+		},
+		{
+			"name": "DB_PASSWORD",
+			"displayName": "Database Password",
+			"description": "Database user password",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "VOLUME_CAPACITY",
+			"displayName": "Database Volume Capacity",
+			"description": "Size of persistent storage for database volume.",
+			"value": "1Gi",
+			"required": true
+		},
+		{
+			"name": "JGROUPS_ENCRYPT_SECRET",
+			"displayName": "JGroups Secret Name",
+			"description": "The name of the secret containing the keystore file",
+			"value": "sso-app-secret"
+		},
+		{
+			"name": "JGROUPS_ENCRYPT_KEYSTORE",
+			"displayName": "JGroups Keystore Filename",
+			"description": "The name of the keystore file within the secret",
+			"value": "jgroups.jceks"
+		},
+		{
+			"name": "JGROUPS_ENCRYPT_NAME",
+			"displayName": "JGroups Certificate Name",
+			"description": "The name associated with the server certificate (e.g. secret-key)"
+		},
+		{
+			"name": "JGROUPS_ENCRYPT_PASSWORD",
+			"displayName": "JGroups Keystore Password",
+			"description": "The password for the keystore and certificate (e.g. password)"
+		},
+		{
+			"name": "JGROUPS_CLUSTER_PASSWORD",
+			"displayName": "JGroups Cluster Password",
+			"description": "JGroups cluster password",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "IMAGE_STREAM_NAMESPACE",
+			"displayName": "ImageStream Namespace",
+			"description": "Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.",
+			"value": "openshift",
+			"required": true
+		},
+		{
+			"name": "SSO_ADMIN_USERNAME",
+			"displayName": "RH-SSO Administrator Username",
+			"description": "RH-SSO Server administrator username",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "SSO_ADMIN_PASSWORD",
+			"displayName": "RH-SSO Administrator Password",
+			"description": "RH-SSO Server administrator password",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "SSO_REALM",
+			"displayName": "RH-SSO Realm",
+			"description": "Realm to be created in the RH-SSO server (e.g. demorealm)."
+		},
+		{
+			"name": "SSO_SERVICE_USERNAME",
+			"displayName": "RH-SSO Service Username",
+			"description": "The username used to access the RH-SSO service. This is used by clients to create the appliction client(s) within the specified RH-SSO realm."
+		},
+		{
+			"name": "SSO_SERVICE_PASSWORD",
+			"displayName": "RH-SSO Service Password",
+			"description": "The password for the RH-SSO service user."
+		},
+		{
+			"name": "SSO_TRUSTSTORE",
+			"displayName": "RH-SSO Trust Store",
+			"description": "The name of the truststore file within the secret (e.g. truststore.jks)"
+		},
+		{
+			"name": "SSO_TRUSTSTORE_PASSWORD",
+			"displayName": "RH-SSO Trust Store Password",
+			"description": "The password for the truststore and certificate (e.g. mykeystorepass)"
+		},
+		{
+			"name": "SSO_TRUSTSTORE_SECRET",
+			"displayName": "RH-SSO Trust Store Secret",
+			"description": "The name of the secret containing the truststore file (e.g. truststore-secret). Used for volume secretName",
+			"value": "sso-app-secret"
+		},
+		{
+			"name": "POSTGRESQL_IMAGE_STREAM_TAG",
+			"displayName": "PostgreSQL Image Stream Tag",
+			"description": "The tag to use for the \"postgresql\" image stream. Typically, this aligns with the major.minor version of PostgreSQL.",
+			"value": "10",
+			"required": true
+		},
+		{
+			"name": "MEMORY_LIMIT",
+			"displayName": "Container Memory Limit",
+			"description": "Container memory limit.",
+			"value": "1Gi"
+		}
+	],
+	"labels": {
+		"rhsso": "7.4.1.GA",
+		"template": "sso74-openj9-postgresql-persistent"
+	}
+}

--- a/official/sso/templates/sso74-openj9-postgresql.json
+++ b/official/sso/templates/sso74-openj9-postgresql.json
@@ -1,0 +1,772 @@
+{
+	"kind": "Template",
+	"apiVersion": "v1",
+	"metadata": {
+		"name": "sso74-openj9-postgresql",
+		"creationTimestamp": null,
+		"annotations": {
+			"description": "An example application based on RH-SSO 7.4 on OpenJ9 image. For more information about using this template, see https://github.com/jboss-container-images/redhat-sso-7-openshift-image/tree/sso74-dev/docs.",
+			"iconClass": "icon-sso",
+			"openshift.io/display-name": "Red Hat Single Sign-On 7.4 on OpenJ9 + PostgreSQL (Ephemeral with passthrough TLS)",
+			"openshift.io/provider-display-name": "Red Hat, Inc.",
+			"tags": "sso,keycloak,jboss,hidden",
+			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
+			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.4 on OpenJ9 server based deployment, deployment configuration for PostgreSQL using ephemeral (temporary) storage, and securing RH-SSO communication using passthrough TLS.",
+			"template.openshift.io/support-url": "https://access.redhat.com",
+			"version": "7.4.1.GA"
+		}
+	},
+	"message": "A new RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
+	"objects": [
+		{
+			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"description": "The web server's http port.",
+					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-postgresql\", \"kind\": \"Service\"}]"
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}",
+					"component": "server"
+				},
+				"name": "${APPLICATION_NAME}"
+			},
+			"spec": {
+				"ports": [
+					{
+						"port": 8080,
+						"targetPort": 8080
+					}
+				],
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"description": "The web server's https port.",
+					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-postgresql\", \"kind\": \"Service\"}]"
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}",
+					"component": "server"
+				},
+				"name": "secure-${APPLICATION_NAME}"
+			},
+			"spec": {
+				"ports": [
+					{
+						"port": 8443,
+						"targetPort": 8443
+					}
+				],
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"description": "The database server's port."
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}",
+					"component": "database"
+				},
+				"name": "${APPLICATION_NAME}-postgresql"
+			},
+			"spec": {
+				"ports": [
+					{
+						"port": 5432,
+						"targetPort": 5432
+					}
+				],
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"description": "The JGroups ping port for clustering.",
+					"service.alpha.kubernetes.io/tolerate-unready-endpoints": "true"
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}-ping"
+			},
+			"spec": {
+				"clusterIP": "None",
+				"ports": [
+					{
+						"name": "ping",
+						"port": 8888
+					}
+				],
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"id": "${APPLICATION_NAME}-http",
+			"kind": "Route",
+			"metadata": {
+				"annotations": {
+					"description": "Route for application's http service."
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}",
+					"component": "server"
+				},
+				"name": "${APPLICATION_NAME}"
+			},
+			"spec": {
+				"host": "${HOSTNAME_HTTP}",
+				"to": {
+					"name": "${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"id": "${APPLICATION_NAME}-https",
+			"kind": "Route",
+			"metadata": {
+				"annotations": {
+					"description": "Route for application's https service."
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}",
+					"component": "server"
+				},
+				"name": "secure-${APPLICATION_NAME}"
+			},
+			"spec": {
+				"host": "${HOSTNAME_HTTPS}",
+				"tls": {
+					"termination": "passthrough"
+				},
+				"to": {
+					"name": "secure-${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "DeploymentConfig",
+			"metadata": {
+				"labels": {
+					"application": "${APPLICATION_NAME}",
+					"component": "server"
+				},
+				"name": "${APPLICATION_NAME}"
+			},
+			"spec": {
+				"replicas": 1,
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}"
+				},
+				"strategy": {
+					"type": "Recreate"
+				},
+				"template": {
+					"metadata": {
+						"labels": {
+							"application": "${APPLICATION_NAME}",
+							"component": "server",
+							"deploymentConfig": "${APPLICATION_NAME}"
+						},
+						"name": "${APPLICATION_NAME}"
+					},
+					"spec": {
+						"containers": [
+							{
+								"env": [
+									{
+										"name": "SSO_HOSTNAME",
+										"value": "${SSO_HOSTNAME}"
+									},
+									{
+										"name": "DB_SERVICE_PREFIX_MAPPING",
+										"value": "${APPLICATION_NAME}-postgresql=DB"
+									},
+									{
+										"name": "DB_JNDI",
+										"value": "${DB_JNDI}"
+									},
+									{
+										"name": "DB_USERNAME",
+										"value": "${DB_USERNAME}"
+									},
+									{
+										"name": "DB_PASSWORD",
+										"value": "${DB_PASSWORD}"
+									},
+									{
+										"name": "DB_DATABASE",
+										"value": "${DB_DATABASE}"
+									},
+									{
+										"name": "TX_DATABASE_PREFIX_MAPPING",
+										"value": "${APPLICATION_NAME}-postgresql=DB"
+									},
+									{
+										"name": "DB_MIN_POOL_SIZE",
+										"value": "${DB_MIN_POOL_SIZE}"
+									},
+									{
+										"name": "DB_MAX_POOL_SIZE",
+										"value": "${DB_MAX_POOL_SIZE}"
+									},
+									{
+										"name": "DB_TX_ISOLATION",
+										"value": "${DB_TX_ISOLATION}"
+									},
+									{
+										"name": "JGROUPS_PING_PROTOCOL",
+										"value": "openshift.DNS_PING"
+									},
+									{
+										"name": "OPENSHIFT_DNS_PING_SERVICE_NAME",
+										"value": "${APPLICATION_NAME}-ping"
+									},
+									{
+										"name": "OPENSHIFT_DNS_PING_SERVICE_PORT",
+										"value": "8888"
+									},
+									{
+										"name": "HTTPS_KEYSTORE_DIR",
+										"value": "/etc/eap-secret-volume"
+									},
+									{
+										"name": "HTTPS_KEYSTORE",
+										"value": "${HTTPS_KEYSTORE}"
+									},
+									{
+										"name": "HTTPS_KEYSTORE_TYPE",
+										"value": "${HTTPS_KEYSTORE_TYPE}"
+									},
+									{
+										"name": "HTTPS_NAME",
+										"value": "${HTTPS_NAME}"
+									},
+									{
+										"name": "HTTPS_PASSWORD",
+										"value": "${HTTPS_PASSWORD}"
+									},
+									{
+										"name": "JGROUPS_ENCRYPT_SECRET",
+										"value": "${JGROUPS_ENCRYPT_SECRET}"
+									},
+									{
+										"name": "JGROUPS_ENCRYPT_KEYSTORE_DIR",
+										"value": "/etc/jgroups-encrypt-secret-volume"
+									},
+									{
+										"name": "JGROUPS_ENCRYPT_KEYSTORE",
+										"value": "${JGROUPS_ENCRYPT_KEYSTORE}"
+									},
+									{
+										"name": "JGROUPS_ENCRYPT_NAME",
+										"value": "${JGROUPS_ENCRYPT_NAME}"
+									},
+									{
+										"name": "JGROUPS_ENCRYPT_PASSWORD",
+										"value": "${JGROUPS_ENCRYPT_PASSWORD}"
+									},
+									{
+										"name": "JGROUPS_CLUSTER_PASSWORD",
+										"value": "${JGROUPS_CLUSTER_PASSWORD}"
+									},
+									{
+										"name": "SSO_ADMIN_USERNAME",
+										"value": "${SSO_ADMIN_USERNAME}"
+									},
+									{
+										"name": "SSO_ADMIN_PASSWORD",
+										"value": "${SSO_ADMIN_PASSWORD}"
+									},
+									{
+										"name": "SSO_REALM",
+										"value": "${SSO_REALM}"
+									},
+									{
+										"name": "SSO_SERVICE_USERNAME",
+										"value": "${SSO_SERVICE_USERNAME}"
+									},
+									{
+										"name": "SSO_SERVICE_PASSWORD",
+										"value": "${SSO_SERVICE_PASSWORD}"
+									},
+									{
+										"name": "SSO_TRUSTSTORE",
+										"value": "${SSO_TRUSTSTORE}"
+									},
+									{
+										"name": "SSO_TRUSTSTORE_DIR",
+										"value": "/etc/sso-secret-volume"
+									},
+									{
+										"name": "SSO_TRUSTSTORE_PASSWORD",
+										"value": "${SSO_TRUSTSTORE_PASSWORD}"
+									}
+								],
+								"image": "${APPLICATION_NAME}",
+								"imagePullPolicy": "Always",
+								"livenessProbe": {
+									"exec": {
+										"command": [
+											"/bin/bash",
+											"-c",
+											"/opt/eap/bin/livenessProbe.sh"
+										]
+									},
+									"initialDelaySeconds": 60
+								},
+								"name": "${APPLICATION_NAME}",
+								"ports": [
+									{
+										"containerPort": 8778,
+										"name": "jolokia",
+										"protocol": "TCP"
+									},
+									{
+										"containerPort": 8080,
+										"name": "http",
+										"protocol": "TCP"
+									},
+									{
+										"containerPort": 8443,
+										"name": "https",
+										"protocol": "TCP"
+									},
+									{
+										"containerPort": 8888,
+										"name": "ping",
+										"protocol": "TCP"
+									}
+								],
+								"readinessProbe": {
+									"exec": {
+										"command": [
+											"/bin/bash",
+											"-c",
+											"/opt/eap/bin/readinessProbe.sh"
+										]
+									}
+								},
+								"resources": {
+									"limits": {
+										"memory": "${MEMORY_LIMIT}"
+									}
+								},
+								"volumeMounts": [
+									{
+										"mountPath": "/etc/eap-secret-volume",
+										"name": "eap-keystore-volume",
+										"readOnly": true
+									},
+									{
+										"mountPath": "/etc/jgroups-encrypt-secret-volume",
+										"name": "eap-jgroups-keystore-volume",
+										"readOnly": true
+									},
+									{
+										"mountPath": "/etc/sso-secret-volume",
+										"name": "sso-truststore-volume",
+										"readOnly": true
+									}
+								]
+							}
+						],
+						"terminationGracePeriodSeconds": 75,
+						"volumes": [
+							{
+								"name": "eap-keystore-volume",
+								"secret": {
+									"secretName": "${HTTPS_SECRET}"
+								}
+							},
+							{
+								"name": "eap-jgroups-keystore-volume",
+								"secret": {
+									"secretName": "${JGROUPS_ENCRYPT_SECRET}"
+								}
+							},
+							{
+								"name": "sso-truststore-volume",
+								"secret": {
+									"secretName": "${SSO_TRUSTSTORE_SECRET}"
+								}
+							}
+						]
+					}
+				},
+				"triggers": [
+					{
+						"imageChangeParams": {
+							"automatic": true,
+							"containerNames": [
+								"${APPLICATION_NAME}"
+							],
+							"from": {
+								"kind": "ImageStreamTag",
+								"name": "sso74-openj9-openshift-rhel8:7.4",
+								"namespace": "${IMAGE_STREAM_NAMESPACE}"
+							}
+						},
+						"type": "ImageChange"
+					},
+					{
+						"type": "ConfigChange"
+					}
+				]
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "DeploymentConfig",
+			"metadata": {
+				"labels": {
+					"application": "${APPLICATION_NAME}",
+					"component": "database"
+				},
+				"name": "${APPLICATION_NAME}-postgresql"
+			},
+			"spec": {
+				"replicas": 1,
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+				},
+				"strategy": {
+					"type": "Recreate"
+				},
+				"template": {
+					"metadata": {
+						"labels": {
+							"application": "${APPLICATION_NAME}",
+							"component": "database",
+							"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+						},
+						"name": "${APPLICATION_NAME}-postgresql"
+					},
+					"spec": {
+						"containers": [
+							{
+								"env": [
+									{
+										"name": "POSTGRESQL_USER",
+										"value": "${DB_USERNAME}"
+									},
+									{
+										"name": "POSTGRESQL_PASSWORD",
+										"value": "${DB_PASSWORD}"
+									},
+									{
+										"name": "POSTGRESQL_DATABASE",
+										"value": "${DB_DATABASE}"
+									},
+									{
+										"name": "POSTGRESQL_MAX_CONNECTIONS",
+										"value": "${POSTGRESQL_MAX_CONNECTIONS}"
+									},
+									{
+										"name": "POSTGRESQL_MAX_PREPARED_TRANSACTIONS",
+										"value": "${POSTGRESQL_MAX_CONNECTIONS}"
+									},
+									{
+										"name": "POSTGRESQL_SHARED_BUFFERS",
+										"value": "${POSTGRESQL_SHARED_BUFFERS}"
+									}
+								],
+								"image": "postgresql",
+								"imagePullPolicy": "Always",
+								"livenessProbe": {
+									"initialDelaySeconds": 30,
+									"tcpSocket": {
+										"port": 5432
+									},
+									"timeoutSeconds": 1
+								},
+								"name": "${APPLICATION_NAME}-postgresql",
+								"ports": [
+									{
+										"containerPort": 5432,
+										"protocol": "TCP"
+									}
+								],
+								"readinessProbe": {
+									"exec": {
+										"command": [
+											"/bin/sh",
+											"-i",
+											"-c",
+											"psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'"
+										]
+									},
+									"initialDelaySeconds": 5,
+									"timeoutSeconds": 1
+								},
+								"volumeMounts": [
+									{
+										"mountPath": "/var/lib/pgsql/data",
+										"name": "${APPLICATION_NAME}-data"
+									}
+								]
+							}
+						],
+						"terminationGracePeriodSeconds": 60,
+						"volumes": [
+							{
+								"emptyDir": {
+									"medium": ""
+								},
+								"name": "${APPLICATION_NAME}-data"
+							}
+						]
+					}
+				},
+				"triggers": [
+					{
+						"imageChangeParams": {
+							"automatic": true,
+							"containerNames": [
+								"${APPLICATION_NAME}-postgresql"
+							],
+							"from": {
+								"kind": "ImageStreamTag",
+								"name": "postgresql:${POSTGRESQL_IMAGE_STREAM_TAG}",
+								"namespace": "${IMAGE_STREAM_NAMESPACE}"
+							}
+						},
+						"type": "ImageChange"
+					},
+					{
+						"type": "ConfigChange"
+					}
+				]
+			}
+		}
+	],
+	"parameters": [
+		{
+			"name": "APPLICATION_NAME",
+			"displayName": "Application Name",
+			"description": "The name for the application.",
+			"value": "sso",
+			"required": true
+		},
+		{
+			"name": "HOSTNAME_HTTP",
+			"displayName": "Custom http Route Hostname",
+			"description": "Custom hostname for http service route. Leave blank for default hostname, e.g.: \u003capplication-name\u003e.\u003cproject\u003e.\u003cdefault-domain-suffix\u003e"
+		},
+		{
+			"name": "HOSTNAME_HTTPS",
+			"displayName": "Custom https Route Hostname",
+			"description": "Custom hostname for https service route. Leave blank for default hostname, e.g.: \u003capplication-name\u003e.\u003cproject\u003e.\u003cdefault-domain-suffix\u003e"
+		},
+		{
+			"name": "SSO_HOSTNAME",
+			"displayName": "Custom RH-SSO Server Hostname",
+			"description": "Custom hostname for the RH-SSO server."
+		},
+		{
+			"name": "DB_JNDI",
+			"displayName": "Database JNDI Name",
+			"description": "Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/postgresql",
+			"value": "java:jboss/datasources/KeycloakDS"
+		},
+		{
+			"name": "DB_DATABASE",
+			"displayName": "Database Name",
+			"description": "Database name",
+			"value": "root",
+			"required": true
+		},
+		{
+			"name": "HTTPS_SECRET",
+			"displayName": "Server Keystore Secret Name",
+			"description": "The name of the secret containing the keystore file",
+			"value": "sso-app-secret"
+		},
+		{
+			"name": "HTTPS_KEYSTORE",
+			"displayName": "Server Keystore Filename",
+			"description": "The name of the keystore file within the secret",
+			"value": "keystore.jks"
+		},
+		{
+			"name": "HTTPS_KEYSTORE_TYPE",
+			"displayName": "Server Keystore Type",
+			"description": "The type of the keystore file (JKS or JCEKS)"
+		},
+		{
+			"name": "HTTPS_NAME",
+			"displayName": "Server Certificate Name",
+			"description": "The name associated with the server certificate (e.g. jboss)"
+		},
+		{
+			"name": "HTTPS_PASSWORD",
+			"displayName": "Server Keystore Password",
+			"description": "The password for the keystore and certificate (e.g. mykeystorepass)"
+		},
+		{
+			"name": "DB_MIN_POOL_SIZE",
+			"displayName": "Datasource Minimum Pool Size",
+			"description": "Sets xa-pool/min-pool-size for the configured datasource."
+		},
+		{
+			"name": "DB_MAX_POOL_SIZE",
+			"displayName": "Datasource Maximum Pool Size",
+			"description": "Sets xa-pool/max-pool-size for the configured datasource."
+		},
+		{
+			"name": "DB_TX_ISOLATION",
+			"displayName": "Datasource Transaction Isolation",
+			"description": "Sets transaction-isolation for the configured datasource."
+		},
+		{
+			"name": "POSTGRESQL_MAX_CONNECTIONS",
+			"displayName": "PostgreSQL Maximum number of connections",
+			"description": "The maximum number of client connections allowed. This also sets the maximum number of prepared transactions."
+		},
+		{
+			"name": "POSTGRESQL_SHARED_BUFFERS",
+			"displayName": "PostgreSQL Shared Buffers",
+			"description": "Configures how much memory is dedicated to PostgreSQL for caching data."
+		},
+		{
+			"name": "DB_USERNAME",
+			"displayName": "Database Username",
+			"description": "Database user name",
+			"generate": "expression",
+			"from": "user[a-zA-Z0-9]{3}",
+			"required": true
+		},
+		{
+			"name": "DB_PASSWORD",
+			"displayName": "Database Password",
+			"description": "Database user password",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "JGROUPS_ENCRYPT_SECRET",
+			"displayName": "JGroups Secret Name",
+			"description": "The name of the secret containing the keystore file",
+			"value": "sso-app-secret"
+		},
+		{
+			"name": "JGROUPS_ENCRYPT_KEYSTORE",
+			"displayName": "JGroups Keystore Filename",
+			"description": "The name of the keystore file within the secret",
+			"value": "jgroups.jceks"
+		},
+		{
+			"name": "JGROUPS_ENCRYPT_NAME",
+			"displayName": "JGroups Certificate Name",
+			"description": "The name associated with the server certificate (e.g. secret-key)"
+		},
+		{
+			"name": "JGROUPS_ENCRYPT_PASSWORD",
+			"displayName": "JGroups Keystore Password",
+			"description": "The password for the keystore and certificate (e.g. password)"
+		},
+		{
+			"name": "JGROUPS_CLUSTER_PASSWORD",
+			"displayName": "JGroups Cluster Password",
+			"description": "JGroups cluster password",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "IMAGE_STREAM_NAMESPACE",
+			"displayName": "ImageStream Namespace",
+			"description": "Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.",
+			"value": "openshift",
+			"required": true
+		},
+		{
+			"name": "SSO_ADMIN_USERNAME",
+			"displayName": "RH-SSO Administrator Username",
+			"description": "RH-SSO Server administrator username",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "SSO_ADMIN_PASSWORD",
+			"displayName": "RH-SSO Administrator Password",
+			"description": "RH-SSO Server administrator password",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "SSO_REALM",
+			"displayName": "RH-SSO Realm",
+			"description": "Realm to be created in the RH-SSO server (e.g. demorealm)."
+		},
+		{
+			"name": "SSO_SERVICE_USERNAME",
+			"displayName": "RH-SSO Service Username",
+			"description": "The username used to access the RH-SSO service. This is used by clients to create the appliction client(s) within the specified RH-SSO realm."
+		},
+		{
+			"name": "SSO_SERVICE_PASSWORD",
+			"displayName": "RH-SSO Service Password",
+			"description": "The password for the RH-SSO service user."
+		},
+		{
+			"name": "SSO_TRUSTSTORE",
+			"displayName": "RH-SSO Trust Store",
+			"description": "The name of the truststore file within the secret (e.g. truststore.jks)"
+		},
+		{
+			"name": "SSO_TRUSTSTORE_PASSWORD",
+			"displayName": "RH-SSO Trust Store Password",
+			"description": "The password for the truststore and certificate (e.g. mykeystorepass)"
+		},
+		{
+			"name": "SSO_TRUSTSTORE_SECRET",
+			"displayName": "RH-SSO Trust Store Secret",
+			"description": "The name of the secret containing the truststore file (e.g. truststore-secret). Used for volume secretName",
+			"value": "sso-app-secret"
+		},
+		{
+			"name": "POSTGRESQL_IMAGE_STREAM_TAG",
+			"displayName": "PostgreSQL Image Stream Tag",
+			"description": "The tag to use for the \"postgresql\" image stream. Typically, this aligns with the major.minor version of PostgreSQL.",
+			"value": "10",
+			"required": true
+		},
+		{
+			"name": "MEMORY_LIMIT",
+			"displayName": "Container Memory Limit",
+			"description": "Container memory limit.",
+			"value": "1Gi"
+		}
+	],
+	"labels": {
+		"rhsso": "7.4.1.GA",
+		"template": "sso74-openj9-postgresql"
+	}
+}

--- a/official/sso/templates/sso74-postgresql-persistent.json
+++ b/official/sso/templates/sso74-postgresql-persistent.json
@@ -13,7 +13,7 @@
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
 			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.4 on OpenJDK server based deployment, deployment configuration for PostgreSQL using persistence, and securing RH-SSO communication using passthrough TLS.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "7.4.0.GA"
+			"version": "7.4.1.GA"
 		}
 	},
 	"message": "A new persistent RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
@@ -788,7 +788,7 @@
 		}
 	],
 	"labels": {
-		"rhsso": "7.4.0.GA",
+		"rhsso": "7.4.1.GA",
 		"template": "sso74-postgresql-persistent"
 	}
 }

--- a/official/sso/templates/sso74-postgresql.json
+++ b/official/sso/templates/sso74-postgresql.json
@@ -13,7 +13,7 @@
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
 			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.4 on OpenJDK server based deployment, deployment configuration for PostgreSQL using ephemeral (temporary) storage, and securing RH-SSO communication using passthrough TLS.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "7.4.0.GA"
+			"version": "7.4.1.GA"
 		}
 	},
 	"message": "A new RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
@@ -766,7 +766,7 @@
 		}
 	],
 	"labels": {
-		"rhsso": "7.4.0.GA",
+		"rhsso": "7.4.1.GA",
 		"template": "sso74-postgresql"
 	}
 }


### PR DESCRIPTION
Changes are as follows (they were intentionally left separated into two independent commits, since each of them is fixing different KEYCLOAK JIRA):

1.commit:
```
    [KEYCLOAK-13513] Upgrade templates & imagestream definition for the
    Red Hat Single Sign-On 7.4 for OpenJDK on OpenShift image to version
    v7.4.1.GA
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>
```
2. commit:
```
    [KEYCLOAK-14462] Mark the so far existing RH-SSO 7.4 templates &
    image stream as x86_64 architecture specific.
    
    Also introduce RH-SSO 7.4 templates & imagestream for the s390x
    architecture -- "Red Hat Single Sign-On 7.4 for OpenJ9 on OpenShift"
    release stream, and set their latest version to "v7.4.1.GA" too
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>
```

PTAL (once got a chance)

Thanks! Jan