### PR TITLE
Reinstate nodejs-mongodb-example

### DIFF
--- a/official.yaml
+++ b/official.yaml
@@ -93,6 +93,14 @@ data:
     templates:
       - location: https://raw.githubusercontent.com/sclorg/nodejs-ex/master/openshift/templates/nodejs.json
         docs: https://github.com/sclorg/nodejs-ex/blob/master/README.md
+      - location: https://raw.githubusercontent.com/sclorg/nodejs-ex/master/openshift/templates/nodejs-mongodb.json
+        docs: https://github.com/sclorg/nodejs-ex/blob/master/README.md
+        tags:
+          - okd
+          - ocp
+          - arch_ppc64le
+          - arch_s390x
+          - arch_x86_64
       - location: https://raw.githubusercontent.com/nodeshift-starters/nodejs-rest-http-crud/master/.openshift/postgresql-template.json
         docs: https://github.com/nodeshift-starters/nodejs-rest-http-crud/blob/master/README.md
         tags:

--- a/official/nodejs/templates/nodejs-mongodb-example.json
+++ b/official/nodejs/templates/nodejs-mongodb-example.json
@@ -1,0 +1,539 @@
+{
+	"kind": "Template",
+	"apiVersion": "v1",
+	"metadata": {
+		"name": "nodejs-mongodb-example",
+		"creationTimestamp": null,
+		"annotations": {
+			"description": "An example Node.js application with a MongoDB database. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/nodejs-ex/blob/master/README.md.\n\nWARNING: Any data stored will be lost upon pod destruction. Only use this template for testing.",
+			"iconClass": "icon-nodejs",
+			"openshift.io/display-name": "Node.js + MongoDB (Ephemeral)",
+			"openshift.io/documentation-url": "https://github.com/sclorg/nodejs-ex",
+			"openshift.io/long-description": "This template defines resources needed to develop a NodeJS application, including a build configuration, application deployment configuration, and database deployment configuration.  The database is stored in non-persistent storage, so this configuration should be used for experimental purposes only.",
+			"openshift.io/provider-display-name": "Red Hat, Inc.",
+			"openshift.io/support-url": "https://access.redhat.com",
+			"tags": "quickstart,nodejs,hidden",
+			"template.openshift.io/bindable": "false"
+		}
+	},
+	"message": "The following service(s) have been created in your project: ${NAME}, ${DATABASE_SERVICE_NAME}.\n\nFor more information about using this template, including OpenShift considerations, see https://github.com/sclorg/nodejs-ex/blob/master/README.md.",
+	"objects": [
+		{
+			"apiVersion": "v1",
+			"kind": "Secret",
+			"metadata": {
+				"name": "${NAME}"
+			},
+			"stringData": {
+				"database-admin-password": "${DATABASE_ADMIN_PASSWORD}",
+				"database-password": "${DATABASE_PASSWORD}",
+				"database-user": "${DATABASE_USER}"
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"description": "Exposes and load balances the application pods",
+					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${DATABASE_SERVICE_NAME}\", \"kind\": \"Service\"}]"
+				},
+				"name": "${NAME}"
+			},
+			"spec": {
+				"ports": [
+					{
+						"name": "web",
+						"port": 8080,
+						"targetPort": 8080
+					}
+				],
+				"selector": {
+					"name": "${NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "Route",
+			"metadata": {
+				"name": "${NAME}"
+			},
+			"spec": {
+				"host": "${APPLICATION_DOMAIN}",
+				"to": {
+					"kind": "Service",
+					"name": "${NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "ImageStream",
+			"metadata": {
+				"annotations": {
+					"description": "Keeps track of changes in the application image"
+				},
+				"name": "${NAME}"
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "BuildConfig",
+			"metadata": {
+				"annotations": {
+					"description": "Defines how to build the application",
+					"template.alpha.openshift.io/wait-for-ready": "true"
+				},
+				"name": "${NAME}"
+			},
+			"spec": {
+				"output": {
+					"to": {
+						"kind": "ImageStreamTag",
+						"name": "${NAME}:latest"
+					}
+				},
+				"postCommit": {
+					"script": "npm test"
+				},
+				"source": {
+					"contextDir": "${CONTEXT_DIR}",
+					"git": {
+						"ref": "${SOURCE_REPOSITORY_REF}",
+						"uri": "${SOURCE_REPOSITORY_URL}"
+					},
+					"type": "Git"
+				},
+				"strategy": {
+					"sourceStrategy": {
+						"env": [
+							{
+								"name": "NPM_MIRROR",
+								"value": "${NPM_MIRROR}"
+							}
+						],
+						"from": {
+							"kind": "ImageStreamTag",
+							"name": "nodejs:${NODEJS_VERSION}",
+							"namespace": "${NAMESPACE}"
+						}
+					},
+					"type": "Source"
+				},
+				"triggers": [
+					{
+						"type": "ImageChange"
+					},
+					{
+						"type": "ConfigChange"
+					},
+					{
+						"github": {
+							"secret": "${GITHUB_WEBHOOK_SECRET}"
+						},
+						"type": "GitHub"
+					},
+					{
+						"generic": {
+							"secret": "${GENERIC_WEBHOOK_SECRET}"
+						},
+						"type": "Generic"
+					}
+				]
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "DeploymentConfig",
+			"metadata": {
+				"annotations": {
+					"description": "Defines how to deploy the application server",
+					"template.alpha.openshift.io/wait-for-ready": "true"
+				},
+				"name": "${NAME}"
+			},
+			"spec": {
+				"replicas": 1,
+				"selector": {
+					"name": "${NAME}"
+				},
+				"strategy": {
+					"type": "Recreate"
+				},
+				"template": {
+					"metadata": {
+						"labels": {
+							"name": "${NAME}"
+						},
+						"name": "${NAME}"
+					},
+					"spec": {
+						"containers": [
+							{
+								"env": [
+									{
+										"name": "DATABASE_SERVICE_NAME",
+										"value": "${DATABASE_SERVICE_NAME}"
+									},
+									{
+										"name": "MONGODB_USER",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-user",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "MONGODB_PASSWORD",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-password",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "MONGODB_DATABASE",
+										"value": "${DATABASE_NAME}"
+									},
+									{
+										"name": "MONGODB_ADMIN_PASSWORD",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-admin-password",
+												"name": "${NAME}"
+											}
+										}
+									}
+								],
+								"image": " ",
+								"livenessProbe": {
+									"httpGet": {
+										"path": "/",
+										"port": 8080
+									},
+									"initialDelaySeconds": 30,
+									"timeoutSeconds": 3
+								},
+								"name": "nodejs-mongodb-example",
+								"ports": [
+									{
+										"containerPort": 8080
+									}
+								],
+								"readinessProbe": {
+									"httpGet": {
+										"path": "/",
+										"port": 8080
+									},
+									"initialDelaySeconds": 3,
+									"timeoutSeconds": 3
+								},
+								"resources": {
+									"limits": {
+										"memory": "${MEMORY_LIMIT}"
+									}
+								}
+							}
+						]
+					}
+				},
+				"triggers": [
+					{
+						"imageChangeParams": {
+							"automatic": true,
+							"containerNames": [
+								"nodejs-mongodb-example"
+							],
+							"from": {
+								"kind": "ImageStreamTag",
+								"name": "${NAME}:latest"
+							}
+						},
+						"type": "ImageChange"
+					},
+					{
+						"type": "ConfigChange"
+					}
+				]
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"description": "Exposes the database server"
+				},
+				"name": "${DATABASE_SERVICE_NAME}"
+			},
+			"spec": {
+				"ports": [
+					{
+						"name": "mongodb",
+						"port": 27017,
+						"targetPort": 27017
+					}
+				],
+				"selector": {
+					"name": "${DATABASE_SERVICE_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "DeploymentConfig",
+			"metadata": {
+				"annotations": {
+					"description": "Defines how to deploy the database",
+					"template.alpha.openshift.io/wait-for-ready": "true"
+				},
+				"name": "${DATABASE_SERVICE_NAME}"
+			},
+			"spec": {
+				"replicas": 1,
+				"selector": {
+					"name": "${DATABASE_SERVICE_NAME}"
+				},
+				"strategy": {
+					"type": "Recreate"
+				},
+				"template": {
+					"metadata": {
+						"labels": {
+							"name": "${DATABASE_SERVICE_NAME}"
+						},
+						"name": "${DATABASE_SERVICE_NAME}"
+					},
+					"spec": {
+						"containers": [
+							{
+								"env": [
+									{
+										"name": "MONGODB_USER",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-user",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "MONGODB_PASSWORD",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-password",
+												"name": "${NAME}"
+											}
+										}
+									},
+									{
+										"name": "MONGODB_DATABASE",
+										"value": "${DATABASE_NAME}"
+									},
+									{
+										"name": "MONGODB_ADMIN_PASSWORD",
+										"valueFrom": {
+											"secretKeyRef": {
+												"key": "database-admin-password",
+												"name": "${NAME}"
+											}
+										}
+									}
+								],
+								"image": " ",
+								"livenessProbe": {
+									"initialDelaySeconds": 30,
+									"tcpSocket": {
+										"port": 27017
+									},
+									"timeoutSeconds": 1
+								},
+								"name": "mongodb",
+								"ports": [
+									{
+										"containerPort": 27017
+									}
+								],
+								"readinessProbe": {
+									"exec": {
+										"command": [
+											"/bin/sh",
+											"-i",
+											"-c",
+											"mongo 127.0.0.1:27017/$MONGODB_DATABASE -u $MONGODB_USER -p $MONGODB_PASSWORD --eval=\"quit()\""
+										]
+									},
+									"initialDelaySeconds": 3,
+									"timeoutSeconds": 1
+								},
+								"resources": {
+									"limits": {
+										"memory": "${MEMORY_MONGODB_LIMIT}"
+									}
+								},
+								"volumeMounts": [
+									{
+										"mountPath": "/var/lib/mongodb/data",
+										"name": "${DATABASE_SERVICE_NAME}-data"
+									}
+								]
+							}
+						],
+						"volumes": [
+							{
+								"emptyDir": {
+									"medium": ""
+								},
+								"name": "${DATABASE_SERVICE_NAME}-data"
+							}
+						]
+					}
+				},
+				"triggers": [
+					{
+						"imageChangeParams": {
+							"automatic": true,
+							"containerNames": [
+								"mongodb"
+							],
+							"from": {
+								"kind": "ImageStreamTag",
+								"name": "mongodb:${MONGODB_VERSION}",
+								"namespace": "${NAMESPACE}"
+							}
+						},
+						"type": "ImageChange"
+					},
+					{
+						"type": "ConfigChange"
+					}
+				]
+			}
+		}
+	],
+	"parameters": [
+		{
+			"name": "NAME",
+			"displayName": "Name",
+			"description": "The name assigned to all of the frontend objects defined in this template.",
+			"value": "nodejs-mongodb-example",
+			"required": true
+		},
+		{
+			"name": "NAMESPACE",
+			"displayName": "Namespace",
+			"description": "The OpenShift Namespace where the ImageStream resides.",
+			"value": "openshift",
+			"required": true
+		},
+		{
+			"name": "NODEJS_VERSION",
+			"displayName": "Version of NodeJS Image",
+			"description": "Version of NodeJS image to be used (10, 12, or latest).",
+			"value": "12",
+			"required": true
+		},
+		{
+			"name": "MONGODB_VERSION",
+			"displayName": "Version of MongoDB Image",
+			"description": "Version of MongoDB image to be used (3.6 or latest).",
+			"value": "3.6",
+			"required": true
+		},
+		{
+			"name": "MEMORY_LIMIT",
+			"displayName": "Memory Limit",
+			"description": "Maximum amount of memory the Node.js container can use.",
+			"value": "512Mi",
+			"required": true
+		},
+		{
+			"name": "MEMORY_MONGODB_LIMIT",
+			"displayName": "Memory Limit (MongoDB)",
+			"description": "Maximum amount of memory the MongoDB container can use.",
+			"value": "512Mi",
+			"required": true
+		},
+		{
+			"name": "SOURCE_REPOSITORY_URL",
+			"displayName": "Git Repository URL",
+			"description": "The URL of the repository with your application source code.",
+			"value": "https://github.com/sclorg/nodejs-ex.git",
+			"required": true
+		},
+		{
+			"name": "SOURCE_REPOSITORY_REF",
+			"displayName": "Git Reference",
+			"description": "Set this to a branch name, tag or other ref of your repository if you are not using the default branch."
+		},
+		{
+			"name": "CONTEXT_DIR",
+			"displayName": "Context Directory",
+			"description": "Set this to the relative path to your project if it is not in the root of your repository."
+		},
+		{
+			"name": "APPLICATION_DOMAIN",
+			"displayName": "Application Hostname",
+			"description": "The exposed hostname that will route to the Node.js service, if left blank a value will be defaulted."
+		},
+		{
+			"name": "GITHUB_WEBHOOK_SECRET",
+			"displayName": "GitHub Webhook Secret",
+			"description": "Github trigger secret.  A difficult to guess string encoded as part of the webhook URL.  Not encrypted.",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{40}"
+		},
+		{
+			"name": "GENERIC_WEBHOOK_SECRET",
+			"displayName": "Generic Webhook Secret",
+			"description": "A secret string used to configure the Generic webhook.",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{40}"
+		},
+		{
+			"name": "DATABASE_SERVICE_NAME",
+			"displayName": "Database Service Name",
+			"value": "mongodb",
+			"required": true
+		},
+		{
+			"name": "DATABASE_USER",
+			"displayName": "MongoDB Username",
+			"description": "Username for MongoDB user that will be used for accessing the database.",
+			"generate": "expression",
+			"from": "user[A-Z0-9]{3}"
+		},
+		{
+			"name": "DATABASE_PASSWORD",
+			"displayName": "MongoDB Password",
+			"description": "Password for the MongoDB user.",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{16}"
+		},
+		{
+			"name": "DATABASE_NAME",
+			"displayName": "Database Name",
+			"value": "sampledb",
+			"required": true
+		},
+		{
+			"name": "DATABASE_ADMIN_PASSWORD",
+			"displayName": "Database Administrator Password",
+			"description": "Password for the database admin user.",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{16}"
+		},
+		{
+			"name": "NPM_MIRROR",
+			"displayName": "Custom NPM Mirror URL",
+			"description": "The custom NPM mirror URL"
+		}
+	],
+	"labels": {
+		"app": "nodejs-mongodb-example",
+		"template": "nodejs-mongodb-example"
+	}
+}


### PR DESCRIPTION
This example is still used in image-ecosystem and jenkins e2e tests.
Therefore, leave it in, albeit hidden, until tests can be ported to the
new nodejs-postgresql-example.

/assign @gabemontero