### PR TITLE
Do not build with -race by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,9 @@ verify-periodic-old: ## Run periodic job verification using the old syntax. Exam
 	hack/verify-periodic-old.sh
 .PHONY: verify-periodic-old
 
-# Using -race here since we are running concurrently
 build: ## Build the library executable. Example: make build
 	@go version
-	go build -mod=vendor -race
+	go build -mod=vendor $(DEBUGFLAGS)
 .PHONY: build
 
 import: ## Run the import script. Example: make import


### PR DESCRIPTION
The -race flag is not supported by gccgo, nor by golang on some
architectures (at least s390x).

See https://github.com/openshift/library/pull/253#issuecomment-693199288

/assign @coreydaley