### PR TITLE
Updating imagestreams and templates for JWS 5.4

### DIFF
--- a/official.yaml
+++ b/official.yaml
@@ -10,7 +10,8 @@ variables:
   rhsso74_openj9_version: v7.4.3.GA
   webserver_version: ose-v1.4.17
   webserver3_version: jws31-v1.4
-  webserver5_version: jws53-v1.0
+  webserver5el7_version: jws54el7-v1.0
+  webserver5el8_version: jws54el8-v1.0
   webserver5_openj9_version: jws53openj9el7-v1.1
   ips_ds_version: 6.4.12.GA
   rhdm_version: 7.9.0.GA
@@ -1266,54 +1267,72 @@ data:
           - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-3-openshift-image/{webserver3_version}/templates/jws31-tomcat8-postgresql-s2i.json
         docs: https://github.com/jboss-openshift/application-templates/blob/{webserver_version}/docs/webserver/jws31-tomcat8-postgresql-s2i.adoc
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5_version}/templates/jws53-openjdk8-tomcat9-basic-s2i.json
+      # List the JWS 5 RHEL7 templates below
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk8-tomcat9-rhel7-basic-s2i.json
         tags:
           - ocp
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5_version}/templates/jws53-openjdk8-tomcat9-https-s2i.json
-        tags:
-          - ocp
-          - online-starter
-          - online-professional
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5_version}/templates/jws53-openjdk8-tomcat9-mongodb-persistent-s2i.json
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5_version}/templates/jws53-openjdk8-tomcat9-mongodb-s2i.json
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5_version}/templates/jws53-openjdk8-tomcat9-mysql-persistent-s2i.json
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk8-tomcat9-rhel7-https-s2i.json
         tags:
           - ocp
           - online-starter
           - online-professional
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5_version}/templates/jws53-openjdk8-tomcat9-mysql-s2i.json
-        tags:
-          - ocp
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5_version}/templates/jws53-openjdk8-tomcat9-postgresql-persistent-s2i.json
-        tags:
-          - ocp
-          - online-starter
-          - online-professional
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5_version}/templates/jws53-openjdk8-tomcat9-postgresql-s2i.json
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5_version}/templates/jws53-openjdk11-tomcat9-basic-s2i.json
-        tags:
-          - ocp
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5_version}/templates/jws53-openjdk11-tomcat9-https-s2i.json
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk8-tomcat9-rhel7-mongodb-persistent-s2i.json
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk8-tomcat9-rhel7-mongodb-s2i.json
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk8-tomcat9-rhel7-mysql-persistent-s2i.json
         tags:
           - ocp
           - online-starter
           - online-professional
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5_version}/templates/jws53-openjdk11-tomcat9-mongodb-persistent-s2i.json
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5_version}/templates/jws53-openjdk11-tomcat9-mongodb-s2i.json
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5_version}/templates/jws53-openjdk11-tomcat9-mysql-persistent-s2i.json
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk8-tomcat9-rhel7-mysql-s2i.json
+        tags:
+          - ocp
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk8-tomcat9-rhel7-postgresql-persistent-s2i.json
         tags:
           - ocp
           - online-starter
           - online-professional
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5_version}/templates/jws53-openjdk11-tomcat9-mysql-s2i.json
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk8-tomcat9-rhel7-postgresql-s2i.json
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk11-tomcat9-rhel7-basic-s2i.json
         tags:
           - ocp
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5_version}/templates/jws53-openjdk11-tomcat9-postgresql-persistent-s2i.json
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk11-tomcat9-rhel7-https-s2i.json
         tags:
           - ocp
           - online-starter
           - online-professional
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5_version}/templates/jws53-openjdk11-tomcat9-postgresql-s2i.json
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk11-tomcat9-rhel7-mongodb-persistent-s2i.json
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk11-tomcat9-rhel7-mongodb-s2i.json
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk11-tomcat9-rhel7-mysql-persistent-s2i.json
+        tags:
+          - ocp
+          - online-starter
+          - online-professional
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk11-tomcat9-rhel7-mysql-s2i.json
+        tags:
+          - ocp
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk11-tomcat9-rhel7-postgresql-persistent-s2i.json
+        tags:
+          - ocp
+          - online-starter
+          - online-professional
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk11-tomcat9-rhel7-postgresql-s2i.json
+      # List the JWS 5 UBI8 templates below
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el8_version}/templates/jws54-openjdk8-tomcat9-ubi8-basic-s2i.json
+        tags:
+          - ocp
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el8_version}/templates/jws54-openjdk8-tomcat9-ubi8-https-s2i.json
+        tags:
+          - ocp
+          - online-starter
+          - online-professional
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el8_version}/templates/jws54-openjdk11-tomcat9-ubi8-basic-s2i.json
+        tags:
+          - ocp
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el8_version}/templates/jws54-openjdk11-tomcat9-ubi8-https-s2i.json
+        tags:
+          - ocp
+          - online-starter
+          - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5_openj9_version}/templates/jws53-openj9-tomcat9-rhel7-basic-s2i.json
         tags:
           - ocp
@@ -1354,14 +1373,23 @@ data:
           - ocp
           - online-starter
           - online-professional
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5_version}/templates/jws53-openjdk8-tomcat9-image-stream.json
-        suffix: rhel7
+      # List the JWS 5 imagestreams below
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk8-tomcat9-rhel7-image-stream.json
         tags:
           - ocp
           - online-starter
           - online-professional
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5_version}/templates/jws53-openjdk11-tomcat9-image-stream.json
-        suffix: rhel7
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk11-tomcat9-rhel7-image-stream.json
+        tags:
+          - ocp
+          - online-starter
+          - online-professional
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el8_version}/templates/jws54-openjdk8-tomcat9-ubi8-image-stream.json
+        tags:
+          - ocp
+          - online-starter
+          - online-professional
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el8_version}/templates/jws54-openjdk11-tomcat9-ubi8-image-stream.json
         tags:
           - ocp
           - online-starter

--- a/official.yaml
+++ b/official.yaml
@@ -1279,18 +1279,18 @@ data:
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk8-tomcat9-rhel7-mongodb-persistent-s2i.json
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk8-tomcat9-rhel7-mongodb-s2i.json
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk8-tomcat9-rhel7-mysql-persistent-s2i.json
-        tags:
-          - ocp
-          - online-starter
-          - online-professional
+        #tags:
+        #  - ocp
+        #  - online-starter
+        #  - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk8-tomcat9-rhel7-mysql-s2i.json
-        tags:
-          - ocp
+        #tags:
+        #  - ocp
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk8-tomcat9-rhel7-postgresql-persistent-s2i.json
-        tags:
-          - ocp
-          - online-starter
-          - online-professional
+        #tags:
+        #  - ocp
+        #  - online-starter
+        #  - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk8-tomcat9-rhel7-postgresql-s2i.json
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk11-tomcat9-rhel7-basic-s2i.json
         tags:
@@ -1303,18 +1303,18 @@ data:
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk11-tomcat9-rhel7-mongodb-persistent-s2i.json
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk11-tomcat9-rhel7-mongodb-s2i.json
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk11-tomcat9-rhel7-mysql-persistent-s2i.json
-        tags:
-          - ocp
-          - online-starter
-          - online-professional
+        #tags:
+        #  - ocp
+        #  - online-starter
+        #  - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk11-tomcat9-rhel7-mysql-s2i.json
-        tags:
-          - ocp
+        #tags:
+        #  - ocp
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk11-tomcat9-rhel7-postgresql-persistent-s2i.json
-        tags:
-          - ocp
-          - online-starter
-          - online-professional
+        #tags:
+        #  - ocp
+        #  - online-starter
+        #  - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk11-tomcat9-rhel7-postgresql-s2i.json
       # List the JWS 5 UBI8 templates below
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el8_version}/templates/jws54-openjdk8-tomcat9-ubi8-basic-s2i.json

--- a/official/webserver/imagestreams/jboss-webserver54-openjdk11-tomcat9-openshift-rhel7.json
+++ b/official/webserver/imagestreams/jboss-webserver54-openjdk11-tomcat9-openshift-rhel7.json
@@ -1,0 +1,67 @@
+{
+	"kind": "ImageStream",
+	"apiVersion": "v1",
+	"metadata": {
+		"name": "jboss-webserver54-openjdk11-tomcat9-openshift-rhel7",
+		"creationTimestamp": null,
+		"annotations": {
+			"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK11 on RHEL7",
+			"openshift.io/provider-display-name": "Red Hat, Inc.",
+			"version": "1.0"
+		}
+	},
+	"spec": {
+		"lookupPolicy": {
+			"local": false
+		},
+		"tags": [
+			{
+				"name": "latest",
+				"annotations": {
+					"description": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK11 on RHEL7 S2I images.",
+					"iconClass": "icon-rh-tomcat",
+					"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK11 on RHEL7",
+					"sampleContextDir": "tomcat-websocket-chat",
+					"sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
+					"supports": "tomcat9:5.4,tomcat:9,java:11",
+					"tags": "builder,tomcat,tomcat9,java,jboss,hidden",
+					"version": "latest"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/jboss-webserver-5/webserver54-openjdk11-tomcat9-openshift-rhel7:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "1.0",
+				"annotations": {
+					"description": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK11 on RHEL7 S2I images.",
+					"iconClass": "icon-rh-tomcat",
+					"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK11 on RHEL7",
+					"sampleContextDir": "tomcat-websocket-chat",
+					"sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
+					"supports": "tomcat9:5.4,tomcat:9,java:11",
+					"tags": "builder,tomcat,tomcat9,java,jboss,hidden",
+					"version": "1.0"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/jboss-webserver-5/webserver54-openjdk11-tomcat9-openshift-rhel7:1.0"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			}
+		]
+	},
+	"status": {
+		"dockerImageRepository": ""
+	}
+}

--- a/official/webserver/imagestreams/jboss-webserver54-openjdk11-tomcat9-openshift-ubi8.json
+++ b/official/webserver/imagestreams/jboss-webserver54-openjdk11-tomcat9-openshift-ubi8.json
@@ -2,10 +2,10 @@
 	"kind": "ImageStream",
 	"apiVersion": "v1",
 	"metadata": {
-		"name": "jboss-webserver53-openjdk8-tomcat9-openshift",
+		"name": "jboss-webserver54-openjdk11-tomcat9-openshift-ubi8",
 		"creationTimestamp": null,
 		"annotations": {
-			"openshift.io/display-name": "JBoss Web Server 5.3 Apache Tomcat 9 OpenJDK8",
+			"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK11 on UBI8",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
 			"version": "1.0"
 		}
@@ -18,18 +18,18 @@
 			{
 				"name": "latest",
 				"annotations": {
-					"description": "JBoss Web Server 5.3 Apache Tomcat 9 OpenJDK8 S2I images.",
+					"description": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK11 on UBI8 S2I images.",
 					"iconClass": "icon-rh-tomcat",
-					"openshift.io/display-name": "JBoss Web Server 5.3 Apache Tomcat 9 OpenJDK8",
+					"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK11 on UBI8",
 					"sampleContextDir": "tomcat-websocket-chat",
 					"sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-					"supports": "tomcat9:5.3,tomcat:9,java:8",
+					"supports": "tomcat9:5.4,tomcat:9,java:11",
 					"tags": "builder,tomcat,tomcat9,java,jboss,hidden",
 					"version": "latest"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/jboss-webserver-5/webserver53-openjdk8-tomcat9-openshift-rhel7:latest"
+					"name": "registry.redhat.io/jboss-webserver-5/webserver54-openjdk11-tomcat9-openshift-rhel8:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -40,18 +40,18 @@
 			{
 				"name": "1.0",
 				"annotations": {
-					"description": "JBoss Web Server 5.3 Apache Tomcat 9 OpenJDK8 S2I images.",
+					"description": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK11 on UBI8 S2I images.",
 					"iconClass": "icon-rh-tomcat",
-					"openshift.io/display-name": "JBoss Web Server 5.3 Apache Tomcat 9 OpenJDK8",
+					"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK11 on UBI8",
 					"sampleContextDir": "tomcat-websocket-chat",
 					"sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-					"supports": "tomcat9:5.3,tomcat:9,java:8",
+					"supports": "tomcat9:5.4,tomcat:9,java:11",
 					"tags": "builder,tomcat,tomcat9,java,jboss,hidden",
 					"version": "1.0"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/jboss-webserver-5/webserver53-openjdk8-tomcat9-openshift-rhel7:1.0"
+					"name": "registry.redhat.io/jboss-webserver-5/webserver54-openjdk11-tomcat9-openshift-rhel8:1.0"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/official/webserver/imagestreams/jboss-webserver54-openjdk8-tomcat9-openshift-rhel7.json
+++ b/official/webserver/imagestreams/jboss-webserver54-openjdk8-tomcat9-openshift-rhel7.json
@@ -2,10 +2,10 @@
 	"kind": "ImageStream",
 	"apiVersion": "v1",
 	"metadata": {
-		"name": "jboss-webserver53-openjdk11-tomcat9-openshift",
+		"name": "jboss-webserver54-openjdk8-tomcat9-openshift-rhel7",
 		"creationTimestamp": null,
 		"annotations": {
-			"openshift.io/display-name": "JBoss Web Server 5.3 Apache Tomcat 9 OpenJDK11",
+			"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK8 on RHEL7",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
 			"version": "1.0"
 		}
@@ -18,18 +18,18 @@
 			{
 				"name": "latest",
 				"annotations": {
-					"description": "JBoss Web Server 5.3 Apache Tomcat 9 OpenJDK11 S2I images.",
+					"description": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK8 on RHEL7 S2I images.",
 					"iconClass": "icon-rh-tomcat",
-					"openshift.io/display-name": "JBoss Web Server 5.3 Apache Tomcat 9 OpenJDK11",
+					"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK8 on RHEL7",
 					"sampleContextDir": "tomcat-websocket-chat",
 					"sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-					"supports": "tomcat9:5.3,tomcat:9,java:11",
+					"supports": "tomcat9:5.4,tomcat:9,java:8",
 					"tags": "builder,tomcat,tomcat9,java,jboss,hidden",
 					"version": "latest"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/jboss-webserver-5/webserver53-openjdk11-tomcat9-openshift-rhel7:latest"
+					"name": "registry.redhat.io/jboss-webserver-5/webserver54-openjdk8-tomcat9-openshift-rhel7:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -40,18 +40,18 @@
 			{
 				"name": "1.0",
 				"annotations": {
-					"description": "JBoss Web Server 5.3 Apache Tomcat 9 OpenJDK11 S2I images.",
+					"description": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK8 on RHEL7 S2I images.",
 					"iconClass": "icon-rh-tomcat",
-					"openshift.io/display-name": "JBoss Web Server 5.3 Apache Tomcat 9 OpenJDK11",
+					"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK8 on RHEL7",
 					"sampleContextDir": "tomcat-websocket-chat",
 					"sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-					"supports": "tomcat9:5.3,tomcat:9,java:11",
+					"supports": "tomcat9:5.4,tomcat:9,java:8",
 					"tags": "builder,tomcat,tomcat9,java,jboss,hidden",
 					"version": "1.0"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/jboss-webserver-5/webserver53-openjdk11-tomcat9-openshift-rhel7:1.0"
+					"name": "registry.redhat.io/jboss-webserver-5/webserver54-openjdk8-tomcat9-openshift-rhel7:1.0"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/official/webserver/imagestreams/jboss-webserver54-openjdk8-tomcat9-openshift-ubi8.json
+++ b/official/webserver/imagestreams/jboss-webserver54-openjdk8-tomcat9-openshift-ubi8.json
@@ -1,0 +1,67 @@
+{
+	"kind": "ImageStream",
+	"apiVersion": "v1",
+	"metadata": {
+		"name": "jboss-webserver54-openjdk8-tomcat9-openshift-ubi8",
+		"creationTimestamp": null,
+		"annotations": {
+			"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK8 on UBI8",
+			"openshift.io/provider-display-name": "Red Hat, Inc.",
+			"version": "1.0"
+		}
+	},
+	"spec": {
+		"lookupPolicy": {
+			"local": false
+		},
+		"tags": [
+			{
+				"name": "latest",
+				"annotations": {
+					"description": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK8 on UBI8 S2I images.",
+					"iconClass": "icon-rh-tomcat",
+					"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK8 on UBI8",
+					"sampleContextDir": "tomcat-websocket-chat",
+					"sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
+					"supports": "tomcat9:5.4,tomcat:9,java:8",
+					"tags": "builder,tomcat,tomcat9,java,jboss,hidden",
+					"version": "latest"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/jboss-webserver-5/webserver54-openjdk8-tomcat9-openshift-rhel8:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "1.0",
+				"annotations": {
+					"description": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK8 on UBI8 S2I images.",
+					"iconClass": "icon-rh-tomcat",
+					"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK8 on UBI8",
+					"sampleContextDir": "tomcat-websocket-chat",
+					"sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
+					"supports": "tomcat9:5.4,tomcat:9,java:8",
+					"tags": "builder,tomcat,tomcat9,java,jboss,hidden",
+					"version": "1.0"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/jboss-webserver-5/webserver54-openjdk8-tomcat9-openshift-rhel8:1.0"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			}
+		]
+	},
+	"status": {
+		"dockerImageRepository": ""
+	}
+}

--- a/official/webserver/templates/jws54-openjdk11-tomcat9-rhel7-basic-s2i.json
+++ b/official/webserver/templates/jws54-openjdk11-tomcat9-rhel7-basic-s2i.json
@@ -1,0 +1,316 @@
+{
+	"kind": "Template",
+	"apiVersion": "v1",
+	"metadata": {
+		"name": "jws54-openjdk11-tomcat9-rhel7-basic-s2i",
+		"creationTimestamp": null,
+		"annotations": {
+			"description": "An example JBoss Web Server application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
+			"iconClass": "icon-rh-tomcat",
+			"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK11 on RHEL7 (no https)",
+			"openshift.io/provider-display-name": "Red Hat, Inc.",
+			"tags": "tomcat,tomcat9,java,jboss",
+			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-web-server/",
+			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.4 Apache Tomcat 9 based application, including a build configuration, and an application deployment configuration.",
+			"template.openshift.io/support-url": "https://access.redhat.com",
+			"version": "1.0"
+		}
+	},
+	"message": "A new JWS application for Apache Tomcat 9 has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}.",
+	"objects": [
+		{
+			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"description": "The web server's http port."
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}"
+			},
+			"spec": {
+				"ports": [
+					{
+						"port": 8080,
+						"targetPort": 8080
+					}
+				],
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"id": "${APPLICATION_NAME}-http",
+			"kind": "Route",
+			"metadata": {
+				"annotations": {
+					"description": "Route for application's http service."
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}"
+			},
+			"spec": {
+				"host": "${HOSTNAME_HTTP}",
+				"to": {
+					"name": "${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "ImageStream",
+			"metadata": {
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}"
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "BuildConfig",
+			"metadata": {
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}"
+			},
+			"spec": {
+				"output": {
+					"to": {
+						"kind": "ImageStreamTag",
+						"name": "${APPLICATION_NAME}:latest"
+					}
+				},
+				"source": {
+					"contextDir": "${CONTEXT_DIR}",
+					"git": {
+						"ref": "${SOURCE_REPOSITORY_REF}",
+						"uri": "${SOURCE_REPOSITORY_URL}"
+					},
+					"type": "Git"
+				},
+				"strategy": {
+					"sourceStrategy": {
+						"env": [
+							{
+								"name": "MAVEN_MIRROR_URL",
+								"value": "${MAVEN_MIRROR_URL}"
+							},
+							{
+								"name": "ARTIFACT_DIR",
+								"value": "${ARTIFACT_DIR}"
+							}
+						],
+						"forcePull": true,
+						"from": {
+							"kind": "ImageStreamTag",
+							"name": "jboss-webserver54-openjdk11-tomcat9-openshift-rhel7:1.0",
+							"namespace": "${IMAGE_STREAM_NAMESPACE}"
+						}
+					},
+					"type": "Source"
+				},
+				"triggers": [
+					{
+						"github": {
+							"secret": "${GITHUB_WEBHOOK_SECRET}"
+						},
+						"type": "GitHub"
+					},
+					{
+						"generic": {
+							"secret": "${GENERIC_WEBHOOK_SECRET}"
+						},
+						"type": "Generic"
+					},
+					{
+						"imageChange": {},
+						"type": "ImageChange"
+					},
+					{
+						"type": "ConfigChange"
+					}
+				]
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "DeploymentConfig",
+			"metadata": {
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}"
+			},
+			"spec": {
+				"replicas": 1,
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}"
+				},
+				"strategy": {
+					"type": "Recreate"
+				},
+				"template": {
+					"metadata": {
+						"labels": {
+							"application": "${APPLICATION_NAME}",
+							"deploymentConfig": "${APPLICATION_NAME}"
+						},
+						"name": "${APPLICATION_NAME}"
+					},
+					"spec": {
+						"containers": [
+							{
+								"env": [
+									{
+										"name": "JWS_ADMIN_USERNAME",
+										"value": "${JWS_ADMIN_USERNAME}"
+									},
+									{
+										"name": "JWS_ADMIN_PASSWORD",
+										"value": "${JWS_ADMIN_PASSWORD}"
+									}
+								],
+								"image": "${APPLICATION_NAME}",
+								"imagePullPolicy": "Always",
+								"name": "${APPLICATION_NAME}",
+								"ports": [
+									{
+										"containerPort": 8778,
+										"name": "jolokia",
+										"protocol": "TCP"
+									},
+									{
+										"containerPort": 8080,
+										"name": "http",
+										"protocol": "TCP"
+									}
+								],
+								"readinessProbe": {
+									"exec": {
+										"command": [
+											"/bin/bash",
+											"-c",
+											"curl --noproxy '*' -is 'http://localhost:8080/health' | grep -iq '\"status\": \"UP\"'"
+										]
+									}
+								}
+							}
+						],
+						"terminationGracePeriodSeconds": 60
+					}
+				},
+				"triggers": [
+					{
+						"imageChangeParams": {
+							"automatic": true,
+							"containerNames": [
+								"${APPLICATION_NAME}"
+							],
+							"from": {
+								"kind": "ImageStreamTag",
+								"name": "${APPLICATION_NAME}:latest"
+							}
+						},
+						"type": "ImageChange"
+					},
+					{
+						"type": "ConfigChange"
+					}
+				]
+			}
+		}
+	],
+	"parameters": [
+		{
+			"name": "APPLICATION_NAME",
+			"displayName": "Application Name",
+			"description": "The name for the application.",
+			"value": "jws-app",
+			"required": true
+		},
+		{
+			"name": "HOSTNAME_HTTP",
+			"displayName": "Custom http Route Hostname",
+			"description": "Custom hostname for http service route.  Leave blank for default hostname, e.g.: \u003capplication-name\u003e-\u003cproject\u003e.\u003cdefault-domain-suffix\u003e"
+		},
+		{
+			"name": "SOURCE_REPOSITORY_URL",
+			"displayName": "Git Repository URL",
+			"description": "Git source URI for application",
+			"value": "https://github.com/jboss-openshift/openshift-quickstarts.git",
+			"required": true
+		},
+		{
+			"name": "SOURCE_REPOSITORY_REF",
+			"displayName": "Git Reference",
+			"description": "Git branch/tag reference",
+			"value": "1.2"
+		},
+		{
+			"name": "CONTEXT_DIR",
+			"displayName": "Context Directory",
+			"description": "Path within Git project to build; empty for root project directory.",
+			"value": "tomcat-websocket-chat"
+		},
+		{
+			"name": "JWS_ADMIN_USERNAME",
+			"displayName": "JWS Admin Username",
+			"description": "JWS Admin User",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "JWS_ADMIN_PASSWORD",
+			"displayName": "JWS Admin Password",
+			"description": "JWS Admin Password",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "GITHUB_WEBHOOK_SECRET",
+			"displayName": "Github Webhook Secret",
+			"description": "GitHub trigger secret",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "GENERIC_WEBHOOK_SECRET",
+			"displayName": "Generic Webhook Secret",
+			"description": "Generic build trigger secret",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "IMAGE_STREAM_NAMESPACE",
+			"displayName": "ImageStream Namespace",
+			"description": "Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.",
+			"value": "openshift",
+			"required": true
+		},
+		{
+			"name": "MAVEN_MIRROR_URL",
+			"displayName": "Maven mirror URL",
+			"description": "Maven mirror to use for S2I builds"
+		},
+		{
+			"name": "ARTIFACT_DIR",
+			"description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied."
+		}
+	],
+	"labels": {
+		"jws54jdk11el7": "1.0",
+		"template": "jws54-openjdk11-tomcat9-rhel7-basic-s2i"
+	}
+}

--- a/official/webserver/templates/jws54-openjdk11-tomcat9-rhel7-https-s2i.json
+++ b/official/webserver/templates/jws54-openjdk11-tomcat9-rhel7-https-s2i.json
@@ -2,26 +2,28 @@
 	"kind": "Template",
 	"apiVersion": "v1",
 	"metadata": {
-		"name": "jws53-openjdk8-tomcat9-mongodb-s2i",
+		"name": "jws54-openjdk11-tomcat9-rhel7-https-s2i",
 		"creationTimestamp": null,
 		"annotations": {
-			"description": "Application template for JWS MongoDB applications built using S2I.",
+			"description": "An example JBoss Web Server application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
 			"iconClass": "icon-rh-tomcat",
-			"openshift.io/display-name": "JBoss Web Server 5.3 Apache Tomcat 9 OpenJDK8 + MongoDB (Ephemeral with https)",
+			"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK11 on RHEL7 (with https)",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
 			"tags": "tomcat,tomcat9,java,jboss,hidden",
+			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-web-server/",
+			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.4 Apache Tomcat 9 based application, including a build configuration, application deployment configuration, and secure communication using https.",
+			"template.openshift.io/support-url": "https://access.redhat.com",
 			"version": "1.0"
 		}
 	},
-	"message": "A new JWS application for Apache Tomcat 9 (using MongoDB) has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}. For accessing the MongoDB database \"${DB_DATABASE}\" use the credentials ${DB_USERNAME}/${DB_PASSWORD} (Admin password is \"${DB_ADMIN_PASSWORD}\"). Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
+	"message": "A new JWS application for Apache Tomcat 9 has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}. Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
 	"objects": [
 		{
 			"apiVersion": "v1",
 			"kind": "Service",
 			"metadata": {
 				"annotations": {
-					"description": "The web server's http port.",
-					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mongodb\", \"kind\": \"Service\"}]"
+					"description": "The web server's http port."
 				},
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -45,8 +47,7 @@
 			"kind": "Service",
 			"metadata": {
 				"annotations": {
-					"description": "The web server's https port.",
-					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mongodb\", \"kind\": \"Service\"}]"
+					"description": "The web server's https port."
 				},
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -62,30 +63,6 @@
 				],
 				"selector": {
 					"deploymentConfig": "${APPLICATION_NAME}"
-				}
-			}
-		},
-		{
-			"apiVersion": "v1",
-			"kind": "Service",
-			"metadata": {
-				"annotations": {
-					"description": "The database server's port."
-				},
-				"labels": {
-					"application": "${APPLICATION_NAME}"
-				},
-				"name": "${APPLICATION_NAME}-mongodb"
-			},
-			"spec": {
-				"ports": [
-					{
-						"port": 27017,
-						"targetPort": 27017
-					}
-				],
-				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-mongodb"
 				}
 			}
 		},
@@ -181,7 +158,7 @@
 						"forcePull": true,
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "jboss-webserver53-openjdk8-tomcat9-openshift:1.0",
+							"name": "jboss-webserver54-openjdk11-tomcat9-openshift-rhel7:1.0",
 							"namespace": "${IMAGE_STREAM_NAMESPACE}"
 						}
 					},
@@ -240,42 +217,6 @@
 							{
 								"env": [
 									{
-										"name": "DB_SERVICE_PREFIX_MAPPING",
-										"value": "${APPLICATION_NAME}-mongodb=DB"
-									},
-									{
-										"name": "DB_JNDI",
-										"value": "${DB_JNDI}"
-									},
-									{
-										"name": "DB_USERNAME",
-										"value": "${DB_USERNAME}"
-									},
-									{
-										"name": "DB_PASSWORD",
-										"value": "${DB_PASSWORD}"
-									},
-									{
-										"name": "DB_DATABASE",
-										"value": "${DB_DATABASE}"
-									},
-									{
-										"name": "DB_ADMIN_PASSWORD",
-										"value": "${DB_ADMIN_PASSWORD}"
-									},
-									{
-										"name": "DB_MIN_POOL_SIZE",
-										"value": "${DB_MIN_POOL_SIZE}"
-									},
-									{
-										"name": "DB_MAX_POOL_SIZE",
-										"value": "${DB_MAX_POOL_SIZE}"
-									},
-									{
-										"name": "DB_TX_ISOLATION",
-										"value": "${DB_TX_ISOLATION}"
-									},
-									{
 										"name": "JWS_HTTPS_CERTIFICATE_DIR",
 										"value": "/etc/jws-secret-volume"
 									},
@@ -325,7 +266,7 @@
 										"command": [
 											"/bin/bash",
 											"-c",
-											"curl --noproxy '*' -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer\u0026att=stateName' |grep -iq 'stateName *= *STARTED'"
+											"curl --noproxy '*' -is 'http://localhost:8080/health' | grep -iq '\"status\": \"UP\"'"
 										]
 									}
 								},
@@ -368,132 +309,6 @@
 					}
 				]
 			}
-		},
-		{
-			"apiVersion": "v1",
-			"kind": "DeploymentConfig",
-			"metadata": {
-				"labels": {
-					"application": "${APPLICATION_NAME}"
-				},
-				"name": "${APPLICATION_NAME}-mongodb"
-			},
-			"spec": {
-				"replicas": 1,
-				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-mongodb"
-				},
-				"strategy": {
-					"type": "Recreate"
-				},
-				"template": {
-					"metadata": {
-						"labels": {
-							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}-mongodb"
-						},
-						"name": "${APPLICATION_NAME}-mongodb"
-					},
-					"spec": {
-						"containers": [
-							{
-								"env": [
-									{
-										"name": "MONGODB_USER",
-										"value": "${DB_USERNAME}"
-									},
-									{
-										"name": "MONGODB_PASSWORD",
-										"value": "${DB_PASSWORD}"
-									},
-									{
-										"name": "MONGODB_DATABASE",
-										"value": "${DB_DATABASE}"
-									},
-									{
-										"name": "MONGODB_ADMIN_PASSWORD",
-										"value": "${DB_ADMIN_PASSWORD}"
-									},
-									{
-										"name": "MONGODB_NOPREALLOC",
-										"value": "${MONGODB_NOPREALLOC}"
-									},
-									{
-										"name": "MONGODB_SMALLFILES",
-										"value": "${MONGODB_SMALLFILES}"
-									},
-									{
-										"name": "MONGODB_QUIET",
-										"value": "${MONGODB_QUIET}"
-									}
-								],
-								"image": "mongodb",
-								"imagePullPolicy": "Always",
-								"livenessProbe": {
-									"initialDelaySeconds": 30,
-									"tcpSocket": {
-										"port": 27017
-									},
-									"timeoutSeconds": 1
-								},
-								"name": "${APPLICATION_NAME}-mongodb",
-								"ports": [
-									{
-										"containerPort": 27017,
-										"protocol": "TCP"
-									}
-								],
-								"readinessProbe": {
-									"exec": {
-										"command": [
-											"/bin/sh",
-											"-i",
-											"-c",
-											"mongo 127.0.0.1:27017/$MONGODB_DATABASE -u $MONGODB_USER -p $MONGODB_PASSWORD --eval=\"quit()\""
-										]
-									},
-									"initialDelaySeconds": 3,
-									"timeoutSeconds": 1
-								},
-								"volumeMounts": [
-									{
-										"mountPath": "/var/lib/mongodb/data",
-										"name": "${APPLICATION_NAME}-data"
-									}
-								]
-							}
-						],
-						"terminationGracePeriodSeconds": 60,
-						"volumes": [
-							{
-								"emptyDir": {
-									"medium": ""
-								},
-								"name": "${APPLICATION_NAME}-data"
-							}
-						]
-					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${APPLICATION_NAME}-mongodb"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "mongodb:${MONGODB_IMAGE_STREAM_TAG}",
-								"namespace": "${IMAGE_STREAM_NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
-			}
 		}
 	],
 	"parameters": [
@@ -518,7 +333,7 @@
 			"name": "SOURCE_REPOSITORY_URL",
 			"displayName": "Git Repository URL",
 			"description": "Git source URI for application",
-			"value": "https://github.com/jboss-openshift/openshift-quickstarts",
+			"value": "https://github.com/jboss-openshift/openshift-quickstarts.git",
 			"required": true
 		},
 		{
@@ -531,19 +346,7 @@
 			"name": "CONTEXT_DIR",
 			"displayName": "Context Directory",
 			"description": "Path within Git project to build; empty for root project directory.",
-			"value": "todolist/todolist-mongodb"
-		},
-		{
-			"name": "DB_JNDI",
-			"displayName": "Database JNDI Name",
-			"description": "Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb"
-		},
-		{
-			"name": "DB_DATABASE",
-			"displayName": "Database Name",
-			"description": "Database name",
-			"value": "root",
-			"required": true
+			"value": "tomcat-websocket-chat"
 		},
 		{
 			"name": "JWS_HTTPS_SECRET",
@@ -568,60 +371,6 @@
 			"name": "JWS_HTTPS_CERTIFICATE_PASSWORD",
 			"displayName": "Certificate Password",
 			"description": "The certificate password"
-		},
-		{
-			"name": "DB_MIN_POOL_SIZE",
-			"displayName": "Datasource Minimum Pool Size",
-			"description": "Sets xa-pool/min-pool-size for the configured datasource."
-		},
-		{
-			"name": "DB_MAX_POOL_SIZE",
-			"displayName": "Datasource Maximum Pool Size",
-			"description": "Sets xa-pool/max-pool-size for the configured datasource."
-		},
-		{
-			"name": "DB_TX_ISOLATION",
-			"displayName": "Datasource Transaction Isolation",
-			"description": "Sets transaction-isolation for the configured datasource."
-		},
-		{
-			"name": "MONGODB_NOPREALLOC",
-			"displayName": "MongoDB No Preallocation",
-			"description": "Disable data file preallocation."
-		},
-		{
-			"name": "MONGODB_SMALLFILES",
-			"displayName": "MongoDB Small Files",
-			"description": "Set MongoDB to use a smaller default data file size."
-		},
-		{
-			"name": "MONGODB_QUIET",
-			"displayName": "MongoDB Quiet",
-			"description": "Runs MongoDB in a quiet mode that attempts to limit the amount of output."
-		},
-		{
-			"name": "DB_USERNAME",
-			"displayName": "Database Username",
-			"description": "Database user name",
-			"generate": "expression",
-			"from": "user[a-zA-Z0-9]{3}",
-			"required": true
-		},
-		{
-			"name": "DB_PASSWORD",
-			"displayName": "Database Password",
-			"description": "Database user password",
-			"generate": "expression",
-			"from": "[a-zA-Z0-9]{8}",
-			"required": true
-		},
-		{
-			"name": "DB_ADMIN_PASSWORD",
-			"displayName": "Database admin password",
-			"description": "Database admin password",
-			"generate": "expression",
-			"from": "[a-zA-Z0-9]{8}",
-			"required": true
 		},
 		{
 			"name": "JWS_ADMIN_USERNAME",
@@ -670,17 +419,10 @@
 		{
 			"name": "ARTIFACT_DIR",
 			"description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied."
-		},
-		{
-			"name": "MONGODB_IMAGE_STREAM_TAG",
-			"displayName": "MongoDB Image Stream Tag",
-			"description": "The tag to use for the \"mongodb\" image stream.  Typically, this aligns with the major.minor version of MongoDB.",
-			"value": "3.2",
-			"required": true
 		}
 	],
 	"labels": {
-		"jws53": "1.0",
-		"template": "jws53-openjdk8-tomcat9-mongodb-s2i"
+		"jws54jdk11el7": "1.0",
+		"template": "jws54-openjdk11-tomcat9-rhel7-https-s2i"
 	}
 }

--- a/official/webserver/templates/jws54-openjdk11-tomcat9-rhel7-mongodb-persistent-s2i.json
+++ b/official/webserver/templates/jws54-openjdk11-tomcat9-rhel7-mongodb-persistent-s2i.json
@@ -1,0 +1,716 @@
+{
+	"kind": "Template",
+	"apiVersion": "v1",
+	"metadata": {
+		"name": "jws54-openjdk11-tomcat9-rhel7-mongodb-persistent-s2i",
+		"creationTimestamp": null,
+		"annotations": {
+			"description": "An example JBoss Web Server application with a MongoDB database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
+			"iconClass": "icon-rh-tomcat",
+			"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK11 on RHEL7 + MongoDB (with https)",
+			"openshift.io/provider-display-name": "Red Hat, Inc.",
+			"tags": "tomcat,tomcat9,java,jboss",
+			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-web-server/",
+			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.4 Apache Tomcat 9 based application, including a build configuration, application deployment configuration, database deployment configuration for MongoDB using persistence and secure communication using https.",
+			"template.openshift.io/support-url": "https://access.redhat.com",
+			"version": "1.0"
+		}
+	},
+	"message": "A new persistent JWS application for Apache Tomcat 9 (using MongoDB) has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}. For accessing the MongoDB database \"${DB_DATABASE}\" use the credentials ${DB_USERNAME}/${DB_PASSWORD} (Admin password is \"${DB_ADMIN_PASSWORD}\"). Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
+	"objects": [
+		{
+			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"description": "The web server's http port.",
+					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mongodb\", \"kind\": \"Service\"}]"
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}"
+			},
+			"spec": {
+				"ports": [
+					{
+						"port": 8080,
+						"targetPort": 8080
+					}
+				],
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"description": "The web server's https port.",
+					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mongodb\", \"kind\": \"Service\"}]"
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "secure-${APPLICATION_NAME}"
+			},
+			"spec": {
+				"ports": [
+					{
+						"port": 8443,
+						"targetPort": 8443
+					}
+				],
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"description": "The database server's port."
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}-mongodb"
+			},
+			"spec": {
+				"ports": [
+					{
+						"port": 27017,
+						"targetPort": 27017
+					}
+				],
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}-mongodb"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"id": "${APPLICATION_NAME}-http",
+			"kind": "Route",
+			"metadata": {
+				"annotations": {
+					"description": "Route for application's http service."
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}"
+			},
+			"spec": {
+				"host": "${HOSTNAME_HTTP}",
+				"to": {
+					"name": "${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"id": "${APPLICATION_NAME}-https",
+			"kind": "Route",
+			"metadata": {
+				"annotations": {
+					"description": "Route for application's https service."
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "secure-${APPLICATION_NAME}"
+			},
+			"spec": {
+				"host": "${HOSTNAME_HTTPS}",
+				"tls": {
+					"termination": "passthrough"
+				},
+				"to": {
+					"name": "secure-${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "ImageStream",
+			"metadata": {
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}"
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "BuildConfig",
+			"metadata": {
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}"
+			},
+			"spec": {
+				"output": {
+					"to": {
+						"kind": "ImageStreamTag",
+						"name": "${APPLICATION_NAME}:latest"
+					}
+				},
+				"source": {
+					"contextDir": "${CONTEXT_DIR}",
+					"git": {
+						"ref": "${SOURCE_REPOSITORY_REF}",
+						"uri": "${SOURCE_REPOSITORY_URL}"
+					},
+					"type": "Git"
+				},
+				"strategy": {
+					"sourceStrategy": {
+						"env": [
+							{
+								"name": "MAVEN_MIRROR_URL",
+								"value": "${MAVEN_MIRROR_URL}"
+							},
+							{
+								"name": "ARTIFACT_DIR",
+								"value": "${ARTIFACT_DIR}"
+							}
+						],
+						"forcePull": true,
+						"from": {
+							"kind": "ImageStreamTag",
+							"name": "jboss-webserver54-openjdk11-tomcat9-openshift-rhel7:1.0",
+							"namespace": "${IMAGE_STREAM_NAMESPACE}"
+						}
+					},
+					"type": "Source"
+				},
+				"triggers": [
+					{
+						"github": {
+							"secret": "${GITHUB_WEBHOOK_SECRET}"
+						},
+						"type": "GitHub"
+					},
+					{
+						"generic": {
+							"secret": "${GENERIC_WEBHOOK_SECRET}"
+						},
+						"type": "Generic"
+					},
+					{
+						"imageChange": {},
+						"type": "ImageChange"
+					},
+					{
+						"type": "ConfigChange"
+					}
+				]
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "DeploymentConfig",
+			"metadata": {
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}"
+			},
+			"spec": {
+				"replicas": 1,
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}"
+				},
+				"strategy": {
+					"type": "Recreate"
+				},
+				"template": {
+					"metadata": {
+						"labels": {
+							"application": "${APPLICATION_NAME}",
+							"deploymentConfig": "${APPLICATION_NAME}"
+						},
+						"name": "${APPLICATION_NAME}"
+					},
+					"spec": {
+						"containers": [
+							{
+								"env": [
+									{
+										"name": "DB_SERVICE_PREFIX_MAPPING",
+										"value": "${APPLICATION_NAME}-mongodb=DB"
+									},
+									{
+										"name": "DB_JNDI",
+										"value": "${DB_JNDI}"
+									},
+									{
+										"name": "DB_USERNAME",
+										"value": "${DB_USERNAME}"
+									},
+									{
+										"name": "DB_PASSWORD",
+										"value": "${DB_PASSWORD}"
+									},
+									{
+										"name": "DB_DATABASE",
+										"value": "${DB_DATABASE}"
+									},
+									{
+										"name": "DB_ADMIN_PASSWORD",
+										"value": "${DB_ADMIN_PASSWORD}"
+									},
+									{
+										"name": "DB_MIN_POOL_SIZE",
+										"value": "${DB_MIN_POOL_SIZE}"
+									},
+									{
+										"name": "DB_MAX_POOL_SIZE",
+										"value": "${DB_MAX_POOL_SIZE}"
+									},
+									{
+										"name": "DB_TX_ISOLATION",
+										"value": "${DB_TX_ISOLATION}"
+									},
+									{
+										"name": "JWS_HTTPS_CERTIFICATE_DIR",
+										"value": "/etc/jws-secret-volume"
+									},
+									{
+										"name": "JWS_HTTPS_CERTIFICATE",
+										"value": "${JWS_HTTPS_CERTIFICATE}"
+									},
+									{
+										"name": "JWS_HTTPS_CERTIFICATE_KEY",
+										"value": "${JWS_HTTPS_CERTIFICATE_KEY}"
+									},
+									{
+										"name": "JWS_HTTPS_CERTIFICATE_PASSWORD",
+										"value": "${JWS_HTTPS_CERTIFICATE_PASSWORD}"
+									},
+									{
+										"name": "JWS_ADMIN_USERNAME",
+										"value": "${JWS_ADMIN_USERNAME}"
+									},
+									{
+										"name": "JWS_ADMIN_PASSWORD",
+										"value": "${JWS_ADMIN_PASSWORD}"
+									}
+								],
+								"image": "${APPLICATION_NAME}",
+								"imagePullPolicy": "Always",
+								"name": "${APPLICATION_NAME}",
+								"ports": [
+									{
+										"containerPort": 8778,
+										"name": "jolokia",
+										"protocol": "TCP"
+									},
+									{
+										"containerPort": 8080,
+										"name": "http",
+										"protocol": "TCP"
+									},
+									{
+										"containerPort": 8443,
+										"name": "https",
+										"protocol": "TCP"
+									}
+								],
+								"readinessProbe": {
+									"exec": {
+										"command": [
+											"/bin/bash",
+											"-c",
+											"curl --noproxy '*' -is 'http://localhost:8080/health' | grep -iq '\"status\": \"UP\"'"
+										]
+									}
+								},
+								"volumeMounts": [
+									{
+										"mountPath": "/etc/jws-secret-volume",
+										"name": "jws-certificate-volume",
+										"readOnly": true
+									}
+								]
+							}
+						],
+						"terminationGracePeriodSeconds": 60,
+						"volumes": [
+							{
+								"name": "jws-certificate-volume",
+								"secret": {
+									"secretName": "${JWS_HTTPS_SECRET}"
+								}
+							}
+						]
+					}
+				},
+				"triggers": [
+					{
+						"imageChangeParams": {
+							"automatic": true,
+							"containerNames": [
+								"${APPLICATION_NAME}"
+							],
+							"from": {
+								"kind": "ImageStreamTag",
+								"name": "${APPLICATION_NAME}:latest"
+							}
+						},
+						"type": "ImageChange"
+					},
+					{
+						"type": "ConfigChange"
+					}
+				]
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "DeploymentConfig",
+			"metadata": {
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}-mongodb"
+			},
+			"spec": {
+				"replicas": 1,
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}-mongodb"
+				},
+				"strategy": {
+					"type": "Recreate"
+				},
+				"template": {
+					"metadata": {
+						"labels": {
+							"application": "${APPLICATION_NAME}",
+							"deploymentConfig": "${APPLICATION_NAME}-mongodb"
+						},
+						"name": "${APPLICATION_NAME}-mongodb"
+					},
+					"spec": {
+						"containers": [
+							{
+								"env": [
+									{
+										"name": "MONGODB_USER",
+										"value": "${DB_USERNAME}"
+									},
+									{
+										"name": "MONGODB_PASSWORD",
+										"value": "${DB_PASSWORD}"
+									},
+									{
+										"name": "MONGODB_DATABASE",
+										"value": "${DB_DATABASE}"
+									},
+									{
+										"name": "MONGODB_ADMIN_PASSWORD",
+										"value": "${DB_ADMIN_PASSWORD}"
+									},
+									{
+										"name": "MONGODB_NOPREALLOC",
+										"value": "${MONGODB_NOPREALLOC}"
+									},
+									{
+										"name": "MONGODB_SMALLFILES",
+										"value": "${MONGODB_SMALLFILES}"
+									},
+									{
+										"name": "MONGODB_QUIET",
+										"value": "${MONGODB_QUIET}"
+									}
+								],
+								"image": "mongodb",
+								"imagePullPolicy": "Always",
+								"livenessProbe": {
+									"initialDelaySeconds": 30,
+									"tcpSocket": {
+										"port": 27017
+									},
+									"timeoutSeconds": 1
+								},
+								"name": "${APPLICATION_NAME}-mongodb",
+								"ports": [
+									{
+										"containerPort": 27017,
+										"protocol": "TCP"
+									}
+								],
+								"readinessProbe": {
+									"exec": {
+										"command": [
+											"/bin/sh",
+											"-i",
+											"-c",
+											"mongo 127.0.0.1:27017/$MONGODB_DATABASE -u $MONGODB_USER -p $MONGODB_PASSWORD --eval=\"quit()\""
+										]
+									},
+									"initialDelaySeconds": 3,
+									"timeoutSeconds": 1
+								},
+								"volumeMounts": [
+									{
+										"mountPath": "/var/lib/mongodb/data",
+										"name": "${APPLICATION_NAME}-mongodb-pvol"
+									}
+								]
+							}
+						],
+						"terminationGracePeriodSeconds": 60,
+						"volumes": [
+							{
+								"name": "${APPLICATION_NAME}-mongodb-pvol",
+								"persistentVolumeClaim": {
+									"claimName": "${APPLICATION_NAME}-mongodb-claim"
+								}
+							}
+						]
+					}
+				},
+				"triggers": [
+					{
+						"imageChangeParams": {
+							"automatic": true,
+							"containerNames": [
+								"${APPLICATION_NAME}-mongodb"
+							],
+							"from": {
+								"kind": "ImageStreamTag",
+								"name": "mongodb:${MONGODB_IMAGE_STREAM_TAG}",
+								"namespace": "${IMAGE_STREAM_NAMESPACE}"
+							}
+						},
+						"type": "ImageChange"
+					},
+					{
+						"type": "ConfigChange"
+					}
+				]
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "PersistentVolumeClaim",
+			"metadata": {
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}-mongodb-claim"
+			},
+			"spec": {
+				"accessModes": [
+					"ReadWriteOnce"
+				],
+				"resources": {
+					"requests": {
+						"storage": "${VOLUME_CAPACITY}"
+					}
+				}
+			}
+		}
+	],
+	"parameters": [
+		{
+			"name": "APPLICATION_NAME",
+			"displayName": "Application Name",
+			"description": "The name for the application.",
+			"value": "jws-app",
+			"required": true
+		},
+		{
+			"name": "HOSTNAME_HTTP",
+			"displayName": "Custom http Route Hostname",
+			"description": "Custom hostname for http service route.  Leave blank for default hostname, e.g.: \u003capplication-name\u003e-\u003cproject\u003e.\u003cdefault-domain-suffix\u003e"
+		},
+		{
+			"name": "HOSTNAME_HTTPS",
+			"displayName": "Custom https Route Hostname",
+			"description": "Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-\u003capplication-name\u003e-\u003cproject\u003e.\u003cdefault-domain-suffix\u003e"
+		},
+		{
+			"name": "SOURCE_REPOSITORY_URL",
+			"displayName": "Git Repository URL",
+			"description": "Git source URI for application",
+			"value": "https://github.com/jboss-openshift/openshift-quickstarts",
+			"required": true
+		},
+		{
+			"name": "SOURCE_REPOSITORY_REF",
+			"displayName": "Git Reference",
+			"description": "Git branch/tag reference",
+			"value": "1.2"
+		},
+		{
+			"name": "CONTEXT_DIR",
+			"displayName": "Context Directory",
+			"description": "Path within Git project to build; empty for root project directory.",
+			"value": "todolist/todolist-mongodb"
+		},
+		{
+			"name": "DB_JNDI",
+			"displayName": "Database JNDI Name",
+			"description": "Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb"
+		},
+		{
+			"name": "DB_DATABASE",
+			"displayName": "Database Name",
+			"description": "Database name",
+			"value": "root",
+			"required": true
+		},
+		{
+			"name": "VOLUME_CAPACITY",
+			"displayName": "Database Volume Capacity",
+			"description": "Size of persistent storage for database volume.",
+			"value": "1Gi",
+			"required": true
+		},
+		{
+			"name": "JWS_HTTPS_SECRET",
+			"displayName": "Secret Name",
+			"description": "The name of the secret containing the certificate files",
+			"value": "jws-app-secret",
+			"required": true
+		},
+		{
+			"name": "JWS_HTTPS_CERTIFICATE",
+			"displayName": "Certificate Name",
+			"description": "The name of the certificate file within the secret",
+			"value": "server.crt"
+		},
+		{
+			"name": "JWS_HTTPS_CERTIFICATE_KEY",
+			"displayName": "Certificate Key Name",
+			"description": "The name of the certificate key file within the secret",
+			"value": "server.key"
+		},
+		{
+			"name": "JWS_HTTPS_CERTIFICATE_PASSWORD",
+			"displayName": "Certificate Password",
+			"description": "The certificate password"
+		},
+		{
+			"name": "DB_MIN_POOL_SIZE",
+			"displayName": "Datasource Minimum Pool Size",
+			"description": "Sets xa-pool/min-pool-size for the configured datasource."
+		},
+		{
+			"name": "DB_MAX_POOL_SIZE",
+			"displayName": "Datasource Maximum Pool Size",
+			"description": "Sets xa-pool/max-pool-size for the configured datasource."
+		},
+		{
+			"name": "DB_TX_ISOLATION",
+			"displayName": "Datasource Transaction Isolation",
+			"description": "Sets transaction-isolation for the configured datasource."
+		},
+		{
+			"name": "MONGODB_NOPREALLOC",
+			"displayName": "MongoDB No Preallocation",
+			"description": "Disable data file preallocation."
+		},
+		{
+			"name": "MONGODB_SMALLFILES",
+			"displayName": "MongoDB Small Files",
+			"description": "Set MongoDB to use a smaller default data file size."
+		},
+		{
+			"name": "MONGODB_QUIET",
+			"displayName": "MongoDB Quiet",
+			"description": "Runs MongoDB in a quiet mode that attempts to limit the amount of output."
+		},
+		{
+			"name": "DB_USERNAME",
+			"displayName": "Database Username",
+			"description": "Database user name",
+			"generate": "expression",
+			"from": "user[a-zA-Z0-9]{3}",
+			"required": true
+		},
+		{
+			"name": "DB_PASSWORD",
+			"displayName": "Database Password",
+			"description": "Database user password",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "DB_ADMIN_PASSWORD",
+			"displayName": "Database admin password",
+			"description": "Database admin password",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "JWS_ADMIN_USERNAME",
+			"displayName": "JWS Admin Username",
+			"description": "JWS Admin User",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "JWS_ADMIN_PASSWORD",
+			"displayName": "JWS Admin Password",
+			"description": "JWS Admin Password",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "GITHUB_WEBHOOK_SECRET",
+			"displayName": "Github Webhook Secret",
+			"description": "GitHub trigger secret",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "GENERIC_WEBHOOK_SECRET",
+			"displayName": "Generic Webhook Secret",
+			"description": "Generic build trigger secret",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "IMAGE_STREAM_NAMESPACE",
+			"displayName": "ImageStream Namespace",
+			"description": "Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.",
+			"value": "openshift",
+			"required": true
+		},
+		{
+			"name": "MAVEN_MIRROR_URL",
+			"displayName": "Maven mirror URL",
+			"description": "Maven mirror to use for S2I builds"
+		},
+		{
+			"name": "ARTIFACT_DIR",
+			"description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied."
+		},
+		{
+			"name": "MONGODB_IMAGE_STREAM_TAG",
+			"displayName": "MongoDB Image Stream Tag",
+			"description": "The tag to use for the \"mongodb\" image stream.  Typically, this aligns with the major.minor version of MongoDB.",
+			"value": "3.2",
+			"required": true
+		}
+	],
+	"labels": {
+		"jws54jdk11el7": "1.0",
+		"template": "jws54-openjdk11-tomcat9-rhel7-mongodb-persistent-s2i"
+	}
+}

--- a/official/webserver/templates/jws54-openjdk11-tomcat9-rhel7-mongodb-s2i.json
+++ b/official/webserver/templates/jws54-openjdk11-tomcat9-rhel7-mongodb-s2i.json
@@ -2,21 +2,18 @@
 	"kind": "Template",
 	"apiVersion": "v1",
 	"metadata": {
-		"name": "jws53-openjdk11-tomcat9-mysql-persistent-s2i",
+		"name": "jws54-openjdk11-tomcat9-rhel7-mongodb-s2i",
 		"creationTimestamp": null,
 		"annotations": {
-			"description": "An example JBoss Web Server application with a MySQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
+			"description": "Application template for JWS MongoDB applications built using S2I.",
 			"iconClass": "icon-rh-tomcat",
-			"openshift.io/display-name": "JBoss Web Server 5.3 Apache Tomcat 9 OpenJDK11+ MySQL (with https)",
+			"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK11 on RHEL7 + MongoDB (Ephemeral with https)",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
-			"tags": "tomcat,tomcat9,java,jboss",
-			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-web-server/",
-			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.3 Apache Tomcat 9 based application, including a build configuration, application deployment configuration, database deployment configuration for MySQL using persistence and secure communication using https.",
-			"template.openshift.io/support-url": "https://access.redhat.com",
+			"tags": "tomcat,tomcat9,java,jboss,hidden",
 			"version": "1.0"
 		}
 	},
-	"message": "A new persistent JWS application for Apache Tomcat 9 (using MySQL) has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}. For accessing the MySQL database \"${DB_DATABASE}\" use the credentials ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
+	"message": "A new JWS application for Apache Tomcat 9 (using MongoDB) has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}. For accessing the MongoDB database \"${DB_DATABASE}\" use the credentials ${DB_USERNAME}/${DB_PASSWORD} (Admin password is \"${DB_ADMIN_PASSWORD}\"). Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
 	"objects": [
 		{
 			"apiVersion": "v1",
@@ -24,7 +21,7 @@
 			"metadata": {
 				"annotations": {
 					"description": "The web server's http port.",
-					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mysql\", \"kind\": \"Service\"}]"
+					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mongodb\", \"kind\": \"Service\"}]"
 				},
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -49,7 +46,7 @@
 			"metadata": {
 				"annotations": {
 					"description": "The web server's https port.",
-					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mysql\", \"kind\": \"Service\"}]"
+					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mongodb\", \"kind\": \"Service\"}]"
 				},
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -78,17 +75,17 @@
 				"labels": {
 					"application": "${APPLICATION_NAME}"
 				},
-				"name": "${APPLICATION_NAME}-mysql"
+				"name": "${APPLICATION_NAME}-mongodb"
 			},
 			"spec": {
 				"ports": [
 					{
-						"port": 3306,
-						"targetPort": 3306
+						"port": 27017,
+						"targetPort": 27017
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-mysql"
+					"deploymentConfig": "${APPLICATION_NAME}-mongodb"
 				}
 			}
 		},
@@ -184,7 +181,7 @@
 						"forcePull": true,
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "jboss-webserver53-openjdk11-tomcat9-openshift:1.0",
+							"name": "jboss-webserver54-openjdk11-tomcat9-openshift-rhel7:1.0",
 							"namespace": "${IMAGE_STREAM_NAMESPACE}"
 						}
 					},
@@ -244,7 +241,7 @@
 								"env": [
 									{
 										"name": "DB_SERVICE_PREFIX_MAPPING",
-										"value": "${APPLICATION_NAME}-mysql=DB"
+										"value": "${APPLICATION_NAME}-mongodb=DB"
 									},
 									{
 										"name": "DB_JNDI",
@@ -261,6 +258,10 @@
 									{
 										"name": "DB_DATABASE",
 										"value": "${DB_DATABASE}"
+									},
+									{
+										"name": "DB_ADMIN_PASSWORD",
+										"value": "${DB_ADMIN_PASSWORD}"
 									},
 									{
 										"name": "DB_MIN_POOL_SIZE",
@@ -324,7 +325,7 @@
 										"command": [
 											"/bin/bash",
 											"-c",
-											"curl --noproxy '*' -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer\u0026att=stateName' |grep -iq 'stateName *= *STARTED'"
+											"curl --noproxy '*' -is 'http://localhost:8080/health' | grep -iq '\"status\": \"UP\"'"
 										]
 									}
 								},
@@ -375,12 +376,12 @@
 				"labels": {
 					"application": "${APPLICATION_NAME}"
 				},
-				"name": "${APPLICATION_NAME}-mysql"
+				"name": "${APPLICATION_NAME}-mongodb"
 			},
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-mysql"
+					"deploymentConfig": "${APPLICATION_NAME}-mongodb"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -389,59 +390,56 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}-mysql"
+							"deploymentConfig": "${APPLICATION_NAME}-mongodb"
 						},
-						"name": "${APPLICATION_NAME}-mysql"
+						"name": "${APPLICATION_NAME}-mongodb"
 					},
 					"spec": {
 						"containers": [
 							{
 								"env": [
 									{
-										"name": "MYSQL_USER",
+										"name": "MONGODB_USER",
 										"value": "${DB_USERNAME}"
 									},
 									{
-										"name": "MYSQL_PASSWORD",
+										"name": "MONGODB_PASSWORD",
 										"value": "${DB_PASSWORD}"
 									},
 									{
-										"name": "MYSQL_DATABASE",
+										"name": "MONGODB_DATABASE",
 										"value": "${DB_DATABASE}"
 									},
 									{
-										"name": "MYSQL_LOWER_CASE_TABLE_NAMES",
-										"value": "${MYSQL_LOWER_CASE_TABLE_NAMES}"
+										"name": "MONGODB_ADMIN_PASSWORD",
+										"value": "${DB_ADMIN_PASSWORD}"
 									},
 									{
-										"name": "MYSQL_MAX_CONNECTIONS",
-										"value": "${MYSQL_MAX_CONNECTIONS}"
+										"name": "MONGODB_NOPREALLOC",
+										"value": "${MONGODB_NOPREALLOC}"
 									},
 									{
-										"name": "MYSQL_FT_MIN_WORD_LEN",
-										"value": "${MYSQL_FT_MIN_WORD_LEN}"
+										"name": "MONGODB_SMALLFILES",
+										"value": "${MONGODB_SMALLFILES}"
 									},
 									{
-										"name": "MYSQL_FT_MAX_WORD_LEN",
-										"value": "${MYSQL_FT_MAX_WORD_LEN}"
-									},
-									{
-										"name": "MYSQL_AIO",
-										"value": "${MYSQL_AIO}"
+										"name": "MONGODB_QUIET",
+										"value": "${MONGODB_QUIET}"
 									}
 								],
-								"image": "mysql",
+								"image": "mongodb",
+								"imagePullPolicy": "Always",
 								"livenessProbe": {
 									"initialDelaySeconds": 30,
 									"tcpSocket": {
-										"port": 3306
+										"port": 27017
 									},
 									"timeoutSeconds": 1
 								},
-								"name": "${APPLICATION_NAME}-mysql",
+								"name": "${APPLICATION_NAME}-mongodb",
 								"ports": [
 									{
-										"containerPort": 3306,
+										"containerPort": 27017,
 										"protocol": "TCP"
 									}
 								],
@@ -451,16 +449,16 @@
 											"/bin/sh",
 											"-i",
 											"-c",
-											"MYSQL_PWD=\"$MYSQL_PASSWORD\" mysql -h 127.0.0.1 -u $MYSQL_USER -D $MYSQL_DATABASE -e 'SELECT 1'"
+											"mongo 127.0.0.1:27017/$MONGODB_DATABASE -u $MONGODB_USER -p $MONGODB_PASSWORD --eval=\"quit()\""
 										]
 									},
-									"initialDelaySeconds": 5,
+									"initialDelaySeconds": 3,
 									"timeoutSeconds": 1
 								},
 								"volumeMounts": [
 									{
-										"mountPath": "/var/lib/mysql/data",
-										"name": "${APPLICATION_NAME}-mysql-pvol"
+										"mountPath": "/var/lib/mongodb/data",
+										"name": "${APPLICATION_NAME}-data"
 									}
 								]
 							}
@@ -468,10 +466,10 @@
 						"terminationGracePeriodSeconds": 60,
 						"volumes": [
 							{
-								"name": "${APPLICATION_NAME}-mysql-pvol",
-								"persistentVolumeClaim": {
-									"claimName": "${APPLICATION_NAME}-mysql-claim"
-								}
+								"emptyDir": {
+									"medium": ""
+								},
+								"name": "${APPLICATION_NAME}-data"
 							}
 						]
 					}
@@ -481,11 +479,11 @@
 						"imageChangeParams": {
 							"automatic": true,
 							"containerNames": [
-								"${APPLICATION_NAME}-mysql"
+								"${APPLICATION_NAME}-mongodb"
 							],
 							"from": {
 								"kind": "ImageStreamTag",
-								"name": "mysql:${MYSQL_IMAGE_STREAM_TAG}",
+								"name": "mongodb:${MONGODB_IMAGE_STREAM_TAG}",
 								"namespace": "${IMAGE_STREAM_NAMESPACE}"
 							}
 						},
@@ -495,26 +493,6 @@
 						"type": "ConfigChange"
 					}
 				]
-			}
-		},
-		{
-			"apiVersion": "v1",
-			"kind": "PersistentVolumeClaim",
-			"metadata": {
-				"labels": {
-					"application": "${APPLICATION_NAME}"
-				},
-				"name": "${APPLICATION_NAME}-mysql-claim"
-			},
-			"spec": {
-				"accessModes": [
-					"ReadWriteOnce"
-				],
-				"resources": {
-					"requests": {
-						"storage": "${VOLUME_CAPACITY}"
-					}
-				}
 			}
 		}
 	],
@@ -553,26 +531,18 @@
 			"name": "CONTEXT_DIR",
 			"displayName": "Context Directory",
 			"description": "Path within Git project to build; empty for root project directory.",
-			"value": "todolist/todolist-jdbc"
+			"value": "todolist/todolist-mongodb"
 		},
 		{
 			"name": "DB_JNDI",
 			"displayName": "Database JNDI Name",
-			"description": "Database JNDI name used by application to resolve the datasource, e.g. jboss/datasources/mysqlDS",
-			"value": "jboss/datasources/defaultDS"
+			"description": "Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb"
 		},
 		{
 			"name": "DB_DATABASE",
 			"displayName": "Database Name",
 			"description": "Database name",
 			"value": "root",
-			"required": true
-		},
-		{
-			"name": "VOLUME_CAPACITY",
-			"displayName": "Database Volume Capacity",
-			"description": "Size of persistent storage for database volume.",
-			"value": "1Gi",
 			"required": true
 		},
 		{
@@ -615,29 +585,19 @@
 			"description": "Sets transaction-isolation for the configured datasource."
 		},
 		{
-			"name": "MYSQL_LOWER_CASE_TABLE_NAMES",
-			"displayName": "MySQL Lower Case Table Names",
-			"description": "Sets how the table names are stored and compared."
+			"name": "MONGODB_NOPREALLOC",
+			"displayName": "MongoDB No Preallocation",
+			"description": "Disable data file preallocation."
 		},
 		{
-			"name": "MYSQL_MAX_CONNECTIONS",
-			"displayName": "MySQL Maximum number of connections",
-			"description": "The maximum permitted number of simultaneous client connections."
+			"name": "MONGODB_SMALLFILES",
+			"displayName": "MongoDB Small Files",
+			"description": "Set MongoDB to use a smaller default data file size."
 		},
 		{
-			"name": "MYSQL_FT_MIN_WORD_LEN",
-			"displayName": "MySQL FullText Minimum Word Length",
-			"description": "The minimum length of the word to be included in a FULLTEXT index."
-		},
-		{
-			"name": "MYSQL_FT_MAX_WORD_LEN",
-			"displayName": "MySQL FullText Maximum Word Length",
-			"description": "The maximum length of the word to be included in a FULLTEXT index."
-		},
-		{
-			"name": "MYSQL_AIO",
-			"displayName": "MySQL AIO",
-			"description": "Controls the innodb_use_native_aio setting value if the native AIO is broken."
+			"name": "MONGODB_QUIET",
+			"displayName": "MongoDB Quiet",
+			"description": "Runs MongoDB in a quiet mode that attempts to limit the amount of output."
 		},
 		{
 			"name": "DB_USERNAME",
@@ -651,6 +611,14 @@
 			"name": "DB_PASSWORD",
 			"displayName": "Database Password",
 			"description": "Database user password",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "DB_ADMIN_PASSWORD",
+			"displayName": "Database admin password",
+			"description": "Database admin password",
 			"generate": "expression",
 			"from": "[a-zA-Z0-9]{8}",
 			"required": true
@@ -704,15 +672,15 @@
 			"description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied."
 		},
 		{
-			"name": "MYSQL_IMAGE_STREAM_TAG",
-			"displayName": "MySQL Image Stream Tag",
-			"description": "The tag to use for the \"mysql\" image stream.  Typically, this aligns with the major.minor version of MySQL.",
-			"value": "5.7",
+			"name": "MONGODB_IMAGE_STREAM_TAG",
+			"displayName": "MongoDB Image Stream Tag",
+			"description": "The tag to use for the \"mongodb\" image stream.  Typically, this aligns with the major.minor version of MongoDB.",
+			"value": "3.2",
 			"required": true
 		}
 	],
 	"labels": {
-		"jws53": "1.0",
-		"template": "jws53-openjdk11-tomcat9-mysql-persistent-s2i"
+		"jws54jdk11el7": "1.0",
+		"template": "jws54-openjdk11-tomcat9-rhel7-mongodb-s2i"
 	}
 }

--- a/official/webserver/templates/jws54-openjdk11-tomcat9-rhel7-mysql-persistent-s2i.json
+++ b/official/webserver/templates/jws54-openjdk11-tomcat9-rhel7-mysql-persistent-s2i.json
@@ -2,18 +2,21 @@
 	"kind": "Template",
 	"apiVersion": "v1",
 	"metadata": {
-		"name": "jws53-openjdk8-tomcat9-postgresql-s2i",
+		"name": "jws54-openjdk11-tomcat9-rhel7-mysql-persistent-s2i",
 		"creationTimestamp": null,
 		"annotations": {
-			"description": "Application template for JWS PostgreSQL applications built using S2I.",
+			"description": "An example JBoss Web Server application with a MySQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
 			"iconClass": "icon-rh-tomcat",
-			"openshift.io/display-name": "JBoss Web Server 5.3 Apache Tomcat 9 OpenJDK8 + PostgreSQL (Ephemeral with https)",
+			"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK11 on RHEL7 + MySQL (with https)",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
-			"tags": "tomcat,tomcat9,java,jboss,hidden",
+			"tags": "tomcat,tomcat9,java,jboss",
+			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-web-server/",
+			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.4 Apache Tomcat 9 based application, including a build configuration, application deployment configuration, database deployment configuration for MySQL using persistence and secure communication using https.",
+			"template.openshift.io/support-url": "https://access.redhat.com",
 			"version": "1.0"
 		}
 	},
-	"message": "A new JWS application for Apache Tomcat 9 (using PostgreSQL) has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}. For accessing the PostgreSQL database \"${DB_DATABASE}\" use the credentials ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
+	"message": "A new persistent JWS application for Apache Tomcat 9 (using MySQL) has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}. For accessing the MySQL database \"${DB_DATABASE}\" use the credentials ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
 	"objects": [
 		{
 			"apiVersion": "v1",
@@ -21,7 +24,7 @@
 			"metadata": {
 				"annotations": {
 					"description": "The web server's http port.",
-					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-postgresql\", \"kind\": \"Service\"}]"
+					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mysql\", \"kind\": \"Service\"}]"
 				},
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -46,7 +49,7 @@
 			"metadata": {
 				"annotations": {
 					"description": "The web server's https port.",
-					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-postgresql\", \"kind\": \"Service\"}]"
+					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mysql\", \"kind\": \"Service\"}]"
 				},
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -75,17 +78,17 @@
 				"labels": {
 					"application": "${APPLICATION_NAME}"
 				},
-				"name": "${APPLICATION_NAME}-postgresql"
+				"name": "${APPLICATION_NAME}-mysql"
 			},
 			"spec": {
 				"ports": [
 					{
-						"port": 5432,
-						"targetPort": 5432
+						"port": 3306,
+						"targetPort": 3306
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deploymentConfig": "${APPLICATION_NAME}-mysql"
 				}
 			}
 		},
@@ -181,7 +184,7 @@
 						"forcePull": true,
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "jboss-webserver53-openjdk8-tomcat9-openshift:1.0",
+							"name": "jboss-webserver54-openjdk11-tomcat9-openshift-rhel7:1.0",
 							"namespace": "${IMAGE_STREAM_NAMESPACE}"
 						}
 					},
@@ -241,7 +244,7 @@
 								"env": [
 									{
 										"name": "DB_SERVICE_PREFIX_MAPPING",
-										"value": "${APPLICATION_NAME}-postgresql=DB"
+										"value": "${APPLICATION_NAME}-mysql=DB"
 									},
 									{
 										"name": "DB_JNDI",
@@ -321,7 +324,7 @@
 										"command": [
 											"/bin/bash",
 											"-c",
-											"curl --noproxy '*' -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer\u0026att=stateName' |grep -iq 'stateName *= *STARTED'"
+											"curl --noproxy '*' -is 'http://localhost:8080/health' | grep -iq '\"status\": \"UP\"'"
 										]
 									}
 								},
@@ -334,6 +337,7 @@
 								]
 							}
 						],
+						"terminationGracePeriodSeconds": 60,
 						"volumes": [
 							{
 								"name": "jws-certificate-volume",
@@ -371,12 +375,12 @@
 				"labels": {
 					"application": "${APPLICATION_NAME}"
 				},
-				"name": "${APPLICATION_NAME}-postgresql"
+				"name": "${APPLICATION_NAME}-mysql"
 			},
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deploymentConfig": "${APPLICATION_NAME}-mysql"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -385,51 +389,59 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+							"deploymentConfig": "${APPLICATION_NAME}-mysql"
 						},
-						"name": "${APPLICATION_NAME}-postgresql"
+						"name": "${APPLICATION_NAME}-mysql"
 					},
 					"spec": {
 						"containers": [
 							{
 								"env": [
 									{
-										"name": "POSTGRESQL_USER",
+										"name": "MYSQL_USER",
 										"value": "${DB_USERNAME}"
 									},
 									{
-										"name": "POSTGRESQL_PASSWORD",
+										"name": "MYSQL_PASSWORD",
 										"value": "${DB_PASSWORD}"
 									},
 									{
-										"name": "POSTGRESQL_DATABASE",
+										"name": "MYSQL_DATABASE",
 										"value": "${DB_DATABASE}"
 									},
 									{
-										"name": "POSTGRESQL_MAX_CONNECTIONS",
-										"value": "${POSTGRESQL_MAX_CONNECTIONS}"
+										"name": "MYSQL_LOWER_CASE_TABLE_NAMES",
+										"value": "${MYSQL_LOWER_CASE_TABLE_NAMES}"
 									},
 									{
-										"name": "POSTGRESQL_MAX_PREPARED_TRANSACTIONS",
-										"value": "${POSTGRESQL_MAX_CONNECTIONS}"
+										"name": "MYSQL_MAX_CONNECTIONS",
+										"value": "${MYSQL_MAX_CONNECTIONS}"
 									},
 									{
-										"name": "POSTGRESQL_SHARED_BUFFERS",
-										"value": "${POSTGRESQL_SHARED_BUFFERS}"
+										"name": "MYSQL_FT_MIN_WORD_LEN",
+										"value": "${MYSQL_FT_MIN_WORD_LEN}"
+									},
+									{
+										"name": "MYSQL_FT_MAX_WORD_LEN",
+										"value": "${MYSQL_FT_MAX_WORD_LEN}"
+									},
+									{
+										"name": "MYSQL_AIO",
+										"value": "${MYSQL_AIO}"
 									}
 								],
-								"image": "postgresql",
+								"image": "mysql",
 								"livenessProbe": {
 									"initialDelaySeconds": 30,
 									"tcpSocket": {
-										"port": 5432
+										"port": 3306
 									},
 									"timeoutSeconds": 1
 								},
-								"name": "${APPLICATION_NAME}-postgresql",
+								"name": "${APPLICATION_NAME}-mysql",
 								"ports": [
 									{
-										"containerPort": 5432,
+										"containerPort": 3306,
 										"protocol": "TCP"
 									}
 								],
@@ -439,7 +451,7 @@
 											"/bin/sh",
 											"-i",
 											"-c",
-											"psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'"
+											"MYSQL_PWD=\"$MYSQL_PASSWORD\" mysql -h 127.0.0.1 -u $MYSQL_USER -D $MYSQL_DATABASE -e 'SELECT 1'"
 										]
 									},
 									"initialDelaySeconds": 5,
@@ -447,18 +459,19 @@
 								},
 								"volumeMounts": [
 									{
-										"mountPath": "/var/lib/pgsql/data",
-										"name": "${APPLICATION_NAME}-data"
+										"mountPath": "/var/lib/mysql/data",
+										"name": "${APPLICATION_NAME}-mysql-pvol"
 									}
 								]
 							}
 						],
+						"terminationGracePeriodSeconds": 60,
 						"volumes": [
 							{
-								"emptyDir": {
-									"medium": ""
-								},
-								"name": "${APPLICATION_NAME}-data"
+								"name": "${APPLICATION_NAME}-mysql-pvol",
+								"persistentVolumeClaim": {
+									"claimName": "${APPLICATION_NAME}-mysql-claim"
+								}
 							}
 						]
 					}
@@ -468,11 +481,11 @@
 						"imageChangeParams": {
 							"automatic": true,
 							"containerNames": [
-								"${APPLICATION_NAME}-postgresql"
+								"${APPLICATION_NAME}-mysql"
 							],
 							"from": {
 								"kind": "ImageStreamTag",
-								"name": "postgresql:${POSTGRESQL_IMAGE_STREAM_TAG}",
+								"name": "mysql:${MYSQL_IMAGE_STREAM_TAG}",
 								"namespace": "${IMAGE_STREAM_NAMESPACE}"
 							}
 						},
@@ -482,6 +495,26 @@
 						"type": "ConfigChange"
 					}
 				]
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "PersistentVolumeClaim",
+			"metadata": {
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}-mysql-claim"
+			},
+			"spec": {
+				"accessModes": [
+					"ReadWriteOnce"
+				],
+				"resources": {
+					"requests": {
+						"storage": "${VOLUME_CAPACITY}"
+					}
+				}
 			}
 		}
 	],
@@ -525,7 +558,7 @@
 		{
 			"name": "DB_JNDI",
 			"displayName": "Database JNDI Name",
-			"description": "Database JNDI name used by application to resolve the datasource, e.g. jboss/datasources/postgresqlDS",
+			"description": "Database JNDI name used by application to resolve the datasource, e.g. jboss/datasources/mysqlDS",
 			"value": "jboss/datasources/defaultDS"
 		},
 		{
@@ -533,6 +566,13 @@
 			"displayName": "Database Name",
 			"description": "Database name",
 			"value": "root",
+			"required": true
+		},
+		{
+			"name": "VOLUME_CAPACITY",
+			"displayName": "Database Volume Capacity",
+			"description": "Size of persistent storage for database volume.",
+			"value": "1Gi",
 			"required": true
 		},
 		{
@@ -575,14 +615,29 @@
 			"description": "Sets transaction-isolation for the configured datasource."
 		},
 		{
-			"name": "POSTGRESQL_MAX_CONNECTIONS",
-			"displayName": "PostgreSQL Maximum number of connections",
-			"description": "The maximum number of client connections allowed. This also sets the maximum number of prepared transactions."
+			"name": "MYSQL_LOWER_CASE_TABLE_NAMES",
+			"displayName": "MySQL Lower Case Table Names",
+			"description": "Sets how the table names are stored and compared."
 		},
 		{
-			"name": "POSTGRESQL_SHARED_BUFFERS",
-			"displayName": "PostgreSQL Shared Buffers",
-			"description": "Configures how much memory is dedicated to PostgreSQL for caching data."
+			"name": "MYSQL_MAX_CONNECTIONS",
+			"displayName": "MySQL Maximum number of connections",
+			"description": "The maximum permitted number of simultaneous client connections."
+		},
+		{
+			"name": "MYSQL_FT_MIN_WORD_LEN",
+			"displayName": "MySQL FullText Minimum Word Length",
+			"description": "The minimum length of the word to be included in a FULLTEXT index."
+		},
+		{
+			"name": "MYSQL_FT_MAX_WORD_LEN",
+			"displayName": "MySQL FullText Maximum Word Length",
+			"description": "The maximum length of the word to be included in a FULLTEXT index."
+		},
+		{
+			"name": "MYSQL_AIO",
+			"displayName": "MySQL AIO",
+			"description": "Controls the innodb_use_native_aio setting value if the native AIO is broken."
 		},
 		{
 			"name": "DB_USERNAME",
@@ -649,15 +704,15 @@
 			"description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied."
 		},
 		{
-			"name": "POSTGRESQL_IMAGE_STREAM_TAG",
-			"displayName": "PostgreSQL Image Stream Tag",
-			"description": "The tag to use for the \"postgresql\" image stream.  Typically, this aligns with the major.minor version of PostgreSQL.",
-			"value": "9.5",
+			"name": "MYSQL_IMAGE_STREAM_TAG",
+			"displayName": "MySQL Image Stream Tag",
+			"description": "The tag to use for the \"mysql\" image stream.  Typically, this aligns with the major.minor version of MySQL.",
+			"value": "5.7",
 			"required": true
 		}
 	],
 	"labels": {
-		"jws53": "1.0",
-		"template": "jws53-openjdk8-tomcat9-postgresql-s2i"
+		"jws54jdk11el7": "1.0",
+		"template": "jws54-openjdk11-tomcat9-rhel7-mysql-persistent-s2i"
 	}
 }

--- a/official/webserver/templates/jws54-openjdk11-tomcat9-rhel7-mysql-s2i.json
+++ b/official/webserver/templates/jws54-openjdk11-tomcat9-rhel7-mysql-s2i.json
@@ -2,18 +2,18 @@
 	"kind": "Template",
 	"apiVersion": "v1",
 	"metadata": {
-		"name": "jws53-openjdk11-tomcat9-postgresql-persistent-s2i",
+		"name": "jws54-openjdk11-tomcat9-rhel7-mysql-s2i",
 		"creationTimestamp": null,
 		"annotations": {
-			"description": "Application template for JWS PostgreSQL applications with persistent storage built using S2I.",
+			"description": "Application template for JWS MySQL applications built using S2I.",
 			"iconClass": "icon-rh-tomcat",
-			"openshift.io/display-name": "JBoss Web Server 5.3 Apache Tomcat 9 OpenJDK11 + PostgreSQL (with https)",
+			"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK11 on RHEL7 + MySQL (Ephemeral with https)",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
-			"tags": "tomcat,tomcat9,java,jboss",
+			"tags": "tomcat,tomcat9,java,jboss,hidden",
 			"version": "1.0"
 		}
 	},
-	"message": "A new persistent JWS application for Apache Tomcat 9 (using PostgreSQL) has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}. For accessing the PostgreSQL database \"${DB_DATABASE}\" use the credentials ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
+	"message": "A new JWS application for Apache Tomcat 9 (using MySQL) has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}. For accessing the MySQL database \"${DB_DATABASE}\" use the credentials ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
 	"objects": [
 		{
 			"apiVersion": "v1",
@@ -21,7 +21,7 @@
 			"metadata": {
 				"annotations": {
 					"description": "The web server's http port.",
-					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-postgresql\", \"kind\": \"Service\"}]"
+					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mysql\", \"kind\": \"Service\"}]"
 				},
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -46,7 +46,7 @@
 			"metadata": {
 				"annotations": {
 					"description": "The web server's https port.",
-					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-postgresql\", \"kind\": \"Service\"}]"
+					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mysql\", \"kind\": \"Service\"}]"
 				},
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -75,17 +75,17 @@
 				"labels": {
 					"application": "${APPLICATION_NAME}"
 				},
-				"name": "${APPLICATION_NAME}-postgresql"
+				"name": "${APPLICATION_NAME}-mysql"
 			},
 			"spec": {
 				"ports": [
 					{
-						"port": 5432,
-						"targetPort": 5432
+						"port": 3306,
+						"targetPort": 3306
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deploymentConfig": "${APPLICATION_NAME}-mysql"
 				}
 			}
 		},
@@ -181,7 +181,7 @@
 						"forcePull": true,
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "jboss-webserver53-openjdk11-tomcat9-openshift:1.0",
+							"name": "jboss-webserver54-openjdk11-tomcat9-openshift-rhel7:1.0",
 							"namespace": "${IMAGE_STREAM_NAMESPACE}"
 						}
 					},
@@ -241,7 +241,7 @@
 								"env": [
 									{
 										"name": "DB_SERVICE_PREFIX_MAPPING",
-										"value": "${APPLICATION_NAME}-postgresql=DB"
+										"value": "${APPLICATION_NAME}-mysql=DB"
 									},
 									{
 										"name": "DB_JNDI",
@@ -321,7 +321,7 @@
 										"command": [
 											"/bin/bash",
 											"-c",
-											"curl --noproxy '*' -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer\u0026att=stateName' |grep -iq 'stateName *= *STARTED'"
+											"curl --noproxy '*' -is 'http://localhost:8080/health' | grep -iq '\"status\": \"UP\"'"
 										]
 									}
 								},
@@ -372,12 +372,12 @@
 				"labels": {
 					"application": "${APPLICATION_NAME}"
 				},
-				"name": "${APPLICATION_NAME}-postgresql"
+				"name": "${APPLICATION_NAME}-mysql"
 			},
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deploymentConfig": "${APPLICATION_NAME}-mysql"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -386,51 +386,59 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+							"deploymentConfig": "${APPLICATION_NAME}-mysql"
 						},
-						"name": "${APPLICATION_NAME}-postgresql"
+						"name": "${APPLICATION_NAME}-mysql"
 					},
 					"spec": {
 						"containers": [
 							{
 								"env": [
 									{
-										"name": "POSTGRESQL_USER",
+										"name": "MYSQL_USER",
 										"value": "${DB_USERNAME}"
 									},
 									{
-										"name": "POSTGRESQL_PASSWORD",
+										"name": "MYSQL_PASSWORD",
 										"value": "${DB_PASSWORD}"
 									},
 									{
-										"name": "POSTGRESQL_DATABASE",
+										"name": "MYSQL_DATABASE",
 										"value": "${DB_DATABASE}"
 									},
 									{
-										"name": "POSTGRESQL_MAX_CONNECTIONS",
-										"value": "${POSTGRESQL_MAX_CONNECTIONS}"
+										"name": "MYSQL_LOWER_CASE_TABLE_NAMES",
+										"value": "${MYSQL_LOWER_CASE_TABLE_NAMES}"
 									},
 									{
-										"name": "POSTGRESQL_MAX_PREPARED_TRANSACTIONS",
-										"value": "${POSTGRESQL_MAX_CONNECTIONS}"
+										"name": "MYSQL_MAX_CONNECTIONS",
+										"value": "${MYSQL_MAX_CONNECTIONS}"
 									},
 									{
-										"name": "POSTGRESQL_SHARED_BUFFERS",
-										"value": "${POSTGRESQL_SHARED_BUFFERS}"
+										"name": "MYSQL_FT_MIN_WORD_LEN",
+										"value": "${MYSQL_FT_MIN_WORD_LEN}"
+									},
+									{
+										"name": "MYSQL_FT_MAX_WORD_LEN",
+										"value": "${MYSQL_FT_MAX_WORD_LEN}"
+									},
+									{
+										"name": "MYSQL_AIO",
+										"value": "${MYSQL_AIO}"
 									}
 								],
-								"image": "postgresql",
+								"image": "mysql",
 								"livenessProbe": {
 									"initialDelaySeconds": 30,
 									"tcpSocket": {
-										"port": 5432
+										"port": 3306
 									},
 									"timeoutSeconds": 1
 								},
-								"name": "${APPLICATION_NAME}-postgresql",
+								"name": "${APPLICATION_NAME}-mysql",
 								"ports": [
 									{
-										"containerPort": 5432,
+										"containerPort": 3306,
 										"protocol": "TCP"
 									}
 								],
@@ -440,7 +448,7 @@
 											"/bin/sh",
 											"-i",
 											"-c",
-											"psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'"
+											"MYSQL_PWD=\"$MYSQL_PASSWORD\" mysql -h 127.0.0.1 -u $MYSQL_USER -D $MYSQL_DATABASE -e 'SELECT 1'"
 										]
 									},
 									"initialDelaySeconds": 5,
@@ -448,8 +456,8 @@
 								},
 								"volumeMounts": [
 									{
-										"mountPath": "/var/lib/pgsql/data",
-										"name": "${APPLICATION_NAME}-postgresql-pvol"
+										"mountPath": "/var/lib/mysql/data",
+										"name": "${APPLICATION_NAME}-data"
 									}
 								]
 							}
@@ -457,10 +465,10 @@
 						"terminationGracePeriodSeconds": 60,
 						"volumes": [
 							{
-								"name": "${APPLICATION_NAME}-postgresql-pvol",
-								"persistentVolumeClaim": {
-									"claimName": "${APPLICATION_NAME}-postgresql-claim"
-								}
+								"emptyDir": {
+									"medium": ""
+								},
+								"name": "${APPLICATION_NAME}-data"
 							}
 						]
 					}
@@ -470,11 +478,11 @@
 						"imageChangeParams": {
 							"automatic": true,
 							"containerNames": [
-								"${APPLICATION_NAME}-postgresql"
+								"${APPLICATION_NAME}-mysql"
 							],
 							"from": {
 								"kind": "ImageStreamTag",
-								"name": "postgresql:${POSTGRESQL_IMAGE_STREAM_TAG}",
+								"name": "mysql:${MYSQL_IMAGE_STREAM_TAG}",
 								"namespace": "${IMAGE_STREAM_NAMESPACE}"
 							}
 						},
@@ -484,26 +492,6 @@
 						"type": "ConfigChange"
 					}
 				]
-			}
-		},
-		{
-			"apiVersion": "v1",
-			"kind": "PersistentVolumeClaim",
-			"metadata": {
-				"labels": {
-					"application": "${APPLICATION_NAME}"
-				},
-				"name": "${APPLICATION_NAME}-postgresql-claim"
-			},
-			"spec": {
-				"accessModes": [
-					"ReadWriteOnce"
-				],
-				"resources": {
-					"requests": {
-						"storage": "${VOLUME_CAPACITY}"
-					}
-				}
 			}
 		}
 	],
@@ -547,7 +535,7 @@
 		{
 			"name": "DB_JNDI",
 			"displayName": "Database JNDI Name",
-			"description": "Database JNDI name used by application to resolve the datasource, e.g. jboss/datasources/postgresqlDS",
+			"description": "Database JNDI name used by application to resolve the datasource, e.g. jboss/datasources/mysqlDS",
 			"value": "jboss/datasources/defaultDS"
 		},
 		{
@@ -555,13 +543,6 @@
 			"displayName": "Database Name",
 			"description": "Database name",
 			"value": "root",
-			"required": true
-		},
-		{
-			"name": "VOLUME_CAPACITY",
-			"displayName": "Database Volume Capacity",
-			"description": "Size of persistent storage for database volume.",
-			"value": "1Gi",
 			"required": true
 		},
 		{
@@ -604,14 +585,29 @@
 			"description": "Sets transaction-isolation for the configured datasource."
 		},
 		{
-			"name": "POSTGRESQL_MAX_CONNECTIONS",
-			"displayName": "PostgreSQL Maximum number of connections",
-			"description": "The maximum number of client connections allowed. This also sets the maximum number of prepared transactions."
+			"name": "MYSQL_LOWER_CASE_TABLE_NAMES",
+			"displayName": "MySQL Lower Case Table Names",
+			"description": "Sets how the table names are stored and compared."
 		},
 		{
-			"name": "POSTGRESQL_SHARED_BUFFERS",
-			"displayName": "PostgreSQL Shared Buffers",
-			"description": "Configures how much memory is dedicated to PostgreSQL for caching data."
+			"name": "MYSQL_MAX_CONNECTIONS",
+			"displayName": "MySQL Maximum number of connections",
+			"description": "The maximum permitted number of simultaneous client connections."
+		},
+		{
+			"name": "MYSQL_FT_MIN_WORD_LEN",
+			"displayName": "MySQL FullText Minimum Word Length",
+			"description": "The minimum length of the word to be included in a FULLTEXT index."
+		},
+		{
+			"name": "MYSQL_FT_MAX_WORD_LEN",
+			"displayName": "MySQL FullText Maximum Word Length",
+			"description": "The maximum length of the word to be included in a FULLTEXT index."
+		},
+		{
+			"name": "MYSQL_AIO",
+			"displayName": "MySQL AIO",
+			"description": "Controls the innodb_use_native_aio setting value if the native AIO is broken."
 		},
 		{
 			"name": "DB_USERNAME",
@@ -678,15 +674,15 @@
 			"description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied."
 		},
 		{
-			"name": "POSTGRESQL_IMAGE_STREAM_TAG",
-			"displayName": "PostgreSQL Image Stream Tag",
-			"description": "The tag to use for the \"postgresql\" image stream.  Typically, this aligns with the major.minor version of PostgreSQL.",
-			"value": "9.5",
+			"name": "MYSQL_IMAGE_STREAM_TAG",
+			"displayName": "MySQL Image Stream Tag",
+			"description": "The tag to use for the \"mysql\" image stream.  Typically, this aligns with the major.minor version of MySQL.",
+			"value": "5.7",
 			"required": true
 		}
 	],
 	"labels": {
-		"jws53": "1.0",
-		"template": "jws53-openjdk11-tomcat9-postgresql-persistent-s2i"
+		"jws54jdk11el7": "1.0",
+		"template": "jws54-openjdk11-tomcat9-rhel7-mysql-s2i"
 	}
 }

--- a/official/webserver/templates/jws54-openjdk11-tomcat9-rhel7-postgresql-persistent-s2i.json
+++ b/official/webserver/templates/jws54-openjdk11-tomcat9-rhel7-postgresql-persistent-s2i.json
@@ -2,18 +2,18 @@
 	"kind": "Template",
 	"apiVersion": "v1",
 	"metadata": {
-		"name": "jws53-openjdk11-tomcat9-mysql-s2i",
+		"name": "jws54-openjdk11-tomcat9-rhel7-postgresql-persistent-s2i",
 		"creationTimestamp": null,
 		"annotations": {
-			"description": "Application template for JWS MySQL applications built using S2I.",
+			"description": "Application template for JWS PostgreSQL applications with persistent storage built using S2I.",
 			"iconClass": "icon-rh-tomcat",
-			"openshift.io/display-name": "JBoss Web Server 5.3 Apache Tomcat 9 OpenJDK11 + MySQL (Ephemeral with https)",
+			"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK11 on RHEL7 + PostgreSQL (with https)",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
-			"tags": "tomcat,tomcat9,java,jboss,hidden",
+			"tags": "tomcat,tomcat9,java,jboss",
 			"version": "1.0"
 		}
 	},
-	"message": "A new JWS application for Apache Tomcat 9 (using MySQL) has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}. For accessing the MySQL database \"${DB_DATABASE}\" use the credentials ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
+	"message": "A new persistent JWS application for Apache Tomcat 9 (using PostgreSQL) has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}. For accessing the PostgreSQL database \"${DB_DATABASE}\" use the credentials ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
 	"objects": [
 		{
 			"apiVersion": "v1",
@@ -21,7 +21,7 @@
 			"metadata": {
 				"annotations": {
 					"description": "The web server's http port.",
-					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mysql\", \"kind\": \"Service\"}]"
+					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-postgresql\", \"kind\": \"Service\"}]"
 				},
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -46,7 +46,7 @@
 			"metadata": {
 				"annotations": {
 					"description": "The web server's https port.",
-					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mysql\", \"kind\": \"Service\"}]"
+					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-postgresql\", \"kind\": \"Service\"}]"
 				},
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -75,17 +75,17 @@
 				"labels": {
 					"application": "${APPLICATION_NAME}"
 				},
-				"name": "${APPLICATION_NAME}-mysql"
+				"name": "${APPLICATION_NAME}-postgresql"
 			},
 			"spec": {
 				"ports": [
 					{
-						"port": 3306,
-						"targetPort": 3306
+						"port": 5432,
+						"targetPort": 5432
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-mysql"
+					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
 				}
 			}
 		},
@@ -181,7 +181,7 @@
 						"forcePull": true,
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "jboss-webserver53-openjdk11-tomcat9-openshift:1.0",
+							"name": "jboss-webserver54-openjdk11-tomcat9-openshift-rhel7:1.0",
 							"namespace": "${IMAGE_STREAM_NAMESPACE}"
 						}
 					},
@@ -241,7 +241,7 @@
 								"env": [
 									{
 										"name": "DB_SERVICE_PREFIX_MAPPING",
-										"value": "${APPLICATION_NAME}-mysql=DB"
+										"value": "${APPLICATION_NAME}-postgresql=DB"
 									},
 									{
 										"name": "DB_JNDI",
@@ -321,7 +321,7 @@
 										"command": [
 											"/bin/bash",
 											"-c",
-											"curl --noproxy '*' -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer\u0026att=stateName' |grep -iq 'stateName *= *STARTED'"
+											"curl --noproxy '*' -is 'http://localhost:8080/health' | grep -iq '\"status\": \"UP\"'"
 										]
 									}
 								},
@@ -372,12 +372,12 @@
 				"labels": {
 					"application": "${APPLICATION_NAME}"
 				},
-				"name": "${APPLICATION_NAME}-mysql"
+				"name": "${APPLICATION_NAME}-postgresql"
 			},
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-mysql"
+					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -386,59 +386,51 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}-mysql"
+							"deploymentConfig": "${APPLICATION_NAME}-postgresql"
 						},
-						"name": "${APPLICATION_NAME}-mysql"
+						"name": "${APPLICATION_NAME}-postgresql"
 					},
 					"spec": {
 						"containers": [
 							{
 								"env": [
 									{
-										"name": "MYSQL_USER",
+										"name": "POSTGRESQL_USER",
 										"value": "${DB_USERNAME}"
 									},
 									{
-										"name": "MYSQL_PASSWORD",
+										"name": "POSTGRESQL_PASSWORD",
 										"value": "${DB_PASSWORD}"
 									},
 									{
-										"name": "MYSQL_DATABASE",
+										"name": "POSTGRESQL_DATABASE",
 										"value": "${DB_DATABASE}"
 									},
 									{
-										"name": "MYSQL_LOWER_CASE_TABLE_NAMES",
-										"value": "${MYSQL_LOWER_CASE_TABLE_NAMES}"
+										"name": "POSTGRESQL_MAX_CONNECTIONS",
+										"value": "${POSTGRESQL_MAX_CONNECTIONS}"
 									},
 									{
-										"name": "MYSQL_MAX_CONNECTIONS",
-										"value": "${MYSQL_MAX_CONNECTIONS}"
+										"name": "POSTGRESQL_MAX_PREPARED_TRANSACTIONS",
+										"value": "${POSTGRESQL_MAX_CONNECTIONS}"
 									},
 									{
-										"name": "MYSQL_FT_MIN_WORD_LEN",
-										"value": "${MYSQL_FT_MIN_WORD_LEN}"
-									},
-									{
-										"name": "MYSQL_FT_MAX_WORD_LEN",
-										"value": "${MYSQL_FT_MAX_WORD_LEN}"
-									},
-									{
-										"name": "MYSQL_AIO",
-										"value": "${MYSQL_AIO}"
+										"name": "POSTGRESQL_SHARED_BUFFERS",
+										"value": "${POSTGRESQL_SHARED_BUFFERS}"
 									}
 								],
-								"image": "mysql",
+								"image": "postgresql",
 								"livenessProbe": {
 									"initialDelaySeconds": 30,
 									"tcpSocket": {
-										"port": 3306
+										"port": 5432
 									},
 									"timeoutSeconds": 1
 								},
-								"name": "${APPLICATION_NAME}-mysql",
+								"name": "${APPLICATION_NAME}-postgresql",
 								"ports": [
 									{
-										"containerPort": 3306,
+										"containerPort": 5432,
 										"protocol": "TCP"
 									}
 								],
@@ -448,7 +440,7 @@
 											"/bin/sh",
 											"-i",
 											"-c",
-											"MYSQL_PWD=\"$MYSQL_PASSWORD\" mysql -h 127.0.0.1 -u $MYSQL_USER -D $MYSQL_DATABASE -e 'SELECT 1'"
+											"psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'"
 										]
 									},
 									"initialDelaySeconds": 5,
@@ -456,8 +448,8 @@
 								},
 								"volumeMounts": [
 									{
-										"mountPath": "/var/lib/mysql/data",
-										"name": "${APPLICATION_NAME}-data"
+										"mountPath": "/var/lib/pgsql/data",
+										"name": "${APPLICATION_NAME}-postgresql-pvol"
 									}
 								]
 							}
@@ -465,10 +457,10 @@
 						"terminationGracePeriodSeconds": 60,
 						"volumes": [
 							{
-								"emptyDir": {
-									"medium": ""
-								},
-								"name": "${APPLICATION_NAME}-data"
+								"name": "${APPLICATION_NAME}-postgresql-pvol",
+								"persistentVolumeClaim": {
+									"claimName": "${APPLICATION_NAME}-postgresql-claim"
+								}
 							}
 						]
 					}
@@ -478,11 +470,11 @@
 						"imageChangeParams": {
 							"automatic": true,
 							"containerNames": [
-								"${APPLICATION_NAME}-mysql"
+								"${APPLICATION_NAME}-postgresql"
 							],
 							"from": {
 								"kind": "ImageStreamTag",
-								"name": "mysql:${MYSQL_IMAGE_STREAM_TAG}",
+								"name": "postgresql:${POSTGRESQL_IMAGE_STREAM_TAG}",
 								"namespace": "${IMAGE_STREAM_NAMESPACE}"
 							}
 						},
@@ -492,6 +484,26 @@
 						"type": "ConfigChange"
 					}
 				]
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "PersistentVolumeClaim",
+			"metadata": {
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}-postgresql-claim"
+			},
+			"spec": {
+				"accessModes": [
+					"ReadWriteOnce"
+				],
+				"resources": {
+					"requests": {
+						"storage": "${VOLUME_CAPACITY}"
+					}
+				}
 			}
 		}
 	],
@@ -535,7 +547,7 @@
 		{
 			"name": "DB_JNDI",
 			"displayName": "Database JNDI Name",
-			"description": "Database JNDI name used by application to resolve the datasource, e.g. jboss/datasources/mysqlDS",
+			"description": "Database JNDI name used by application to resolve the datasource, e.g. jboss/datasources/postgresqlDS",
 			"value": "jboss/datasources/defaultDS"
 		},
 		{
@@ -543,6 +555,13 @@
 			"displayName": "Database Name",
 			"description": "Database name",
 			"value": "root",
+			"required": true
+		},
+		{
+			"name": "VOLUME_CAPACITY",
+			"displayName": "Database Volume Capacity",
+			"description": "Size of persistent storage for database volume.",
+			"value": "1Gi",
 			"required": true
 		},
 		{
@@ -585,29 +604,14 @@
 			"description": "Sets transaction-isolation for the configured datasource."
 		},
 		{
-			"name": "MYSQL_LOWER_CASE_TABLE_NAMES",
-			"displayName": "MySQL Lower Case Table Names",
-			"description": "Sets how the table names are stored and compared."
+			"name": "POSTGRESQL_MAX_CONNECTIONS",
+			"displayName": "PostgreSQL Maximum number of connections",
+			"description": "The maximum number of client connections allowed. This also sets the maximum number of prepared transactions."
 		},
 		{
-			"name": "MYSQL_MAX_CONNECTIONS",
-			"displayName": "MySQL Maximum number of connections",
-			"description": "The maximum permitted number of simultaneous client connections."
-		},
-		{
-			"name": "MYSQL_FT_MIN_WORD_LEN",
-			"displayName": "MySQL FullText Minimum Word Length",
-			"description": "The minimum length of the word to be included in a FULLTEXT index."
-		},
-		{
-			"name": "MYSQL_FT_MAX_WORD_LEN",
-			"displayName": "MySQL FullText Maximum Word Length",
-			"description": "The maximum length of the word to be included in a FULLTEXT index."
-		},
-		{
-			"name": "MYSQL_AIO",
-			"displayName": "MySQL AIO",
-			"description": "Controls the innodb_use_native_aio setting value if the native AIO is broken."
+			"name": "POSTGRESQL_SHARED_BUFFERS",
+			"displayName": "PostgreSQL Shared Buffers",
+			"description": "Configures how much memory is dedicated to PostgreSQL for caching data."
 		},
 		{
 			"name": "DB_USERNAME",
@@ -674,15 +678,15 @@
 			"description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied."
 		},
 		{
-			"name": "MYSQL_IMAGE_STREAM_TAG",
-			"displayName": "MySQL Image Stream Tag",
-			"description": "The tag to use for the \"mysql\" image stream.  Typically, this aligns with the major.minor version of MySQL.",
-			"value": "5.7",
+			"name": "POSTGRESQL_IMAGE_STREAM_TAG",
+			"displayName": "PostgreSQL Image Stream Tag",
+			"description": "The tag to use for the \"postgresql\" image stream.  Typically, this aligns with the major.minor version of PostgreSQL.",
+			"value": "9.5",
 			"required": true
 		}
 	],
 	"labels": {
-		"jws53": "1.0",
-		"template": "jws53-openjdk11-tomcat9-mysql-s2i"
+		"jws54jdk11el7": "1.0",
+		"template": "jws54-openjdk11-tomcat9-rhel7-postgresql-persistent-s2i"
 	}
 }

--- a/official/webserver/templates/jws54-openjdk11-tomcat9-rhel7-postgresql-s2i.json
+++ b/official/webserver/templates/jws54-openjdk11-tomcat9-rhel7-postgresql-s2i.json
@@ -2,12 +2,12 @@
 	"kind": "Template",
 	"apiVersion": "v1",
 	"metadata": {
-		"name": "jws53-openjdk11-tomcat9-postgresql-s2i",
+		"name": "jws54-openjdk11-tomcat9-rhel7-postgresql-s2i",
 		"creationTimestamp": null,
 		"annotations": {
 			"description": "Application template for JWS PostgreSQL applications built using S2I.",
 			"iconClass": "icon-rh-tomcat",
-			"openshift.io/display-name": "JBoss Web Server 5.3 Apache Tomcat 9 OpenJDK11 + PostgreSQL (Ephemeral with https)",
+			"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK11 on RHEL7 + PostgreSQL (Ephemeral with https)",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
 			"tags": "tomcat,tomcat9,java,jboss,hidden",
 			"version": "1.0"
@@ -181,7 +181,7 @@
 						"forcePull": true,
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "jboss-webserver53-openjdk11-tomcat9-openshift:1.0",
+							"name": "jboss-webserver54-openjdk11-tomcat9-openshift-rhel7:1.0",
 							"namespace": "${IMAGE_STREAM_NAMESPACE}"
 						}
 					},
@@ -321,7 +321,7 @@
 										"command": [
 											"/bin/bash",
 											"-c",
-											"curl --noproxy '*' -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer\u0026att=stateName' |grep -iq 'stateName *= *STARTED'"
+											"curl --noproxy '*' -is 'http://localhost:8080/health' | grep -iq '\"status\": \"UP\"'"
 										]
 									}
 								},
@@ -657,7 +657,7 @@
 		}
 	],
 	"labels": {
-		"jws53": "1.0",
-		"template": "jws53-openjdk11-tomcat9-postgresql-s2i"
+		"jws54jdk11el7": "1.0",
+		"template": "jws54-openjdk11-tomcat9-rhel7-postgresql-s2i"
 	}
 }

--- a/official/webserver/templates/jws54-openjdk11-tomcat9-ubi8-basic-s2i.json
+++ b/official/webserver/templates/jws54-openjdk11-tomcat9-ubi8-basic-s2i.json
@@ -2,21 +2,21 @@
 	"kind": "Template",
 	"apiVersion": "v1",
 	"metadata": {
-		"name": "jws53-openjdk11-tomcat9-https-s2i",
+		"name": "jws54-openjdk11-tomcat9-ubi8-basic-s2i",
 		"creationTimestamp": null,
 		"annotations": {
 			"description": "An example JBoss Web Server application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
 			"iconClass": "icon-rh-tomcat",
-			"openshift.io/display-name": "JBoss Web Server 5.3 Apache Tomcat 9 OpenJDK11 (with https)",
+			"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK11 on UBI8 (no https)",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
-			"tags": "tomcat,tomcat9,java,jboss,hidden",
+			"tags": "tomcat,tomcat9,java,jboss",
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-web-server/",
-			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.3 Apache Tomcat 9 based application, including a build configuration, application deployment configuration, and secure communication using https.",
+			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.4 Apache Tomcat 9 based application, including a build configuration, and an application deployment configuration.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
 			"version": "1.0"
 		}
 	},
-	"message": "A new JWS application for Apache Tomcat 9 has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}. Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
+	"message": "A new JWS application for Apache Tomcat 9 has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}.",
 	"objects": [
 		{
 			"apiVersion": "v1",
@@ -44,30 +44,6 @@
 		},
 		{
 			"apiVersion": "v1",
-			"kind": "Service",
-			"metadata": {
-				"annotations": {
-					"description": "The web server's https port."
-				},
-				"labels": {
-					"application": "${APPLICATION_NAME}"
-				},
-				"name": "secure-${APPLICATION_NAME}"
-			},
-			"spec": {
-				"ports": [
-					{
-						"port": 8443,
-						"targetPort": 8443
-					}
-				],
-				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
-				}
-			}
-		},
-		{
-			"apiVersion": "v1",
 			"id": "${APPLICATION_NAME}-http",
 			"kind": "Route",
 			"metadata": {
@@ -83,29 +59,6 @@
 				"host": "${HOSTNAME_HTTP}",
 				"to": {
 					"name": "${APPLICATION_NAME}"
-				}
-			}
-		},
-		{
-			"apiVersion": "v1",
-			"id": "${APPLICATION_NAME}-https",
-			"kind": "Route",
-			"metadata": {
-				"annotations": {
-					"description": "Route for application's https service."
-				},
-				"labels": {
-					"application": "${APPLICATION_NAME}"
-				},
-				"name": "secure-${APPLICATION_NAME}"
-			},
-			"spec": {
-				"host": "${HOSTNAME_HTTPS}",
-				"tls": {
-					"termination": "passthrough"
-				},
-				"to": {
-					"name": "secure-${APPLICATION_NAME}"
 				}
 			}
 		},
@@ -158,7 +111,7 @@
 						"forcePull": true,
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "jboss-webserver53-openjdk11-tomcat9-openshift:1.0",
+							"name": "jboss-webserver54-openjdk11-tomcat9-openshift-ubi8:1.0",
 							"namespace": "${IMAGE_STREAM_NAMESPACE}"
 						}
 					},
@@ -217,22 +170,6 @@
 							{
 								"env": [
 									{
-										"name": "JWS_HTTPS_CERTIFICATE_DIR",
-										"value": "/etc/jws-secret-volume"
-									},
-									{
-										"name": "JWS_HTTPS_CERTIFICATE",
-										"value": "${JWS_HTTPS_CERTIFICATE}"
-									},
-									{
-										"name": "JWS_HTTPS_CERTIFICATE_KEY",
-										"value": "${JWS_HTTPS_CERTIFICATE_KEY}"
-									},
-									{
-										"name": "JWS_HTTPS_CERTIFICATE_PASSWORD",
-										"value": "${JWS_HTTPS_CERTIFICATE_PASSWORD}"
-									},
-									{
 										"name": "JWS_ADMIN_USERNAME",
 										"value": "${JWS_ADMIN_USERNAME}"
 									},
@@ -254,11 +191,6 @@
 										"containerPort": 8080,
 										"name": "http",
 										"protocol": "TCP"
-									},
-									{
-										"containerPort": 8443,
-										"name": "https",
-										"protocol": "TCP"
 									}
 								],
 								"readinessProbe": {
@@ -266,28 +198,13 @@
 										"command": [
 											"/bin/bash",
 											"-c",
-											"curl --noproxy '*' -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer\u0026att=stateName' |grep -iq 'stateName *= *STARTED'"
+											"curl --noproxy '*' -is 'http://localhost:8080/health' | grep -iq '\"status\": \"UP\"'"
 										]
 									}
-								},
-								"volumeMounts": [
-									{
-										"mountPath": "/etc/jws-secret-volume",
-										"name": "jws-certificate-volume",
-										"readOnly": true
-									}
-								]
-							}
-						],
-						"terminationGracePeriodSeconds": 60,
-						"volumes": [
-							{
-								"name": "jws-certificate-volume",
-								"secret": {
-									"secretName": "${JWS_HTTPS_SECRET}"
 								}
 							}
-						]
+						],
+						"terminationGracePeriodSeconds": 60
 					}
 				},
 				"triggers": [
@@ -325,11 +242,6 @@
 			"description": "Custom hostname for http service route.  Leave blank for default hostname, e.g.: \u003capplication-name\u003e-\u003cproject\u003e.\u003cdefault-domain-suffix\u003e"
 		},
 		{
-			"name": "HOSTNAME_HTTPS",
-			"displayName": "Custom https Route Hostname",
-			"description": "Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-\u003capplication-name\u003e-\u003cproject\u003e.\u003cdefault-domain-suffix\u003e"
-		},
-		{
 			"name": "SOURCE_REPOSITORY_URL",
 			"displayName": "Git Repository URL",
 			"description": "Git source URI for application",
@@ -347,30 +259,6 @@
 			"displayName": "Context Directory",
 			"description": "Path within Git project to build; empty for root project directory.",
 			"value": "tomcat-websocket-chat"
-		},
-		{
-			"name": "JWS_HTTPS_SECRET",
-			"displayName": "Secret Name",
-			"description": "The name of the secret containing the certificate files",
-			"value": "jws-app-secret",
-			"required": true
-		},
-		{
-			"name": "JWS_HTTPS_CERTIFICATE",
-			"displayName": "Certificate Name",
-			"description": "The name of the certificate file within the secret",
-			"value": "server.crt"
-		},
-		{
-			"name": "JWS_HTTPS_CERTIFICATE_KEY",
-			"displayName": "Certificate Key Name",
-			"description": "The name of the certificate key file within the secret",
-			"value": "server.key"
-		},
-		{
-			"name": "JWS_HTTPS_CERTIFICATE_PASSWORD",
-			"displayName": "Certificate Password",
-			"description": "The certificate password"
 		},
 		{
 			"name": "JWS_ADMIN_USERNAME",
@@ -422,7 +310,7 @@
 		}
 	],
 	"labels": {
-		"jws53": "1.0",
-		"template": "jws53-openjdk11-tomcat9-https-s2i"
+		"jws54jdk11ubi8": "1.0",
+		"template": "jws54-openjdk11-tomcat9-ubi8-basic-s2i"
 	}
 }

--- a/official/webserver/templates/jws54-openjdk11-tomcat9-ubi8-https-s2i.json
+++ b/official/webserver/templates/jws54-openjdk11-tomcat9-ubi8-https-s2i.json
@@ -2,29 +2,28 @@
 	"kind": "Template",
 	"apiVersion": "v1",
 	"metadata": {
-		"name": "jws53-openjdk8-tomcat9-mysql-persistent-s2i",
+		"name": "jws54-openjdk11-tomcat9-ubi8-https-s2i",
 		"creationTimestamp": null,
 		"annotations": {
-			"description": "An example JBoss Web Server application with a MySQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
+			"description": "An example JBoss Web Server application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
 			"iconClass": "icon-rh-tomcat",
-			"openshift.io/display-name": "JBoss Web Server 5.3 Apache Tomcat 9 OpenJDK8 + MySQL (with https)",
+			"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK11 on UBI8 (with https)",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
-			"tags": "tomcat,tomcat9,java,jboss",
+			"tags": "tomcat,tomcat9,java,jboss,hidden",
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-web-server/",
-			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.3 Apache Tomcat 9 based application, including a build configuration, application deployment configuration, database deployment configuration for MySQL using persistence and secure communication using https.",
+			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.4 Apache Tomcat 9 based application, including a build configuration, application deployment configuration, and secure communication using https.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
 			"version": "1.0"
 		}
 	},
-	"message": "A new persistent JWS application for Apache Tomcat 9 (using MySQL) has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}. For accessing the MySQL database \"${DB_DATABASE}\" use the credentials ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
+	"message": "A new JWS application for Apache Tomcat 9 has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}. Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
 	"objects": [
 		{
 			"apiVersion": "v1",
 			"kind": "Service",
 			"metadata": {
 				"annotations": {
-					"description": "The web server's http port.",
-					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mysql\", \"kind\": \"Service\"}]"
+					"description": "The web server's http port."
 				},
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -48,8 +47,7 @@
 			"kind": "Service",
 			"metadata": {
 				"annotations": {
-					"description": "The web server's https port.",
-					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mysql\", \"kind\": \"Service\"}]"
+					"description": "The web server's https port."
 				},
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -65,30 +63,6 @@
 				],
 				"selector": {
 					"deploymentConfig": "${APPLICATION_NAME}"
-				}
-			}
-		},
-		{
-			"apiVersion": "v1",
-			"kind": "Service",
-			"metadata": {
-				"annotations": {
-					"description": "The database server's port."
-				},
-				"labels": {
-					"application": "${APPLICATION_NAME}"
-				},
-				"name": "${APPLICATION_NAME}-mysql"
-			},
-			"spec": {
-				"ports": [
-					{
-						"port": 3306,
-						"targetPort": 3306
-					}
-				],
-				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-mysql"
 				}
 			}
 		},
@@ -184,7 +158,7 @@
 						"forcePull": true,
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "jboss-webserver53-openjdk8-tomcat9-openshift:1.0",
+							"name": "jboss-webserver54-openjdk11-tomcat9-openshift-ubi8:1.0",
 							"namespace": "${IMAGE_STREAM_NAMESPACE}"
 						}
 					},
@@ -243,38 +217,6 @@
 							{
 								"env": [
 									{
-										"name": "DB_SERVICE_PREFIX_MAPPING",
-										"value": "${APPLICATION_NAME}-mysql=DB"
-									},
-									{
-										"name": "DB_JNDI",
-										"value": "${DB_JNDI}"
-									},
-									{
-										"name": "DB_USERNAME",
-										"value": "${DB_USERNAME}"
-									},
-									{
-										"name": "DB_PASSWORD",
-										"value": "${DB_PASSWORD}"
-									},
-									{
-										"name": "DB_DATABASE",
-										"value": "${DB_DATABASE}"
-									},
-									{
-										"name": "DB_MIN_POOL_SIZE",
-										"value": "${DB_MIN_POOL_SIZE}"
-									},
-									{
-										"name": "DB_MAX_POOL_SIZE",
-										"value": "${DB_MAX_POOL_SIZE}"
-									},
-									{
-										"name": "DB_TX_ISOLATION",
-										"value": "${DB_TX_ISOLATION}"
-									},
-									{
 										"name": "JWS_HTTPS_CERTIFICATE_DIR",
 										"value": "/etc/jws-secret-volume"
 									},
@@ -324,7 +266,7 @@
 										"command": [
 											"/bin/bash",
 											"-c",
-											"curl --noproxy '*' -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer\u0026att=stateName' |grep -iq 'stateName *= *STARTED'"
+											"curl --noproxy '*' -is 'http://localhost:8080/health' | grep -iq '\"status\": \"UP\"'"
 										]
 									}
 								},
@@ -367,155 +309,6 @@
 					}
 				]
 			}
-		},
-		{
-			"apiVersion": "v1",
-			"kind": "DeploymentConfig",
-			"metadata": {
-				"labels": {
-					"application": "${APPLICATION_NAME}"
-				},
-				"name": "${APPLICATION_NAME}-mysql"
-			},
-			"spec": {
-				"replicas": 1,
-				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-mysql"
-				},
-				"strategy": {
-					"type": "Recreate"
-				},
-				"template": {
-					"metadata": {
-						"labels": {
-							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}-mysql"
-						},
-						"name": "${APPLICATION_NAME}-mysql"
-					},
-					"spec": {
-						"containers": [
-							{
-								"env": [
-									{
-										"name": "MYSQL_USER",
-										"value": "${DB_USERNAME}"
-									},
-									{
-										"name": "MYSQL_PASSWORD",
-										"value": "${DB_PASSWORD}"
-									},
-									{
-										"name": "MYSQL_DATABASE",
-										"value": "${DB_DATABASE}"
-									},
-									{
-										"name": "MYSQL_LOWER_CASE_TABLE_NAMES",
-										"value": "${MYSQL_LOWER_CASE_TABLE_NAMES}"
-									},
-									{
-										"name": "MYSQL_MAX_CONNECTIONS",
-										"value": "${MYSQL_MAX_CONNECTIONS}"
-									},
-									{
-										"name": "MYSQL_FT_MIN_WORD_LEN",
-										"value": "${MYSQL_FT_MIN_WORD_LEN}"
-									},
-									{
-										"name": "MYSQL_FT_MAX_WORD_LEN",
-										"value": "${MYSQL_FT_MAX_WORD_LEN}"
-									},
-									{
-										"name": "MYSQL_AIO",
-										"value": "${MYSQL_AIO}"
-									}
-								],
-								"image": "mysql",
-								"livenessProbe": {
-									"initialDelaySeconds": 30,
-									"tcpSocket": {
-										"port": 3306
-									},
-									"timeoutSeconds": 1
-								},
-								"name": "${APPLICATION_NAME}-mysql",
-								"ports": [
-									{
-										"containerPort": 3306,
-										"protocol": "TCP"
-									}
-								],
-								"readinessProbe": {
-									"exec": {
-										"command": [
-											"/bin/sh",
-											"-i",
-											"-c",
-											"MYSQL_PWD=\"$MYSQL_PASSWORD\" mysql -h 127.0.0.1 -u $MYSQL_USER -D $MYSQL_DATABASE -e 'SELECT 1'"
-										]
-									},
-									"initialDelaySeconds": 5,
-									"timeoutSeconds": 1
-								},
-								"volumeMounts": [
-									{
-										"mountPath": "/var/lib/mysql/data",
-										"name": "${APPLICATION_NAME}-mysql-pvol"
-									}
-								]
-							}
-						],
-						"terminationGracePeriodSeconds": 60,
-						"volumes": [
-							{
-								"name": "${APPLICATION_NAME}-mysql-pvol",
-								"persistentVolumeClaim": {
-									"claimName": "${APPLICATION_NAME}-mysql-claim"
-								}
-							}
-						]
-					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${APPLICATION_NAME}-mysql"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "mysql:${MYSQL_IMAGE_STREAM_TAG}",
-								"namespace": "${IMAGE_STREAM_NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
-			}
-		},
-		{
-			"apiVersion": "v1",
-			"kind": "PersistentVolumeClaim",
-			"metadata": {
-				"labels": {
-					"application": "${APPLICATION_NAME}"
-				},
-				"name": "${APPLICATION_NAME}-mysql-claim"
-			},
-			"spec": {
-				"accessModes": [
-					"ReadWriteOnce"
-				],
-				"resources": {
-					"requests": {
-						"storage": "${VOLUME_CAPACITY}"
-					}
-				}
-			}
 		}
 	],
 	"parameters": [
@@ -540,7 +333,7 @@
 			"name": "SOURCE_REPOSITORY_URL",
 			"displayName": "Git Repository URL",
 			"description": "Git source URI for application",
-			"value": "https://github.com/jboss-openshift/openshift-quickstarts",
+			"value": "https://github.com/jboss-openshift/openshift-quickstarts.git",
 			"required": true
 		},
 		{
@@ -553,27 +346,7 @@
 			"name": "CONTEXT_DIR",
 			"displayName": "Context Directory",
 			"description": "Path within Git project to build; empty for root project directory.",
-			"value": "todolist/todolist-jdbc"
-		},
-		{
-			"name": "DB_JNDI",
-			"displayName": "Database JNDI Name",
-			"description": "Database JNDI name used by application to resolve the datasource, e.g. jboss/datasources/mysqlDS",
-			"value": "jboss/datasources/defaultDS"
-		},
-		{
-			"name": "DB_DATABASE",
-			"displayName": "Database Name",
-			"description": "Database name",
-			"value": "root",
-			"required": true
-		},
-		{
-			"name": "VOLUME_CAPACITY",
-			"displayName": "Database Volume Capacity",
-			"description": "Size of persistent storage for database volume.",
-			"value": "1Gi",
-			"required": true
+			"value": "tomcat-websocket-chat"
 		},
 		{
 			"name": "JWS_HTTPS_SECRET",
@@ -598,62 +371,6 @@
 			"name": "JWS_HTTPS_CERTIFICATE_PASSWORD",
 			"displayName": "Certificate Password",
 			"description": "The certificate password"
-		},
-		{
-			"name": "DB_MIN_POOL_SIZE",
-			"displayName": "Datasource Minimum Pool Size",
-			"description": "Sets xa-pool/min-pool-size for the configured datasource."
-		},
-		{
-			"name": "DB_MAX_POOL_SIZE",
-			"displayName": "Datasource Maximum Pool Size",
-			"description": "Sets xa-pool/max-pool-size for the configured datasource."
-		},
-		{
-			"name": "DB_TX_ISOLATION",
-			"displayName": "Datasource Transaction Isolation",
-			"description": "Sets transaction-isolation for the configured datasource."
-		},
-		{
-			"name": "MYSQL_LOWER_CASE_TABLE_NAMES",
-			"displayName": "MySQL Lower Case Table Names",
-			"description": "Sets how the table names are stored and compared."
-		},
-		{
-			"name": "MYSQL_MAX_CONNECTIONS",
-			"displayName": "MySQL Maximum number of connections",
-			"description": "The maximum permitted number of simultaneous client connections."
-		},
-		{
-			"name": "MYSQL_FT_MIN_WORD_LEN",
-			"displayName": "MySQL FullText Minimum Word Length",
-			"description": "The minimum length of the word to be included in a FULLTEXT index."
-		},
-		{
-			"name": "MYSQL_FT_MAX_WORD_LEN",
-			"displayName": "MySQL FullText Maximum Word Length",
-			"description": "The maximum length of the word to be included in a FULLTEXT index."
-		},
-		{
-			"name": "MYSQL_AIO",
-			"displayName": "MySQL AIO",
-			"description": "Controls the innodb_use_native_aio setting value if the native AIO is broken."
-		},
-		{
-			"name": "DB_USERNAME",
-			"displayName": "Database Username",
-			"description": "Database user name",
-			"generate": "expression",
-			"from": "user[a-zA-Z0-9]{3}",
-			"required": true
-		},
-		{
-			"name": "DB_PASSWORD",
-			"displayName": "Database Password",
-			"description": "Database user password",
-			"generate": "expression",
-			"from": "[a-zA-Z0-9]{8}",
-			"required": true
 		},
 		{
 			"name": "JWS_ADMIN_USERNAME",
@@ -702,17 +419,10 @@
 		{
 			"name": "ARTIFACT_DIR",
 			"description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied."
-		},
-		{
-			"name": "MYSQL_IMAGE_STREAM_TAG",
-			"displayName": "MySQL Image Stream Tag",
-			"description": "The tag to use for the \"mysql\" image stream.  Typically, this aligns with the major.minor version of MySQL.",
-			"value": "5.7",
-			"required": true
 		}
 	],
 	"labels": {
-		"jws53": "1.0",
-		"template": "jws53-openjdk8-tomcat9-mysql-persistent-s2i"
+		"jws54jdk11ubi8": "1.0",
+		"template": "jws54-openjdk11-tomcat9-ubi8-https-s2i"
 	}
 }

--- a/official/webserver/templates/jws54-openjdk8-tomcat9-rhel7-basic-s2i.json
+++ b/official/webserver/templates/jws54-openjdk8-tomcat9-rhel7-basic-s2i.json
@@ -2,16 +2,16 @@
 	"kind": "Template",
 	"apiVersion": "v1",
 	"metadata": {
-		"name": "jws53-openjdk8-tomcat9-basic-s2i",
+		"name": "jws54-openjdk8-tomcat9-rhel7-basic-s2i",
 		"creationTimestamp": null,
 		"annotations": {
 			"description": "An example JBoss Web Server application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
 			"iconClass": "icon-rh-tomcat",
-			"openshift.io/display-name": "JBoss Web Server 5.3 Apache Tomcat 9 OpenJDK8 (no https)",
+			"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK8 on RHEL7 (no https)",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
 			"tags": "tomcat,tomcat9,java,jboss",
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-web-server/",
-			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.3 Apache Tomcat 9 based application, including a build configuration, and an application deployment configuration.",
+			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.4 Apache Tomcat 9 based application, including a build configuration, and an application deployment configuration.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
 			"version": "1.0"
 		}
@@ -111,7 +111,7 @@
 						"forcePull": true,
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "jboss-webserver53-openjdk8-tomcat9-openshift:1.0",
+							"name": "jboss-webserver54-openjdk8-tomcat9-openshift-rhel7:1.0",
 							"namespace": "${IMAGE_STREAM_NAMESPACE}"
 						}
 					},
@@ -198,7 +198,7 @@
 										"command": [
 											"/bin/bash",
 											"-c",
-											"curl --noproxy '*' -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer\u0026att=stateName' |grep -iq 'stateName *= *STARTED'"
+											"curl --noproxy '*' -is 'http://localhost:8080/health' | grep -iq '\"status\": \"UP\"'"
 										]
 									}
 								}
@@ -310,7 +310,7 @@
 		}
 	],
 	"labels": {
-		"jws53": "1.0",
-		"template": "jws53-openjdk8-tomcat9-basic-s2i"
+		"jws54jdk8el7": "1.0",
+		"template": "jws54-openjdk8-tomcat9-rhel7-basic-s2i"
 	}
 }

--- a/official/webserver/templates/jws54-openjdk8-tomcat9-rhel7-https-s2i.json
+++ b/official/webserver/templates/jws54-openjdk8-tomcat9-rhel7-https-s2i.json
@@ -2,26 +2,28 @@
 	"kind": "Template",
 	"apiVersion": "v1",
 	"metadata": {
-		"name": "jws53-openjdk11-tomcat9-mongodb-s2i",
+		"name": "jws54-openjdk8-tomcat9-rhel7-https-s2i",
 		"creationTimestamp": null,
 		"annotations": {
-			"description": "Application template for JWS MongoDB applications built using S2I.",
+			"description": "An example JBoss Web Server application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
 			"iconClass": "icon-rh-tomcat",
-			"openshift.io/display-name": "JBoss Web Server 5.3 Apache Tomcat 9 OpenJDK11 + MongoDB (Ephemeral with https)",
+			"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK8 on RHEL7 (with https)",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
 			"tags": "tomcat,tomcat9,java,jboss,hidden",
+			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-web-server/",
+			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.4 Apache Tomcat 9 based application, including a build configuration, application deployment configuration, and secure communication using https.",
+			"template.openshift.io/support-url": "https://access.redhat.com",
 			"version": "1.0"
 		}
 	},
-	"message": "A new JWS application for Apache Tomcat 9 (using MongoDB) has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}. For accessing the MongoDB database \"${DB_DATABASE}\" use the credentials ${DB_USERNAME}/${DB_PASSWORD} (Admin password is \"${DB_ADMIN_PASSWORD}\"). Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
+	"message": "A new JWS application for Apache Tomcat 9 has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}. Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
 	"objects": [
 		{
 			"apiVersion": "v1",
 			"kind": "Service",
 			"metadata": {
 				"annotations": {
-					"description": "The web server's http port.",
-					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mongodb\", \"kind\": \"Service\"}]"
+					"description": "The web server's http port."
 				},
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -45,8 +47,7 @@
 			"kind": "Service",
 			"metadata": {
 				"annotations": {
-					"description": "The web server's https port.",
-					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mongodb\", \"kind\": \"Service\"}]"
+					"description": "The web server's https port."
 				},
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -62,30 +63,6 @@
 				],
 				"selector": {
 					"deploymentConfig": "${APPLICATION_NAME}"
-				}
-			}
-		},
-		{
-			"apiVersion": "v1",
-			"kind": "Service",
-			"metadata": {
-				"annotations": {
-					"description": "The database server's port."
-				},
-				"labels": {
-					"application": "${APPLICATION_NAME}"
-				},
-				"name": "${APPLICATION_NAME}-mongodb"
-			},
-			"spec": {
-				"ports": [
-					{
-						"port": 27017,
-						"targetPort": 27017
-					}
-				],
-				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-mongodb"
 				}
 			}
 		},
@@ -181,7 +158,7 @@
 						"forcePull": true,
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "jboss-webserver53-openjdk11-tomcat9-openshift:1.0",
+							"name": "jboss-webserver54-openjdk8-tomcat9-openshift-rhel7:1.0",
 							"namespace": "${IMAGE_STREAM_NAMESPACE}"
 						}
 					},
@@ -240,42 +217,6 @@
 							{
 								"env": [
 									{
-										"name": "DB_SERVICE_PREFIX_MAPPING",
-										"value": "${APPLICATION_NAME}-mongodb=DB"
-									},
-									{
-										"name": "DB_JNDI",
-										"value": "${DB_JNDI}"
-									},
-									{
-										"name": "DB_USERNAME",
-										"value": "${DB_USERNAME}"
-									},
-									{
-										"name": "DB_PASSWORD",
-										"value": "${DB_PASSWORD}"
-									},
-									{
-										"name": "DB_DATABASE",
-										"value": "${DB_DATABASE}"
-									},
-									{
-										"name": "DB_ADMIN_PASSWORD",
-										"value": "${DB_ADMIN_PASSWORD}"
-									},
-									{
-										"name": "DB_MIN_POOL_SIZE",
-										"value": "${DB_MIN_POOL_SIZE}"
-									},
-									{
-										"name": "DB_MAX_POOL_SIZE",
-										"value": "${DB_MAX_POOL_SIZE}"
-									},
-									{
-										"name": "DB_TX_ISOLATION",
-										"value": "${DB_TX_ISOLATION}"
-									},
-									{
 										"name": "JWS_HTTPS_CERTIFICATE_DIR",
 										"value": "/etc/jws-secret-volume"
 									},
@@ -325,7 +266,7 @@
 										"command": [
 											"/bin/bash",
 											"-c",
-											"curl --noproxy '*' -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer\u0026att=stateName' |grep -iq 'stateName *= *STARTED'"
+											"curl --noproxy '*' -is 'http://localhost:8080/health' | grep -iq '\"status\": \"UP\"'"
 										]
 									}
 								},
@@ -368,132 +309,6 @@
 					}
 				]
 			}
-		},
-		{
-			"apiVersion": "v1",
-			"kind": "DeploymentConfig",
-			"metadata": {
-				"labels": {
-					"application": "${APPLICATION_NAME}"
-				},
-				"name": "${APPLICATION_NAME}-mongodb"
-			},
-			"spec": {
-				"replicas": 1,
-				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-mongodb"
-				},
-				"strategy": {
-					"type": "Recreate"
-				},
-				"template": {
-					"metadata": {
-						"labels": {
-							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}-mongodb"
-						},
-						"name": "${APPLICATION_NAME}-mongodb"
-					},
-					"spec": {
-						"containers": [
-							{
-								"env": [
-									{
-										"name": "MONGODB_USER",
-										"value": "${DB_USERNAME}"
-									},
-									{
-										"name": "MONGODB_PASSWORD",
-										"value": "${DB_PASSWORD}"
-									},
-									{
-										"name": "MONGODB_DATABASE",
-										"value": "${DB_DATABASE}"
-									},
-									{
-										"name": "MONGODB_ADMIN_PASSWORD",
-										"value": "${DB_ADMIN_PASSWORD}"
-									},
-									{
-										"name": "MONGODB_NOPREALLOC",
-										"value": "${MONGODB_NOPREALLOC}"
-									},
-									{
-										"name": "MONGODB_SMALLFILES",
-										"value": "${MONGODB_SMALLFILES}"
-									},
-									{
-										"name": "MONGODB_QUIET",
-										"value": "${MONGODB_QUIET}"
-									}
-								],
-								"image": "mongodb",
-								"imagePullPolicy": "Always",
-								"livenessProbe": {
-									"initialDelaySeconds": 30,
-									"tcpSocket": {
-										"port": 27017
-									},
-									"timeoutSeconds": 1
-								},
-								"name": "${APPLICATION_NAME}-mongodb",
-								"ports": [
-									{
-										"containerPort": 27017,
-										"protocol": "TCP"
-									}
-								],
-								"readinessProbe": {
-									"exec": {
-										"command": [
-											"/bin/sh",
-											"-i",
-											"-c",
-											"mongo 127.0.0.1:27017/$MONGODB_DATABASE -u $MONGODB_USER -p $MONGODB_PASSWORD --eval=\"quit()\""
-										]
-									},
-									"initialDelaySeconds": 3,
-									"timeoutSeconds": 1
-								},
-								"volumeMounts": [
-									{
-										"mountPath": "/var/lib/mongodb/data",
-										"name": "${APPLICATION_NAME}-data"
-									}
-								]
-							}
-						],
-						"terminationGracePeriodSeconds": 60,
-						"volumes": [
-							{
-								"emptyDir": {
-									"medium": ""
-								},
-								"name": "${APPLICATION_NAME}-data"
-							}
-						]
-					}
-				},
-				"triggers": [
-					{
-						"imageChangeParams": {
-							"automatic": true,
-							"containerNames": [
-								"${APPLICATION_NAME}-mongodb"
-							],
-							"from": {
-								"kind": "ImageStreamTag",
-								"name": "mongodb:${MONGODB_IMAGE_STREAM_TAG}",
-								"namespace": "${IMAGE_STREAM_NAMESPACE}"
-							}
-						},
-						"type": "ImageChange"
-					},
-					{
-						"type": "ConfigChange"
-					}
-				]
-			}
 		}
 	],
 	"parameters": [
@@ -518,7 +333,7 @@
 			"name": "SOURCE_REPOSITORY_URL",
 			"displayName": "Git Repository URL",
 			"description": "Git source URI for application",
-			"value": "https://github.com/jboss-openshift/openshift-quickstarts",
+			"value": "https://github.com/jboss-openshift/openshift-quickstarts.git",
 			"required": true
 		},
 		{
@@ -531,19 +346,7 @@
 			"name": "CONTEXT_DIR",
 			"displayName": "Context Directory",
 			"description": "Path within Git project to build; empty for root project directory.",
-			"value": "todolist/todolist-mongodb"
-		},
-		{
-			"name": "DB_JNDI",
-			"displayName": "Database JNDI Name",
-			"description": "Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb"
-		},
-		{
-			"name": "DB_DATABASE",
-			"displayName": "Database Name",
-			"description": "Database name",
-			"value": "root",
-			"required": true
+			"value": "tomcat-websocket-chat"
 		},
 		{
 			"name": "JWS_HTTPS_SECRET",
@@ -568,60 +371,6 @@
 			"name": "JWS_HTTPS_CERTIFICATE_PASSWORD",
 			"displayName": "Certificate Password",
 			"description": "The certificate password"
-		},
-		{
-			"name": "DB_MIN_POOL_SIZE",
-			"displayName": "Datasource Minimum Pool Size",
-			"description": "Sets xa-pool/min-pool-size for the configured datasource."
-		},
-		{
-			"name": "DB_MAX_POOL_SIZE",
-			"displayName": "Datasource Maximum Pool Size",
-			"description": "Sets xa-pool/max-pool-size for the configured datasource."
-		},
-		{
-			"name": "DB_TX_ISOLATION",
-			"displayName": "Datasource Transaction Isolation",
-			"description": "Sets transaction-isolation for the configured datasource."
-		},
-		{
-			"name": "MONGODB_NOPREALLOC",
-			"displayName": "MongoDB No Preallocation",
-			"description": "Disable data file preallocation."
-		},
-		{
-			"name": "MONGODB_SMALLFILES",
-			"displayName": "MongoDB Small Files",
-			"description": "Set MongoDB to use a smaller default data file size."
-		},
-		{
-			"name": "MONGODB_QUIET",
-			"displayName": "MongoDB Quiet",
-			"description": "Runs MongoDB in a quiet mode that attempts to limit the amount of output."
-		},
-		{
-			"name": "DB_USERNAME",
-			"displayName": "Database Username",
-			"description": "Database user name",
-			"generate": "expression",
-			"from": "user[a-zA-Z0-9]{3}",
-			"required": true
-		},
-		{
-			"name": "DB_PASSWORD",
-			"displayName": "Database Password",
-			"description": "Database user password",
-			"generate": "expression",
-			"from": "[a-zA-Z0-9]{8}",
-			"required": true
-		},
-		{
-			"name": "DB_ADMIN_PASSWORD",
-			"displayName": "Database admin password",
-			"description": "Database admin password",
-			"generate": "expression",
-			"from": "[a-zA-Z0-9]{8}",
-			"required": true
 		},
 		{
 			"name": "JWS_ADMIN_USERNAME",
@@ -670,17 +419,10 @@
 		{
 			"name": "ARTIFACT_DIR",
 			"description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied."
-		},
-		{
-			"name": "MONGODB_IMAGE_STREAM_TAG",
-			"displayName": "MongoDB Image Stream Tag",
-			"description": "The tag to use for the \"mongodb\" image stream.  Typically, this aligns with the major.minor version of MongoDB.",
-			"value": "3.2",
-			"required": true
 		}
 	],
 	"labels": {
-		"jws53": "1.0",
-		"template": "jws53-openjdk11-tomcat9-mongodb-s2i"
+		"jws54jdk8el7": "1.0",
+		"template": "jws54-openjdk8-tomcat9-rhel7-https-s2i"
 	}
 }

--- a/official/webserver/templates/jws54-openjdk8-tomcat9-rhel7-mongodb-persistent-s2i.json
+++ b/official/webserver/templates/jws54-openjdk8-tomcat9-rhel7-mongodb-persistent-s2i.json
@@ -2,18 +2,21 @@
 	"kind": "Template",
 	"apiVersion": "v1",
 	"metadata": {
-		"name": "jws53-openjdk8-tomcat9-postgresql-persistent-s2i",
+		"name": "jws54-openjdk8-tomcat9-rhel7-mongodb-persistent-s2i",
 		"creationTimestamp": null,
 		"annotations": {
-			"description": "Application template for JWS PostgreSQL applications with persistent storage built using S2I.",
+			"description": "An example JBoss Web Server application with a MongoDB database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
 			"iconClass": "icon-rh-tomcat",
-			"openshift.io/display-name": "JBoss Web Server 5.3 Apache Tomcat 9 OpenJDK8 + PostgreSQL (with https)",
+			"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK8 on RHEL7 + MongoDB (with https)",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
 			"tags": "tomcat,tomcat9,java,jboss",
+			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-web-server/",
+			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.4 Apache Tomcat 9 based application, including a build configuration, application deployment configuration, database deployment configuration for MongoDB using persistence and secure communication using https.",
+			"template.openshift.io/support-url": "https://access.redhat.com",
 			"version": "1.0"
 		}
 	},
-	"message": "A new persistent JWS application for Apache Tomcat 9 (using PostgreSQL) has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}. For accessing the PostgreSQL database \"${DB_DATABASE}\" use the credentials ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
+	"message": "A new persistent JWS application for Apache Tomcat 9 (using MongoDB) has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}. For accessing the MongoDB database \"${DB_DATABASE}\" use the credentials ${DB_USERNAME}/${DB_PASSWORD} (Admin password is \"${DB_ADMIN_PASSWORD}\"). Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
 	"objects": [
 		{
 			"apiVersion": "v1",
@@ -21,7 +24,7 @@
 			"metadata": {
 				"annotations": {
 					"description": "The web server's http port.",
-					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-postgresql\", \"kind\": \"Service\"}]"
+					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mongodb\", \"kind\": \"Service\"}]"
 				},
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -46,7 +49,7 @@
 			"metadata": {
 				"annotations": {
 					"description": "The web server's https port.",
-					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-postgresql\", \"kind\": \"Service\"}]"
+					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mongodb\", \"kind\": \"Service\"}]"
 				},
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -75,17 +78,17 @@
 				"labels": {
 					"application": "${APPLICATION_NAME}"
 				},
-				"name": "${APPLICATION_NAME}-postgresql"
+				"name": "${APPLICATION_NAME}-mongodb"
 			},
 			"spec": {
 				"ports": [
 					{
-						"port": 5432,
-						"targetPort": 5432
+						"port": 27017,
+						"targetPort": 27017
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deploymentConfig": "${APPLICATION_NAME}-mongodb"
 				}
 			}
 		},
@@ -181,7 +184,7 @@
 						"forcePull": true,
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "jboss-webserver53-openjdk8-tomcat9-openshift:1.0",
+							"name": "jboss-webserver54-openjdk8-tomcat9-openshift-rhel7:1.0",
 							"namespace": "${IMAGE_STREAM_NAMESPACE}"
 						}
 					},
@@ -241,7 +244,7 @@
 								"env": [
 									{
 										"name": "DB_SERVICE_PREFIX_MAPPING",
-										"value": "${APPLICATION_NAME}-postgresql=DB"
+										"value": "${APPLICATION_NAME}-mongodb=DB"
 									},
 									{
 										"name": "DB_JNDI",
@@ -258,6 +261,10 @@
 									{
 										"name": "DB_DATABASE",
 										"value": "${DB_DATABASE}"
+									},
+									{
+										"name": "DB_ADMIN_PASSWORD",
+										"value": "${DB_ADMIN_PASSWORD}"
 									},
 									{
 										"name": "DB_MIN_POOL_SIZE",
@@ -321,7 +328,7 @@
 										"command": [
 											"/bin/bash",
 											"-c",
-											"curl --noproxy '*' -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer\u0026att=stateName' |grep -iq 'stateName *= *STARTED'"
+											"curl --noproxy '*' -is 'http://localhost:8080/health' | grep -iq '\"status\": \"UP\"'"
 										]
 									}
 								},
@@ -372,12 +379,12 @@
 				"labels": {
 					"application": "${APPLICATION_NAME}"
 				},
-				"name": "${APPLICATION_NAME}-postgresql"
+				"name": "${APPLICATION_NAME}-mongodb"
 			},
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+					"deploymentConfig": "${APPLICATION_NAME}-mongodb"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -386,51 +393,56 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+							"deploymentConfig": "${APPLICATION_NAME}-mongodb"
 						},
-						"name": "${APPLICATION_NAME}-postgresql"
+						"name": "${APPLICATION_NAME}-mongodb"
 					},
 					"spec": {
 						"containers": [
 							{
 								"env": [
 									{
-										"name": "POSTGRESQL_USER",
+										"name": "MONGODB_USER",
 										"value": "${DB_USERNAME}"
 									},
 									{
-										"name": "POSTGRESQL_PASSWORD",
+										"name": "MONGODB_PASSWORD",
 										"value": "${DB_PASSWORD}"
 									},
 									{
-										"name": "POSTGRESQL_DATABASE",
+										"name": "MONGODB_DATABASE",
 										"value": "${DB_DATABASE}"
 									},
 									{
-										"name": "POSTGRESQL_MAX_CONNECTIONS",
-										"value": "${POSTGRESQL_MAX_CONNECTIONS}"
+										"name": "MONGODB_ADMIN_PASSWORD",
+										"value": "${DB_ADMIN_PASSWORD}"
 									},
 									{
-										"name": "POSTGRESQL_MAX_PREPARED_TRANSACTIONS",
-										"value": "${POSTGRESQL_MAX_CONNECTIONS}"
+										"name": "MONGODB_NOPREALLOC",
+										"value": "${MONGODB_NOPREALLOC}"
 									},
 									{
-										"name": "POSTGRESQL_SHARED_BUFFERS",
-										"value": "${POSTGRESQL_SHARED_BUFFERS}"
+										"name": "MONGODB_SMALLFILES",
+										"value": "${MONGODB_SMALLFILES}"
+									},
+									{
+										"name": "MONGODB_QUIET",
+										"value": "${MONGODB_QUIET}"
 									}
 								],
-								"image": "postgresql",
+								"image": "mongodb",
+								"imagePullPolicy": "Always",
 								"livenessProbe": {
 									"initialDelaySeconds": 30,
 									"tcpSocket": {
-										"port": 5432
+										"port": 27017
 									},
 									"timeoutSeconds": 1
 								},
-								"name": "${APPLICATION_NAME}-postgresql",
+								"name": "${APPLICATION_NAME}-mongodb",
 								"ports": [
 									{
-										"containerPort": 5432,
+										"containerPort": 27017,
 										"protocol": "TCP"
 									}
 								],
@@ -440,16 +452,16 @@
 											"/bin/sh",
 											"-i",
 											"-c",
-											"psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'"
+											"mongo 127.0.0.1:27017/$MONGODB_DATABASE -u $MONGODB_USER -p $MONGODB_PASSWORD --eval=\"quit()\""
 										]
 									},
-									"initialDelaySeconds": 5,
+									"initialDelaySeconds": 3,
 									"timeoutSeconds": 1
 								},
 								"volumeMounts": [
 									{
-										"mountPath": "/var/lib/pgsql/data",
-										"name": "${APPLICATION_NAME}-postgresql-pvol"
+										"mountPath": "/var/lib/mongodb/data",
+										"name": "${APPLICATION_NAME}-mongodb-pvol"
 									}
 								]
 							}
@@ -457,9 +469,9 @@
 						"terminationGracePeriodSeconds": 60,
 						"volumes": [
 							{
-								"name": "${APPLICATION_NAME}-postgresql-pvol",
+								"name": "${APPLICATION_NAME}-mongodb-pvol",
 								"persistentVolumeClaim": {
-									"claimName": "${APPLICATION_NAME}-postgresql-claim"
+									"claimName": "${APPLICATION_NAME}-mongodb-claim"
 								}
 							}
 						]
@@ -470,11 +482,11 @@
 						"imageChangeParams": {
 							"automatic": true,
 							"containerNames": [
-								"${APPLICATION_NAME}-postgresql"
+								"${APPLICATION_NAME}-mongodb"
 							],
 							"from": {
 								"kind": "ImageStreamTag",
-								"name": "postgresql:${POSTGRESQL_IMAGE_STREAM_TAG}",
+								"name": "mongodb:${MONGODB_IMAGE_STREAM_TAG}",
 								"namespace": "${IMAGE_STREAM_NAMESPACE}"
 							}
 						},
@@ -493,7 +505,7 @@
 				"labels": {
 					"application": "${APPLICATION_NAME}"
 				},
-				"name": "${APPLICATION_NAME}-postgresql-claim"
+				"name": "${APPLICATION_NAME}-mongodb-claim"
 			},
 			"spec": {
 				"accessModes": [
@@ -542,13 +554,12 @@
 			"name": "CONTEXT_DIR",
 			"displayName": "Context Directory",
 			"description": "Path within Git project to build; empty for root project directory.",
-			"value": "todolist/todolist-jdbc"
+			"value": "todolist/todolist-mongodb"
 		},
 		{
 			"name": "DB_JNDI",
 			"displayName": "Database JNDI Name",
-			"description": "Database JNDI name used by application to resolve the datasource, e.g. jboss/datasources/postgresqlDS",
-			"value": "jboss/datasources/defaultDS"
+			"description": "Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb"
 		},
 		{
 			"name": "DB_DATABASE",
@@ -604,14 +615,19 @@
 			"description": "Sets transaction-isolation for the configured datasource."
 		},
 		{
-			"name": "POSTGRESQL_MAX_CONNECTIONS",
-			"displayName": "PostgreSQL Maximum number of connections",
-			"description": "The maximum number of client connections allowed. This also sets the maximum number of prepared transactions."
+			"name": "MONGODB_NOPREALLOC",
+			"displayName": "MongoDB No Preallocation",
+			"description": "Disable data file preallocation."
 		},
 		{
-			"name": "POSTGRESQL_SHARED_BUFFERS",
-			"displayName": "PostgreSQL Shared Buffers",
-			"description": "Configures how much memory is dedicated to PostgreSQL for caching data."
+			"name": "MONGODB_SMALLFILES",
+			"displayName": "MongoDB Small Files",
+			"description": "Set MongoDB to use a smaller default data file size."
+		},
+		{
+			"name": "MONGODB_QUIET",
+			"displayName": "MongoDB Quiet",
+			"description": "Runs MongoDB in a quiet mode that attempts to limit the amount of output."
 		},
 		{
 			"name": "DB_USERNAME",
@@ -625,6 +641,14 @@
 			"name": "DB_PASSWORD",
 			"displayName": "Database Password",
 			"description": "Database user password",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "DB_ADMIN_PASSWORD",
+			"displayName": "Database admin password",
+			"description": "Database admin password",
 			"generate": "expression",
 			"from": "[a-zA-Z0-9]{8}",
 			"required": true
@@ -678,15 +702,15 @@
 			"description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied."
 		},
 		{
-			"name": "POSTGRESQL_IMAGE_STREAM_TAG",
-			"displayName": "PostgreSQL Image Stream Tag",
-			"description": "The tag to use for the \"postgresql\" image stream.  Typically, this aligns with the major.minor version of PostgreSQL.",
-			"value": "9.5",
+			"name": "MONGODB_IMAGE_STREAM_TAG",
+			"displayName": "MongoDB Image Stream Tag",
+			"description": "The tag to use for the \"mongodb\" image stream.  Typically, this aligns with the major.minor version of MongoDB.",
+			"value": "3.2",
 			"required": true
 		}
 	],
 	"labels": {
-		"jws53": "1.0",
-		"template": "jws53-openjdk8-tomcat9-postgresql-persistent-s2i"
+		"jws54jdk8el7": "1.0",
+		"template": "jws54-openjdk8-tomcat9-rhel7-mongodb-persistent-s2i"
 	}
 }

--- a/official/webserver/templates/jws54-openjdk8-tomcat9-rhel7-mongodb-s2i.json
+++ b/official/webserver/templates/jws54-openjdk8-tomcat9-rhel7-mongodb-s2i.json
@@ -1,0 +1,686 @@
+{
+	"kind": "Template",
+	"apiVersion": "v1",
+	"metadata": {
+		"name": "jws54-openjdk8-tomcat9-rhel7-mongodb-s2i",
+		"creationTimestamp": null,
+		"annotations": {
+			"description": "Application template for JWS MongoDB applications built using S2I.",
+			"iconClass": "icon-rh-tomcat",
+			"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK8 on RHEL7 + MongoDB (Ephemeral with https)",
+			"openshift.io/provider-display-name": "Red Hat, Inc.",
+			"tags": "tomcat,tomcat9,java,jboss,hidden",
+			"version": "1.0"
+		}
+	},
+	"message": "A new JWS application for Apache Tomcat 9 (using MongoDB) has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}. For accessing the MongoDB database \"${DB_DATABASE}\" use the credentials ${DB_USERNAME}/${DB_PASSWORD} (Admin password is \"${DB_ADMIN_PASSWORD}\"). Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
+	"objects": [
+		{
+			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"description": "The web server's http port.",
+					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mongodb\", \"kind\": \"Service\"}]"
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}"
+			},
+			"spec": {
+				"ports": [
+					{
+						"port": 8080,
+						"targetPort": 8080
+					}
+				],
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"description": "The web server's https port.",
+					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mongodb\", \"kind\": \"Service\"}]"
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "secure-${APPLICATION_NAME}"
+			},
+			"spec": {
+				"ports": [
+					{
+						"port": 8443,
+						"targetPort": 8443
+					}
+				],
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"description": "The database server's port."
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}-mongodb"
+			},
+			"spec": {
+				"ports": [
+					{
+						"port": 27017,
+						"targetPort": 27017
+					}
+				],
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}-mongodb"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"id": "${APPLICATION_NAME}-http",
+			"kind": "Route",
+			"metadata": {
+				"annotations": {
+					"description": "Route for application's http service."
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}"
+			},
+			"spec": {
+				"host": "${HOSTNAME_HTTP}",
+				"to": {
+					"name": "${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"id": "${APPLICATION_NAME}-https",
+			"kind": "Route",
+			"metadata": {
+				"annotations": {
+					"description": "Route for application's https service."
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "secure-${APPLICATION_NAME}"
+			},
+			"spec": {
+				"host": "${HOSTNAME_HTTPS}",
+				"tls": {
+					"termination": "passthrough"
+				},
+				"to": {
+					"name": "secure-${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "ImageStream",
+			"metadata": {
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}"
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "BuildConfig",
+			"metadata": {
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}"
+			},
+			"spec": {
+				"output": {
+					"to": {
+						"kind": "ImageStreamTag",
+						"name": "${APPLICATION_NAME}:latest"
+					}
+				},
+				"source": {
+					"contextDir": "${CONTEXT_DIR}",
+					"git": {
+						"ref": "${SOURCE_REPOSITORY_REF}",
+						"uri": "${SOURCE_REPOSITORY_URL}"
+					},
+					"type": "Git"
+				},
+				"strategy": {
+					"sourceStrategy": {
+						"env": [
+							{
+								"name": "MAVEN_MIRROR_URL",
+								"value": "${MAVEN_MIRROR_URL}"
+							},
+							{
+								"name": "ARTIFACT_DIR",
+								"value": "${ARTIFACT_DIR}"
+							}
+						],
+						"forcePull": true,
+						"from": {
+							"kind": "ImageStreamTag",
+							"name": "jboss-webserver54-openjdk8-tomcat9-openshift-rhel7:1.0",
+							"namespace": "${IMAGE_STREAM_NAMESPACE}"
+						}
+					},
+					"type": "Source"
+				},
+				"triggers": [
+					{
+						"github": {
+							"secret": "${GITHUB_WEBHOOK_SECRET}"
+						},
+						"type": "GitHub"
+					},
+					{
+						"generic": {
+							"secret": "${GENERIC_WEBHOOK_SECRET}"
+						},
+						"type": "Generic"
+					},
+					{
+						"imageChange": {},
+						"type": "ImageChange"
+					},
+					{
+						"type": "ConfigChange"
+					}
+				]
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "DeploymentConfig",
+			"metadata": {
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}"
+			},
+			"spec": {
+				"replicas": 1,
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}"
+				},
+				"strategy": {
+					"type": "Recreate"
+				},
+				"template": {
+					"metadata": {
+						"labels": {
+							"application": "${APPLICATION_NAME}",
+							"deploymentConfig": "${APPLICATION_NAME}"
+						},
+						"name": "${APPLICATION_NAME}"
+					},
+					"spec": {
+						"containers": [
+							{
+								"env": [
+									{
+										"name": "DB_SERVICE_PREFIX_MAPPING",
+										"value": "${APPLICATION_NAME}-mongodb=DB"
+									},
+									{
+										"name": "DB_JNDI",
+										"value": "${DB_JNDI}"
+									},
+									{
+										"name": "DB_USERNAME",
+										"value": "${DB_USERNAME}"
+									},
+									{
+										"name": "DB_PASSWORD",
+										"value": "${DB_PASSWORD}"
+									},
+									{
+										"name": "DB_DATABASE",
+										"value": "${DB_DATABASE}"
+									},
+									{
+										"name": "DB_ADMIN_PASSWORD",
+										"value": "${DB_ADMIN_PASSWORD}"
+									},
+									{
+										"name": "DB_MIN_POOL_SIZE",
+										"value": "${DB_MIN_POOL_SIZE}"
+									},
+									{
+										"name": "DB_MAX_POOL_SIZE",
+										"value": "${DB_MAX_POOL_SIZE}"
+									},
+									{
+										"name": "DB_TX_ISOLATION",
+										"value": "${DB_TX_ISOLATION}"
+									},
+									{
+										"name": "JWS_HTTPS_CERTIFICATE_DIR",
+										"value": "/etc/jws-secret-volume"
+									},
+									{
+										"name": "JWS_HTTPS_CERTIFICATE",
+										"value": "${JWS_HTTPS_CERTIFICATE}"
+									},
+									{
+										"name": "JWS_HTTPS_CERTIFICATE_KEY",
+										"value": "${JWS_HTTPS_CERTIFICATE_KEY}"
+									},
+									{
+										"name": "JWS_HTTPS_CERTIFICATE_PASSWORD",
+										"value": "${JWS_HTTPS_CERTIFICATE_PASSWORD}"
+									},
+									{
+										"name": "JWS_ADMIN_USERNAME",
+										"value": "${JWS_ADMIN_USERNAME}"
+									},
+									{
+										"name": "JWS_ADMIN_PASSWORD",
+										"value": "${JWS_ADMIN_PASSWORD}"
+									}
+								],
+								"image": "${APPLICATION_NAME}",
+								"imagePullPolicy": "Always",
+								"name": "${APPLICATION_NAME}",
+								"ports": [
+									{
+										"containerPort": 8778,
+										"name": "jolokia",
+										"protocol": "TCP"
+									},
+									{
+										"containerPort": 8080,
+										"name": "http",
+										"protocol": "TCP"
+									},
+									{
+										"containerPort": 8443,
+										"name": "https",
+										"protocol": "TCP"
+									}
+								],
+								"readinessProbe": {
+									"exec": {
+										"command": [
+											"/bin/bash",
+											"-c",
+											"curl --noproxy '*' -is 'http://localhost:8080/health' | grep -iq '\"status\": \"UP\"'"
+										]
+									}
+								},
+								"volumeMounts": [
+									{
+										"mountPath": "/etc/jws-secret-volume",
+										"name": "jws-certificate-volume",
+										"readOnly": true
+									}
+								]
+							}
+						],
+						"terminationGracePeriodSeconds": 60,
+						"volumes": [
+							{
+								"name": "jws-certificate-volume",
+								"secret": {
+									"secretName": "${JWS_HTTPS_SECRET}"
+								}
+							}
+						]
+					}
+				},
+				"triggers": [
+					{
+						"imageChangeParams": {
+							"automatic": true,
+							"containerNames": [
+								"${APPLICATION_NAME}"
+							],
+							"from": {
+								"kind": "ImageStreamTag",
+								"name": "${APPLICATION_NAME}:latest"
+							}
+						},
+						"type": "ImageChange"
+					},
+					{
+						"type": "ConfigChange"
+					}
+				]
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "DeploymentConfig",
+			"metadata": {
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}-mongodb"
+			},
+			"spec": {
+				"replicas": 1,
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}-mongodb"
+				},
+				"strategy": {
+					"type": "Recreate"
+				},
+				"template": {
+					"metadata": {
+						"labels": {
+							"application": "${APPLICATION_NAME}",
+							"deploymentConfig": "${APPLICATION_NAME}-mongodb"
+						},
+						"name": "${APPLICATION_NAME}-mongodb"
+					},
+					"spec": {
+						"containers": [
+							{
+								"env": [
+									{
+										"name": "MONGODB_USER",
+										"value": "${DB_USERNAME}"
+									},
+									{
+										"name": "MONGODB_PASSWORD",
+										"value": "${DB_PASSWORD}"
+									},
+									{
+										"name": "MONGODB_DATABASE",
+										"value": "${DB_DATABASE}"
+									},
+									{
+										"name": "MONGODB_ADMIN_PASSWORD",
+										"value": "${DB_ADMIN_PASSWORD}"
+									},
+									{
+										"name": "MONGODB_NOPREALLOC",
+										"value": "${MONGODB_NOPREALLOC}"
+									},
+									{
+										"name": "MONGODB_SMALLFILES",
+										"value": "${MONGODB_SMALLFILES}"
+									},
+									{
+										"name": "MONGODB_QUIET",
+										"value": "${MONGODB_QUIET}"
+									}
+								],
+								"image": "mongodb",
+								"imagePullPolicy": "Always",
+								"livenessProbe": {
+									"initialDelaySeconds": 30,
+									"tcpSocket": {
+										"port": 27017
+									},
+									"timeoutSeconds": 1
+								},
+								"name": "${APPLICATION_NAME}-mongodb",
+								"ports": [
+									{
+										"containerPort": 27017,
+										"protocol": "TCP"
+									}
+								],
+								"readinessProbe": {
+									"exec": {
+										"command": [
+											"/bin/sh",
+											"-i",
+											"-c",
+											"mongo 127.0.0.1:27017/$MONGODB_DATABASE -u $MONGODB_USER -p $MONGODB_PASSWORD --eval=\"quit()\""
+										]
+									},
+									"initialDelaySeconds": 3,
+									"timeoutSeconds": 1
+								},
+								"volumeMounts": [
+									{
+										"mountPath": "/var/lib/mongodb/data",
+										"name": "${APPLICATION_NAME}-data"
+									}
+								]
+							}
+						],
+						"terminationGracePeriodSeconds": 60,
+						"volumes": [
+							{
+								"emptyDir": {
+									"medium": ""
+								},
+								"name": "${APPLICATION_NAME}-data"
+							}
+						]
+					}
+				},
+				"triggers": [
+					{
+						"imageChangeParams": {
+							"automatic": true,
+							"containerNames": [
+								"${APPLICATION_NAME}-mongodb"
+							],
+							"from": {
+								"kind": "ImageStreamTag",
+								"name": "mongodb:${MONGODB_IMAGE_STREAM_TAG}",
+								"namespace": "${IMAGE_STREAM_NAMESPACE}"
+							}
+						},
+						"type": "ImageChange"
+					},
+					{
+						"type": "ConfigChange"
+					}
+				]
+			}
+		}
+	],
+	"parameters": [
+		{
+			"name": "APPLICATION_NAME",
+			"displayName": "Application Name",
+			"description": "The name for the application.",
+			"value": "jws-app",
+			"required": true
+		},
+		{
+			"name": "HOSTNAME_HTTP",
+			"displayName": "Custom http Route Hostname",
+			"description": "Custom hostname for http service route.  Leave blank for default hostname, e.g.: \u003capplication-name\u003e-\u003cproject\u003e.\u003cdefault-domain-suffix\u003e"
+		},
+		{
+			"name": "HOSTNAME_HTTPS",
+			"displayName": "Custom https Route Hostname",
+			"description": "Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-\u003capplication-name\u003e-\u003cproject\u003e.\u003cdefault-domain-suffix\u003e"
+		},
+		{
+			"name": "SOURCE_REPOSITORY_URL",
+			"displayName": "Git Repository URL",
+			"description": "Git source URI for application",
+			"value": "https://github.com/jboss-openshift/openshift-quickstarts",
+			"required": true
+		},
+		{
+			"name": "SOURCE_REPOSITORY_REF",
+			"displayName": "Git Reference",
+			"description": "Git branch/tag reference",
+			"value": "1.2"
+		},
+		{
+			"name": "CONTEXT_DIR",
+			"displayName": "Context Directory",
+			"description": "Path within Git project to build; empty for root project directory.",
+			"value": "todolist/todolist-mongodb"
+		},
+		{
+			"name": "DB_JNDI",
+			"displayName": "Database JNDI Name",
+			"description": "Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb"
+		},
+		{
+			"name": "DB_DATABASE",
+			"displayName": "Database Name",
+			"description": "Database name",
+			"value": "root",
+			"required": true
+		},
+		{
+			"name": "JWS_HTTPS_SECRET",
+			"displayName": "Secret Name",
+			"description": "The name of the secret containing the certificate files",
+			"value": "jws-app-secret",
+			"required": true
+		},
+		{
+			"name": "JWS_HTTPS_CERTIFICATE",
+			"displayName": "Certificate Name",
+			"description": "The name of the certificate file within the secret",
+			"value": "server.crt"
+		},
+		{
+			"name": "JWS_HTTPS_CERTIFICATE_KEY",
+			"displayName": "Certificate Key Name",
+			"description": "The name of the certificate key file within the secret",
+			"value": "server.key"
+		},
+		{
+			"name": "JWS_HTTPS_CERTIFICATE_PASSWORD",
+			"displayName": "Certificate Password",
+			"description": "The certificate password"
+		},
+		{
+			"name": "DB_MIN_POOL_SIZE",
+			"displayName": "Datasource Minimum Pool Size",
+			"description": "Sets xa-pool/min-pool-size for the configured datasource."
+		},
+		{
+			"name": "DB_MAX_POOL_SIZE",
+			"displayName": "Datasource Maximum Pool Size",
+			"description": "Sets xa-pool/max-pool-size for the configured datasource."
+		},
+		{
+			"name": "DB_TX_ISOLATION",
+			"displayName": "Datasource Transaction Isolation",
+			"description": "Sets transaction-isolation for the configured datasource."
+		},
+		{
+			"name": "MONGODB_NOPREALLOC",
+			"displayName": "MongoDB No Preallocation",
+			"description": "Disable data file preallocation."
+		},
+		{
+			"name": "MONGODB_SMALLFILES",
+			"displayName": "MongoDB Small Files",
+			"description": "Set MongoDB to use a smaller default data file size."
+		},
+		{
+			"name": "MONGODB_QUIET",
+			"displayName": "MongoDB Quiet",
+			"description": "Runs MongoDB in a quiet mode that attempts to limit the amount of output."
+		},
+		{
+			"name": "DB_USERNAME",
+			"displayName": "Database Username",
+			"description": "Database user name",
+			"generate": "expression",
+			"from": "user[a-zA-Z0-9]{3}",
+			"required": true
+		},
+		{
+			"name": "DB_PASSWORD",
+			"displayName": "Database Password",
+			"description": "Database user password",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "DB_ADMIN_PASSWORD",
+			"displayName": "Database admin password",
+			"description": "Database admin password",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "JWS_ADMIN_USERNAME",
+			"displayName": "JWS Admin Username",
+			"description": "JWS Admin User",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "JWS_ADMIN_PASSWORD",
+			"displayName": "JWS Admin Password",
+			"description": "JWS Admin Password",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "GITHUB_WEBHOOK_SECRET",
+			"displayName": "Github Webhook Secret",
+			"description": "GitHub trigger secret",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "GENERIC_WEBHOOK_SECRET",
+			"displayName": "Generic Webhook Secret",
+			"description": "Generic build trigger secret",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "IMAGE_STREAM_NAMESPACE",
+			"displayName": "ImageStream Namespace",
+			"description": "Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.",
+			"value": "openshift",
+			"required": true
+		},
+		{
+			"name": "MAVEN_MIRROR_URL",
+			"displayName": "Maven mirror URL",
+			"description": "Maven mirror to use for S2I builds"
+		},
+		{
+			"name": "ARTIFACT_DIR",
+			"description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied."
+		},
+		{
+			"name": "MONGODB_IMAGE_STREAM_TAG",
+			"displayName": "MongoDB Image Stream Tag",
+			"description": "The tag to use for the \"mongodb\" image stream.  Typically, this aligns with the major.minor version of MongoDB.",
+			"value": "3.2",
+			"required": true
+		}
+	],
+	"labels": {
+		"jws54jdk8el7": "1.0",
+		"template": "jws54-openjdk8-tomcat9-rhel7-mongodb-s2i"
+	}
+}

--- a/official/webserver/templates/jws54-openjdk8-tomcat9-rhel7-mysql-persistent-s2i.json
+++ b/official/webserver/templates/jws54-openjdk8-tomcat9-rhel7-mysql-persistent-s2i.json
@@ -2,18 +2,21 @@
 	"kind": "Template",
 	"apiVersion": "v1",
 	"metadata": {
-		"name": "jws53-openjdk8-tomcat9-mysql-s2i",
+		"name": "jws54-openjdk8-tomcat9-rhel7-mysql-persistent-s2i",
 		"creationTimestamp": null,
 		"annotations": {
-			"description": "Application template for JWS MySQL applications built using S2I.",
+			"description": "An example JBoss Web Server application with a MySQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
 			"iconClass": "icon-rh-tomcat",
-			"openshift.io/display-name": "JBoss Web Server 5.3 Apache Tomcat 9 OpenJDK8 + MySQL (Ephemeral with https)",
+			"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK8 on RHEL7 + MySQL (with https)",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
-			"tags": "tomcat,tomcat9,java,jboss,hidden",
+			"tags": "tomcat,tomcat9,java,jboss",
+			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-web-server/",
+			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.4 Apache Tomcat 9 based application, including a build configuration, application deployment configuration, database deployment configuration for MySQL using persistence and secure communication using https.",
+			"template.openshift.io/support-url": "https://access.redhat.com",
 			"version": "1.0"
 		}
 	},
-	"message": "A new JWS application for Apache Tomcat 9 (using MySQL) has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}. For accessing the MySQL database \"${DB_DATABASE}\" use the credentials ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
+	"message": "A new persistent JWS application for Apache Tomcat 9 (using MySQL) has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}. For accessing the MySQL database \"${DB_DATABASE}\" use the credentials ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
 	"objects": [
 		{
 			"apiVersion": "v1",
@@ -181,7 +184,7 @@
 						"forcePull": true,
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "jboss-webserver53-openjdk8-tomcat9-openshift:1.0",
+							"name": "jboss-webserver54-openjdk8-tomcat9-openshift-rhel7:1.0",
 							"namespace": "${IMAGE_STREAM_NAMESPACE}"
 						}
 					},
@@ -321,7 +324,7 @@
 										"command": [
 											"/bin/bash",
 											"-c",
-											"curl --noproxy '*' -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer\u0026att=stateName' |grep -iq 'stateName *= *STARTED'"
+											"curl --noproxy '*' -is 'http://localhost:8080/health' | grep -iq '\"status\": \"UP\"'"
 										]
 									}
 								},
@@ -457,7 +460,7 @@
 								"volumeMounts": [
 									{
 										"mountPath": "/var/lib/mysql/data",
-										"name": "${APPLICATION_NAME}-data"
+										"name": "${APPLICATION_NAME}-mysql-pvol"
 									}
 								]
 							}
@@ -465,10 +468,10 @@
 						"terminationGracePeriodSeconds": 60,
 						"volumes": [
 							{
-								"emptyDir": {
-									"medium": ""
-								},
-								"name": "${APPLICATION_NAME}-data"
+								"name": "${APPLICATION_NAME}-mysql-pvol",
+								"persistentVolumeClaim": {
+									"claimName": "${APPLICATION_NAME}-mysql-claim"
+								}
 							}
 						]
 					}
@@ -492,6 +495,26 @@
 						"type": "ConfigChange"
 					}
 				]
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "PersistentVolumeClaim",
+			"metadata": {
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}-mysql-claim"
+			},
+			"spec": {
+				"accessModes": [
+					"ReadWriteOnce"
+				],
+				"resources": {
+					"requests": {
+						"storage": "${VOLUME_CAPACITY}"
+					}
+				}
 			}
 		}
 	],
@@ -543,6 +566,13 @@
 			"displayName": "Database Name",
 			"description": "Database name",
 			"value": "root",
+			"required": true
+		},
+		{
+			"name": "VOLUME_CAPACITY",
+			"displayName": "Database Volume Capacity",
+			"description": "Size of persistent storage for database volume.",
+			"value": "1Gi",
 			"required": true
 		},
 		{
@@ -682,7 +712,7 @@
 		}
 	],
 	"labels": {
-		"jws53": "1.0",
-		"template": "jws53-openjdk8-tomcat9-mysql-s2i"
+		"jws54jdk8el7": "1.0",
+		"template": "jws54-openjdk8-tomcat9-rhel7-mysql-persistent-s2i"
 	}
 }

--- a/official/webserver/templates/jws54-openjdk8-tomcat9-rhel7-mysql-s2i.json
+++ b/official/webserver/templates/jws54-openjdk8-tomcat9-rhel7-mysql-s2i.json
@@ -2,21 +2,18 @@
 	"kind": "Template",
 	"apiVersion": "v1",
 	"metadata": {
-		"name": "jws53-openjdk11-tomcat9-mongodb-persistent-s2i",
+		"name": "jws54-openjdk8-tomcat9-rhel7-mysql-s2i",
 		"creationTimestamp": null,
 		"annotations": {
-			"description": "An example JBoss Web Server application with a MongoDB database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
+			"description": "Application template for JWS MySQL applications built using S2I.",
 			"iconClass": "icon-rh-tomcat",
-			"openshift.io/display-name": "JBoss Web Server 5.3 Apache Tomcat 9 OpenJDK11 + MongoDB (with https)",
+			"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK8 on RHEL7 + MySQL (Ephemeral with https)",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
-			"tags": "tomcat,tomcat9,java,jboss",
-			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-web-server/",
-			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.3 Apache Tomcat 9 based application, including a build configuration, application deployment configuration, database deployment configuration for MongoDB using persistence and secure communication using https.",
-			"template.openshift.io/support-url": "https://access.redhat.com",
+			"tags": "tomcat,tomcat9,java,jboss,hidden",
 			"version": "1.0"
 		}
 	},
-	"message": "A new persistent JWS application for Apache Tomcat 9 (using MongoDB) has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}. For accessing the MongoDB database \"${DB_DATABASE}\" use the credentials ${DB_USERNAME}/${DB_PASSWORD} (Admin password is \"${DB_ADMIN_PASSWORD}\"). Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
+	"message": "A new JWS application for Apache Tomcat 9 (using MySQL) has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}. For accessing the MySQL database \"${DB_DATABASE}\" use the credentials ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
 	"objects": [
 		{
 			"apiVersion": "v1",
@@ -24,7 +21,7 @@
 			"metadata": {
 				"annotations": {
 					"description": "The web server's http port.",
-					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mongodb\", \"kind\": \"Service\"}]"
+					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mysql\", \"kind\": \"Service\"}]"
 				},
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -49,7 +46,7 @@
 			"metadata": {
 				"annotations": {
 					"description": "The web server's https port.",
-					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mongodb\", \"kind\": \"Service\"}]"
+					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mysql\", \"kind\": \"Service\"}]"
 				},
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -78,17 +75,17 @@
 				"labels": {
 					"application": "${APPLICATION_NAME}"
 				},
-				"name": "${APPLICATION_NAME}-mongodb"
+				"name": "${APPLICATION_NAME}-mysql"
 			},
 			"spec": {
 				"ports": [
 					{
-						"port": 27017,
-						"targetPort": 27017
+						"port": 3306,
+						"targetPort": 3306
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-mongodb"
+					"deploymentConfig": "${APPLICATION_NAME}-mysql"
 				}
 			}
 		},
@@ -184,7 +181,7 @@
 						"forcePull": true,
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "jboss-webserver53-openjdk11-tomcat9-openshift:1.0",
+							"name": "jboss-webserver54-openjdk8-tomcat9-openshift-rhel7:1.0",
 							"namespace": "${IMAGE_STREAM_NAMESPACE}"
 						}
 					},
@@ -244,7 +241,7 @@
 								"env": [
 									{
 										"name": "DB_SERVICE_PREFIX_MAPPING",
-										"value": "${APPLICATION_NAME}-mongodb=DB"
+										"value": "${APPLICATION_NAME}-mysql=DB"
 									},
 									{
 										"name": "DB_JNDI",
@@ -261,10 +258,6 @@
 									{
 										"name": "DB_DATABASE",
 										"value": "${DB_DATABASE}"
-									},
-									{
-										"name": "DB_ADMIN_PASSWORD",
-										"value": "${DB_ADMIN_PASSWORD}"
 									},
 									{
 										"name": "DB_MIN_POOL_SIZE",
@@ -328,7 +321,7 @@
 										"command": [
 											"/bin/bash",
 											"-c",
-											"curl --noproxy '*' -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer\u0026att=stateName' |grep -iq 'stateName *= *STARTED'"
+											"curl --noproxy '*' -is 'http://localhost:8080/health' | grep -iq '\"status\": \"UP\"'"
 										]
 									}
 								},
@@ -379,12 +372,12 @@
 				"labels": {
 					"application": "${APPLICATION_NAME}"
 				},
-				"name": "${APPLICATION_NAME}-mongodb"
+				"name": "${APPLICATION_NAME}-mysql"
 			},
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-mongodb"
+					"deploymentConfig": "${APPLICATION_NAME}-mysql"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -393,56 +386,59 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}-mongodb"
+							"deploymentConfig": "${APPLICATION_NAME}-mysql"
 						},
-						"name": "${APPLICATION_NAME}-mongodb"
+						"name": "${APPLICATION_NAME}-mysql"
 					},
 					"spec": {
 						"containers": [
 							{
 								"env": [
 									{
-										"name": "MONGODB_USER",
+										"name": "MYSQL_USER",
 										"value": "${DB_USERNAME}"
 									},
 									{
-										"name": "MONGODB_PASSWORD",
+										"name": "MYSQL_PASSWORD",
 										"value": "${DB_PASSWORD}"
 									},
 									{
-										"name": "MONGODB_DATABASE",
+										"name": "MYSQL_DATABASE",
 										"value": "${DB_DATABASE}"
 									},
 									{
-										"name": "MONGODB_ADMIN_PASSWORD",
-										"value": "${DB_ADMIN_PASSWORD}"
+										"name": "MYSQL_LOWER_CASE_TABLE_NAMES",
+										"value": "${MYSQL_LOWER_CASE_TABLE_NAMES}"
 									},
 									{
-										"name": "MONGODB_NOPREALLOC",
-										"value": "${MONGODB_NOPREALLOC}"
+										"name": "MYSQL_MAX_CONNECTIONS",
+										"value": "${MYSQL_MAX_CONNECTIONS}"
 									},
 									{
-										"name": "MONGODB_SMALLFILES",
-										"value": "${MONGODB_SMALLFILES}"
+										"name": "MYSQL_FT_MIN_WORD_LEN",
+										"value": "${MYSQL_FT_MIN_WORD_LEN}"
 									},
 									{
-										"name": "MONGODB_QUIET",
-										"value": "${MONGODB_QUIET}"
+										"name": "MYSQL_FT_MAX_WORD_LEN",
+										"value": "${MYSQL_FT_MAX_WORD_LEN}"
+									},
+									{
+										"name": "MYSQL_AIO",
+										"value": "${MYSQL_AIO}"
 									}
 								],
-								"image": "mongodb",
-								"imagePullPolicy": "Always",
+								"image": "mysql",
 								"livenessProbe": {
 									"initialDelaySeconds": 30,
 									"tcpSocket": {
-										"port": 27017
+										"port": 3306
 									},
 									"timeoutSeconds": 1
 								},
-								"name": "${APPLICATION_NAME}-mongodb",
+								"name": "${APPLICATION_NAME}-mysql",
 								"ports": [
 									{
-										"containerPort": 27017,
+										"containerPort": 3306,
 										"protocol": "TCP"
 									}
 								],
@@ -452,16 +448,16 @@
 											"/bin/sh",
 											"-i",
 											"-c",
-											"mongo 127.0.0.1:27017/$MONGODB_DATABASE -u $MONGODB_USER -p $MONGODB_PASSWORD --eval=\"quit()\""
+											"MYSQL_PWD=\"$MYSQL_PASSWORD\" mysql -h 127.0.0.1 -u $MYSQL_USER -D $MYSQL_DATABASE -e 'SELECT 1'"
 										]
 									},
-									"initialDelaySeconds": 3,
+									"initialDelaySeconds": 5,
 									"timeoutSeconds": 1
 								},
 								"volumeMounts": [
 									{
-										"mountPath": "/var/lib/mongodb/data",
-										"name": "${APPLICATION_NAME}-mongodb-pvol"
+										"mountPath": "/var/lib/mysql/data",
+										"name": "${APPLICATION_NAME}-data"
 									}
 								]
 							}
@@ -469,10 +465,10 @@
 						"terminationGracePeriodSeconds": 60,
 						"volumes": [
 							{
-								"name": "${APPLICATION_NAME}-mongodb-pvol",
-								"persistentVolumeClaim": {
-									"claimName": "${APPLICATION_NAME}-mongodb-claim"
-								}
+								"emptyDir": {
+									"medium": ""
+								},
+								"name": "${APPLICATION_NAME}-data"
 							}
 						]
 					}
@@ -482,11 +478,11 @@
 						"imageChangeParams": {
 							"automatic": true,
 							"containerNames": [
-								"${APPLICATION_NAME}-mongodb"
+								"${APPLICATION_NAME}-mysql"
 							],
 							"from": {
 								"kind": "ImageStreamTag",
-								"name": "mongodb:${MONGODB_IMAGE_STREAM_TAG}",
+								"name": "mysql:${MYSQL_IMAGE_STREAM_TAG}",
 								"namespace": "${IMAGE_STREAM_NAMESPACE}"
 							}
 						},
@@ -496,26 +492,6 @@
 						"type": "ConfigChange"
 					}
 				]
-			}
-		},
-		{
-			"apiVersion": "v1",
-			"kind": "PersistentVolumeClaim",
-			"metadata": {
-				"labels": {
-					"application": "${APPLICATION_NAME}"
-				},
-				"name": "${APPLICATION_NAME}-mongodb-claim"
-			},
-			"spec": {
-				"accessModes": [
-					"ReadWriteOnce"
-				],
-				"resources": {
-					"requests": {
-						"storage": "${VOLUME_CAPACITY}"
-					}
-				}
 			}
 		}
 	],
@@ -554,25 +530,19 @@
 			"name": "CONTEXT_DIR",
 			"displayName": "Context Directory",
 			"description": "Path within Git project to build; empty for root project directory.",
-			"value": "todolist/todolist-mongodb"
+			"value": "todolist/todolist-jdbc"
 		},
 		{
 			"name": "DB_JNDI",
 			"displayName": "Database JNDI Name",
-			"description": "Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb"
+			"description": "Database JNDI name used by application to resolve the datasource, e.g. jboss/datasources/mysqlDS",
+			"value": "jboss/datasources/defaultDS"
 		},
 		{
 			"name": "DB_DATABASE",
 			"displayName": "Database Name",
 			"description": "Database name",
 			"value": "root",
-			"required": true
-		},
-		{
-			"name": "VOLUME_CAPACITY",
-			"displayName": "Database Volume Capacity",
-			"description": "Size of persistent storage for database volume.",
-			"value": "1Gi",
 			"required": true
 		},
 		{
@@ -615,19 +585,29 @@
 			"description": "Sets transaction-isolation for the configured datasource."
 		},
 		{
-			"name": "MONGODB_NOPREALLOC",
-			"displayName": "MongoDB No Preallocation",
-			"description": "Disable data file preallocation."
+			"name": "MYSQL_LOWER_CASE_TABLE_NAMES",
+			"displayName": "MySQL Lower Case Table Names",
+			"description": "Sets how the table names are stored and compared."
 		},
 		{
-			"name": "MONGODB_SMALLFILES",
-			"displayName": "MongoDB Small Files",
-			"description": "Set MongoDB to use a smaller default data file size."
+			"name": "MYSQL_MAX_CONNECTIONS",
+			"displayName": "MySQL Maximum number of connections",
+			"description": "The maximum permitted number of simultaneous client connections."
 		},
 		{
-			"name": "MONGODB_QUIET",
-			"displayName": "MongoDB Quiet",
-			"description": "Runs MongoDB in a quiet mode that attempts to limit the amount of output."
+			"name": "MYSQL_FT_MIN_WORD_LEN",
+			"displayName": "MySQL FullText Minimum Word Length",
+			"description": "The minimum length of the word to be included in a FULLTEXT index."
+		},
+		{
+			"name": "MYSQL_FT_MAX_WORD_LEN",
+			"displayName": "MySQL FullText Maximum Word Length",
+			"description": "The maximum length of the word to be included in a FULLTEXT index."
+		},
+		{
+			"name": "MYSQL_AIO",
+			"displayName": "MySQL AIO",
+			"description": "Controls the innodb_use_native_aio setting value if the native AIO is broken."
 		},
 		{
 			"name": "DB_USERNAME",
@@ -641,14 +621,6 @@
 			"name": "DB_PASSWORD",
 			"displayName": "Database Password",
 			"description": "Database user password",
-			"generate": "expression",
-			"from": "[a-zA-Z0-9]{8}",
-			"required": true
-		},
-		{
-			"name": "DB_ADMIN_PASSWORD",
-			"displayName": "Database admin password",
-			"description": "Database admin password",
 			"generate": "expression",
 			"from": "[a-zA-Z0-9]{8}",
 			"required": true
@@ -702,15 +674,15 @@
 			"description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied."
 		},
 		{
-			"name": "MONGODB_IMAGE_STREAM_TAG",
-			"displayName": "MongoDB Image Stream Tag",
-			"description": "The tag to use for the \"mongodb\" image stream.  Typically, this aligns with the major.minor version of MongoDB.",
-			"value": "3.2",
+			"name": "MYSQL_IMAGE_STREAM_TAG",
+			"displayName": "MySQL Image Stream Tag",
+			"description": "The tag to use for the \"mysql\" image stream.  Typically, this aligns with the major.minor version of MySQL.",
+			"value": "5.7",
 			"required": true
 		}
 	],
 	"labels": {
-		"jws53": "1.0",
-		"template": "jws53-openjdk11-tomcat9-mongodb-persistent-s2i"
+		"jws54jdk8el7": "1.0",
+		"template": "jws5e-openjdk8-tomcat9-rhel7-mysql-s2i"
 	}
 }

--- a/official/webserver/templates/jws54-openjdk8-tomcat9-rhel7-postgresql-persistent-s2i.json
+++ b/official/webserver/templates/jws54-openjdk8-tomcat9-rhel7-postgresql-persistent-s2i.json
@@ -2,21 +2,18 @@
 	"kind": "Template",
 	"apiVersion": "v1",
 	"metadata": {
-		"name": "jws53-openjdk8-tomcat9-mongodb-persistent-s2i",
+		"name": "jws54-openjdk8-tomcat9-rhel7-postgresql-persistent-s2i",
 		"creationTimestamp": null,
 		"annotations": {
-			"description": "An example JBoss Web Server application with a MongoDB database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
+			"description": "Application template for JWS PostgreSQL applications with persistent storage built using S2I.",
 			"iconClass": "icon-rh-tomcat",
-			"openshift.io/display-name": "JBoss Web Server 5.3 Apache Tomcat 9 OpenJDK8 + MongoDB (with https)",
+			"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK8 on RHEL7 + PostgreSQL (with https)",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
 			"tags": "tomcat,tomcat9,java,jboss",
-			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-web-server/",
-			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.3 Apache Tomcat 9 based application, including a build configuration, application deployment configuration, database deployment configuration for MongoDB using persistence and secure communication using https.",
-			"template.openshift.io/support-url": "https://access.redhat.com",
 			"version": "1.0"
 		}
 	},
-	"message": "A new persistent JWS application for Apache Tomcat 9 (using MongoDB) has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}. For accessing the MongoDB database \"${DB_DATABASE}\" use the credentials ${DB_USERNAME}/${DB_PASSWORD} (Admin password is \"${DB_ADMIN_PASSWORD}\"). Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
+	"message": "A new persistent JWS application for Apache Tomcat 9 (using PostgreSQL) has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}. For accessing the PostgreSQL database \"${DB_DATABASE}\" use the credentials ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
 	"objects": [
 		{
 			"apiVersion": "v1",
@@ -24,7 +21,7 @@
 			"metadata": {
 				"annotations": {
 					"description": "The web server's http port.",
-					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mongodb\", \"kind\": \"Service\"}]"
+					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-postgresql\", \"kind\": \"Service\"}]"
 				},
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -49,7 +46,7 @@
 			"metadata": {
 				"annotations": {
 					"description": "The web server's https port.",
-					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-mongodb\", \"kind\": \"Service\"}]"
+					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-postgresql\", \"kind\": \"Service\"}]"
 				},
 				"labels": {
 					"application": "${APPLICATION_NAME}"
@@ -78,17 +75,17 @@
 				"labels": {
 					"application": "${APPLICATION_NAME}"
 				},
-				"name": "${APPLICATION_NAME}-mongodb"
+				"name": "${APPLICATION_NAME}-postgresql"
 			},
 			"spec": {
 				"ports": [
 					{
-						"port": 27017,
-						"targetPort": 27017
+						"port": 5432,
+						"targetPort": 5432
 					}
 				],
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-mongodb"
+					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
 				}
 			}
 		},
@@ -184,7 +181,7 @@
 						"forcePull": true,
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "jboss-webserver53-openjdk8-tomcat9-openshift:1.0",
+							"name": "jboss-webserver54-openjdk8-tomcat9-openshift-rhel7:1.0",
 							"namespace": "${IMAGE_STREAM_NAMESPACE}"
 						}
 					},
@@ -244,7 +241,7 @@
 								"env": [
 									{
 										"name": "DB_SERVICE_PREFIX_MAPPING",
-										"value": "${APPLICATION_NAME}-mongodb=DB"
+										"value": "${APPLICATION_NAME}-postgresql=DB"
 									},
 									{
 										"name": "DB_JNDI",
@@ -261,10 +258,6 @@
 									{
 										"name": "DB_DATABASE",
 										"value": "${DB_DATABASE}"
-									},
-									{
-										"name": "DB_ADMIN_PASSWORD",
-										"value": "${DB_ADMIN_PASSWORD}"
 									},
 									{
 										"name": "DB_MIN_POOL_SIZE",
@@ -328,7 +321,7 @@
 										"command": [
 											"/bin/bash",
 											"-c",
-											"curl --noproxy '*' -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer\u0026att=stateName' |grep -iq 'stateName *= *STARTED'"
+											"curl --noproxy '*' -is 'http://localhost:8080/health' | grep -iq '\"status\": \"UP\"'"
 										]
 									}
 								},
@@ -379,12 +372,12 @@
 				"labels": {
 					"application": "${APPLICATION_NAME}"
 				},
-				"name": "${APPLICATION_NAME}-mongodb"
+				"name": "${APPLICATION_NAME}-postgresql"
 			},
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}-mongodb"
+					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
 				},
 				"strategy": {
 					"type": "Recreate"
@@ -393,56 +386,51 @@
 					"metadata": {
 						"labels": {
 							"application": "${APPLICATION_NAME}",
-							"deploymentConfig": "${APPLICATION_NAME}-mongodb"
+							"deploymentConfig": "${APPLICATION_NAME}-postgresql"
 						},
-						"name": "${APPLICATION_NAME}-mongodb"
+						"name": "${APPLICATION_NAME}-postgresql"
 					},
 					"spec": {
 						"containers": [
 							{
 								"env": [
 									{
-										"name": "MONGODB_USER",
+										"name": "POSTGRESQL_USER",
 										"value": "${DB_USERNAME}"
 									},
 									{
-										"name": "MONGODB_PASSWORD",
+										"name": "POSTGRESQL_PASSWORD",
 										"value": "${DB_PASSWORD}"
 									},
 									{
-										"name": "MONGODB_DATABASE",
+										"name": "POSTGRESQL_DATABASE",
 										"value": "${DB_DATABASE}"
 									},
 									{
-										"name": "MONGODB_ADMIN_PASSWORD",
-										"value": "${DB_ADMIN_PASSWORD}"
+										"name": "POSTGRESQL_MAX_CONNECTIONS",
+										"value": "${POSTGRESQL_MAX_CONNECTIONS}"
 									},
 									{
-										"name": "MONGODB_NOPREALLOC",
-										"value": "${MONGODB_NOPREALLOC}"
+										"name": "POSTGRESQL_MAX_PREPARED_TRANSACTIONS",
+										"value": "${POSTGRESQL_MAX_CONNECTIONS}"
 									},
 									{
-										"name": "MONGODB_SMALLFILES",
-										"value": "${MONGODB_SMALLFILES}"
-									},
-									{
-										"name": "MONGODB_QUIET",
-										"value": "${MONGODB_QUIET}"
+										"name": "POSTGRESQL_SHARED_BUFFERS",
+										"value": "${POSTGRESQL_SHARED_BUFFERS}"
 									}
 								],
-								"image": "mongodb",
-								"imagePullPolicy": "Always",
+								"image": "postgresql",
 								"livenessProbe": {
 									"initialDelaySeconds": 30,
 									"tcpSocket": {
-										"port": 27017
+										"port": 5432
 									},
 									"timeoutSeconds": 1
 								},
-								"name": "${APPLICATION_NAME}-mongodb",
+								"name": "${APPLICATION_NAME}-postgresql",
 								"ports": [
 									{
-										"containerPort": 27017,
+										"containerPort": 5432,
 										"protocol": "TCP"
 									}
 								],
@@ -452,16 +440,16 @@
 											"/bin/sh",
 											"-i",
 											"-c",
-											"mongo 127.0.0.1:27017/$MONGODB_DATABASE -u $MONGODB_USER -p $MONGODB_PASSWORD --eval=\"quit()\""
+											"psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'"
 										]
 									},
-									"initialDelaySeconds": 3,
+									"initialDelaySeconds": 5,
 									"timeoutSeconds": 1
 								},
 								"volumeMounts": [
 									{
-										"mountPath": "/var/lib/mongodb/data",
-										"name": "${APPLICATION_NAME}-mongodb-pvol"
+										"mountPath": "/var/lib/pgsql/data",
+										"name": "${APPLICATION_NAME}-postgresql-pvol"
 									}
 								]
 							}
@@ -469,9 +457,9 @@
 						"terminationGracePeriodSeconds": 60,
 						"volumes": [
 							{
-								"name": "${APPLICATION_NAME}-mongodb-pvol",
+								"name": "${APPLICATION_NAME}-postgresql-pvol",
 								"persistentVolumeClaim": {
-									"claimName": "${APPLICATION_NAME}-mongodb-claim"
+									"claimName": "${APPLICATION_NAME}-postgresql-claim"
 								}
 							}
 						]
@@ -482,11 +470,11 @@
 						"imageChangeParams": {
 							"automatic": true,
 							"containerNames": [
-								"${APPLICATION_NAME}-mongodb"
+								"${APPLICATION_NAME}-postgresql"
 							],
 							"from": {
 								"kind": "ImageStreamTag",
-								"name": "mongodb:${MONGODB_IMAGE_STREAM_TAG}",
+								"name": "postgresql:${POSTGRESQL_IMAGE_STREAM_TAG}",
 								"namespace": "${IMAGE_STREAM_NAMESPACE}"
 							}
 						},
@@ -505,7 +493,7 @@
 				"labels": {
 					"application": "${APPLICATION_NAME}"
 				},
-				"name": "${APPLICATION_NAME}-mongodb-claim"
+				"name": "${APPLICATION_NAME}-postgresql-claim"
 			},
 			"spec": {
 				"accessModes": [
@@ -554,12 +542,13 @@
 			"name": "CONTEXT_DIR",
 			"displayName": "Context Directory",
 			"description": "Path within Git project to build; empty for root project directory.",
-			"value": "todolist/todolist-mongodb"
+			"value": "todolist/todolist-jdbc"
 		},
 		{
 			"name": "DB_JNDI",
 			"displayName": "Database JNDI Name",
-			"description": "Database JNDI name used by application to resolve the datasource, e.g. java:/jboss/datasources/mongodb"
+			"description": "Database JNDI name used by application to resolve the datasource, e.g. jboss/datasources/postgresqlDS",
+			"value": "jboss/datasources/defaultDS"
 		},
 		{
 			"name": "DB_DATABASE",
@@ -615,19 +604,14 @@
 			"description": "Sets transaction-isolation for the configured datasource."
 		},
 		{
-			"name": "MONGODB_NOPREALLOC",
-			"displayName": "MongoDB No Preallocation",
-			"description": "Disable data file preallocation."
+			"name": "POSTGRESQL_MAX_CONNECTIONS",
+			"displayName": "PostgreSQL Maximum number of connections",
+			"description": "The maximum number of client connections allowed. This also sets the maximum number of prepared transactions."
 		},
 		{
-			"name": "MONGODB_SMALLFILES",
-			"displayName": "MongoDB Small Files",
-			"description": "Set MongoDB to use a smaller default data file size."
-		},
-		{
-			"name": "MONGODB_QUIET",
-			"displayName": "MongoDB Quiet",
-			"description": "Runs MongoDB in a quiet mode that attempts to limit the amount of output."
+			"name": "POSTGRESQL_SHARED_BUFFERS",
+			"displayName": "PostgreSQL Shared Buffers",
+			"description": "Configures how much memory is dedicated to PostgreSQL for caching data."
 		},
 		{
 			"name": "DB_USERNAME",
@@ -641,14 +625,6 @@
 			"name": "DB_PASSWORD",
 			"displayName": "Database Password",
 			"description": "Database user password",
-			"generate": "expression",
-			"from": "[a-zA-Z0-9]{8}",
-			"required": true
-		},
-		{
-			"name": "DB_ADMIN_PASSWORD",
-			"displayName": "Database admin password",
-			"description": "Database admin password",
 			"generate": "expression",
 			"from": "[a-zA-Z0-9]{8}",
 			"required": true
@@ -702,15 +678,15 @@
 			"description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied."
 		},
 		{
-			"name": "MONGODB_IMAGE_STREAM_TAG",
-			"displayName": "MongoDB Image Stream Tag",
-			"description": "The tag to use for the \"mongodb\" image stream.  Typically, this aligns with the major.minor version of MongoDB.",
-			"value": "3.2",
+			"name": "POSTGRESQL_IMAGE_STREAM_TAG",
+			"displayName": "PostgreSQL Image Stream Tag",
+			"description": "The tag to use for the \"postgresql\" image stream.  Typically, this aligns with the major.minor version of PostgreSQL.",
+			"value": "9.5",
 			"required": true
 		}
 	],
 	"labels": {
-		"jws53": "1.0",
-		"template": "jws53-openjdk8-tomcat9-mongodb-persistent-s2i"
+		"jws54jdk8el7": "1.0",
+		"template": "jws54-openjdk8-tomcat9-rhel7-postgresql-persistent-s2i"
 	}
 }

--- a/official/webserver/templates/jws54-openjdk8-tomcat9-rhel7-postgresql-s2i.json
+++ b/official/webserver/templates/jws54-openjdk8-tomcat9-rhel7-postgresql-s2i.json
@@ -1,0 +1,663 @@
+{
+	"kind": "Template",
+	"apiVersion": "v1",
+	"metadata": {
+		"name": "jws54-openjdk8-tomcat9-rhel7-postgresql-s2i",
+		"creationTimestamp": null,
+		"annotations": {
+			"description": "Application template for JWS PostgreSQL applications built using S2I.",
+			"iconClass": "icon-rh-tomcat",
+			"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK8 on RHEL7 + PostgreSQL (Ephemeral with https)",
+			"openshift.io/provider-display-name": "Red Hat, Inc.",
+			"tags": "tomcat,tomcat9,java,jboss,hidden",
+			"version": "1.0"
+		}
+	},
+	"message": "A new JWS application for Apache Tomcat 9 (using PostgreSQL) has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}. For accessing the PostgreSQL database \"${DB_DATABASE}\" use the credentials ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
+	"objects": [
+		{
+			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"description": "The web server's http port.",
+					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-postgresql\", \"kind\": \"Service\"}]"
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}"
+			},
+			"spec": {
+				"ports": [
+					{
+						"port": 8080,
+						"targetPort": 8080
+					}
+				],
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"description": "The web server's https port.",
+					"service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-postgresql\", \"kind\": \"Service\"}]"
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "secure-${APPLICATION_NAME}"
+			},
+			"spec": {
+				"ports": [
+					{
+						"port": 8443,
+						"targetPort": 8443
+					}
+				],
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"description": "The database server's port."
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}-postgresql"
+			},
+			"spec": {
+				"ports": [
+					{
+						"port": 5432,
+						"targetPort": 5432
+					}
+				],
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"id": "${APPLICATION_NAME}-http",
+			"kind": "Route",
+			"metadata": {
+				"annotations": {
+					"description": "Route for application's http service."
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}"
+			},
+			"spec": {
+				"host": "${HOSTNAME_HTTP}",
+				"to": {
+					"name": "${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"id": "${APPLICATION_NAME}-https",
+			"kind": "Route",
+			"metadata": {
+				"annotations": {
+					"description": "Route for application's https service."
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "secure-${APPLICATION_NAME}"
+			},
+			"spec": {
+				"host": "${HOSTNAME_HTTPS}",
+				"tls": {
+					"termination": "passthrough"
+				},
+				"to": {
+					"name": "secure-${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "ImageStream",
+			"metadata": {
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}"
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "BuildConfig",
+			"metadata": {
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}"
+			},
+			"spec": {
+				"output": {
+					"to": {
+						"kind": "ImageStreamTag",
+						"name": "${APPLICATION_NAME}:latest"
+					}
+				},
+				"source": {
+					"contextDir": "${CONTEXT_DIR}",
+					"git": {
+						"ref": "${SOURCE_REPOSITORY_REF}",
+						"uri": "${SOURCE_REPOSITORY_URL}"
+					},
+					"type": "Git"
+				},
+				"strategy": {
+					"sourceStrategy": {
+						"env": [
+							{
+								"name": "MAVEN_MIRROR_URL",
+								"value": "${MAVEN_MIRROR_URL}"
+							},
+							{
+								"name": "ARTIFACT_DIR",
+								"value": "${ARTIFACT_DIR}"
+							}
+						],
+						"forcePull": true,
+						"from": {
+							"kind": "ImageStreamTag",
+							"name": "jboss-webserver54-openjdk8-tomcat9-openshift-rhel7:1.0",
+							"namespace": "${IMAGE_STREAM_NAMESPACE}"
+						}
+					},
+					"type": "Source"
+				},
+				"triggers": [
+					{
+						"github": {
+							"secret": "${GITHUB_WEBHOOK_SECRET}"
+						},
+						"type": "GitHub"
+					},
+					{
+						"generic": {
+							"secret": "${GENERIC_WEBHOOK_SECRET}"
+						},
+						"type": "Generic"
+					},
+					{
+						"imageChange": {},
+						"type": "ImageChange"
+					},
+					{
+						"type": "ConfigChange"
+					}
+				]
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "DeploymentConfig",
+			"metadata": {
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}"
+			},
+			"spec": {
+				"replicas": 1,
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}"
+				},
+				"strategy": {
+					"type": "Recreate"
+				},
+				"template": {
+					"metadata": {
+						"labels": {
+							"application": "${APPLICATION_NAME}",
+							"deploymentConfig": "${APPLICATION_NAME}"
+						},
+						"name": "${APPLICATION_NAME}"
+					},
+					"spec": {
+						"containers": [
+							{
+								"env": [
+									{
+										"name": "DB_SERVICE_PREFIX_MAPPING",
+										"value": "${APPLICATION_NAME}-postgresql=DB"
+									},
+									{
+										"name": "DB_JNDI",
+										"value": "${DB_JNDI}"
+									},
+									{
+										"name": "DB_USERNAME",
+										"value": "${DB_USERNAME}"
+									},
+									{
+										"name": "DB_PASSWORD",
+										"value": "${DB_PASSWORD}"
+									},
+									{
+										"name": "DB_DATABASE",
+										"value": "${DB_DATABASE}"
+									},
+									{
+										"name": "DB_MIN_POOL_SIZE",
+										"value": "${DB_MIN_POOL_SIZE}"
+									},
+									{
+										"name": "DB_MAX_POOL_SIZE",
+										"value": "${DB_MAX_POOL_SIZE}"
+									},
+									{
+										"name": "DB_TX_ISOLATION",
+										"value": "${DB_TX_ISOLATION}"
+									},
+									{
+										"name": "JWS_HTTPS_CERTIFICATE_DIR",
+										"value": "/etc/jws-secret-volume"
+									},
+									{
+										"name": "JWS_HTTPS_CERTIFICATE",
+										"value": "${JWS_HTTPS_CERTIFICATE}"
+									},
+									{
+										"name": "JWS_HTTPS_CERTIFICATE_KEY",
+										"value": "${JWS_HTTPS_CERTIFICATE_KEY}"
+									},
+									{
+										"name": "JWS_HTTPS_CERTIFICATE_PASSWORD",
+										"value": "${JWS_HTTPS_CERTIFICATE_PASSWORD}"
+									},
+									{
+										"name": "JWS_ADMIN_USERNAME",
+										"value": "${JWS_ADMIN_USERNAME}"
+									},
+									{
+										"name": "JWS_ADMIN_PASSWORD",
+										"value": "${JWS_ADMIN_PASSWORD}"
+									}
+								],
+								"image": "${APPLICATION_NAME}",
+								"imagePullPolicy": "Always",
+								"name": "${APPLICATION_NAME}",
+								"ports": [
+									{
+										"containerPort": 8778,
+										"name": "jolokia",
+										"protocol": "TCP"
+									},
+									{
+										"containerPort": 8080,
+										"name": "http",
+										"protocol": "TCP"
+									},
+									{
+										"containerPort": 8443,
+										"name": "https",
+										"protocol": "TCP"
+									}
+								],
+								"readinessProbe": {
+									"exec": {
+										"command": [
+											"/bin/bash",
+											"-c",
+											"curl --noproxy '*' -is 'http://localhost:8080/health' | grep -iq '\"status\": \"UP\"'"
+										]
+									}
+								},
+								"volumeMounts": [
+									{
+										"mountPath": "/etc/jws-secret-volume",
+										"name": "jws-certificate-volume",
+										"readOnly": true
+									}
+								]
+							}
+						],
+						"volumes": [
+							{
+								"name": "jws-certificate-volume",
+								"secret": {
+									"secretName": "${JWS_HTTPS_SECRET}"
+								}
+							}
+						]
+					}
+				},
+				"triggers": [
+					{
+						"imageChangeParams": {
+							"automatic": true,
+							"containerNames": [
+								"${APPLICATION_NAME}"
+							],
+							"from": {
+								"kind": "ImageStreamTag",
+								"name": "${APPLICATION_NAME}:latest"
+							}
+						},
+						"type": "ImageChange"
+					},
+					{
+						"type": "ConfigChange"
+					}
+				]
+			}
+		},
+		{
+			"apiVersion": "v1",
+			"kind": "DeploymentConfig",
+			"metadata": {
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "${APPLICATION_NAME}-postgresql"
+			},
+			"spec": {
+				"replicas": 1,
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+				},
+				"strategy": {
+					"type": "Recreate"
+				},
+				"template": {
+					"metadata": {
+						"labels": {
+							"application": "${APPLICATION_NAME}",
+							"deploymentConfig": "${APPLICATION_NAME}-postgresql"
+						},
+						"name": "${APPLICATION_NAME}-postgresql"
+					},
+					"spec": {
+						"containers": [
+							{
+								"env": [
+									{
+										"name": "POSTGRESQL_USER",
+										"value": "${DB_USERNAME}"
+									},
+									{
+										"name": "POSTGRESQL_PASSWORD",
+										"value": "${DB_PASSWORD}"
+									},
+									{
+										"name": "POSTGRESQL_DATABASE",
+										"value": "${DB_DATABASE}"
+									},
+									{
+										"name": "POSTGRESQL_MAX_CONNECTIONS",
+										"value": "${POSTGRESQL_MAX_CONNECTIONS}"
+									},
+									{
+										"name": "POSTGRESQL_MAX_PREPARED_TRANSACTIONS",
+										"value": "${POSTGRESQL_MAX_CONNECTIONS}"
+									},
+									{
+										"name": "POSTGRESQL_SHARED_BUFFERS",
+										"value": "${POSTGRESQL_SHARED_BUFFERS}"
+									}
+								],
+								"image": "postgresql",
+								"livenessProbe": {
+									"initialDelaySeconds": 30,
+									"tcpSocket": {
+										"port": 5432
+									},
+									"timeoutSeconds": 1
+								},
+								"name": "${APPLICATION_NAME}-postgresql",
+								"ports": [
+									{
+										"containerPort": 5432,
+										"protocol": "TCP"
+									}
+								],
+								"readinessProbe": {
+									"exec": {
+										"command": [
+											"/bin/sh",
+											"-i",
+											"-c",
+											"psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'"
+										]
+									},
+									"initialDelaySeconds": 5,
+									"timeoutSeconds": 1
+								},
+								"volumeMounts": [
+									{
+										"mountPath": "/var/lib/pgsql/data",
+										"name": "${APPLICATION_NAME}-data"
+									}
+								]
+							}
+						],
+						"volumes": [
+							{
+								"emptyDir": {
+									"medium": ""
+								},
+								"name": "${APPLICATION_NAME}-data"
+							}
+						]
+					}
+				},
+				"triggers": [
+					{
+						"imageChangeParams": {
+							"automatic": true,
+							"containerNames": [
+								"${APPLICATION_NAME}-postgresql"
+							],
+							"from": {
+								"kind": "ImageStreamTag",
+								"name": "postgresql:${POSTGRESQL_IMAGE_STREAM_TAG}",
+								"namespace": "${IMAGE_STREAM_NAMESPACE}"
+							}
+						},
+						"type": "ImageChange"
+					},
+					{
+						"type": "ConfigChange"
+					}
+				]
+			}
+		}
+	],
+	"parameters": [
+		{
+			"name": "APPLICATION_NAME",
+			"displayName": "Application Name",
+			"description": "The name for the application.",
+			"value": "jws-app",
+			"required": true
+		},
+		{
+			"name": "HOSTNAME_HTTP",
+			"displayName": "Custom http Route Hostname",
+			"description": "Custom hostname for http service route.  Leave blank for default hostname, e.g.: \u003capplication-name\u003e-\u003cproject\u003e.\u003cdefault-domain-suffix\u003e"
+		},
+		{
+			"name": "HOSTNAME_HTTPS",
+			"displayName": "Custom https Route Hostname",
+			"description": "Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-\u003capplication-name\u003e-\u003cproject\u003e.\u003cdefault-domain-suffix\u003e"
+		},
+		{
+			"name": "SOURCE_REPOSITORY_URL",
+			"displayName": "Git Repository URL",
+			"description": "Git source URI for application",
+			"value": "https://github.com/jboss-openshift/openshift-quickstarts",
+			"required": true
+		},
+		{
+			"name": "SOURCE_REPOSITORY_REF",
+			"displayName": "Git Reference",
+			"description": "Git branch/tag reference",
+			"value": "1.2"
+		},
+		{
+			"name": "CONTEXT_DIR",
+			"displayName": "Context Directory",
+			"description": "Path within Git project to build; empty for root project directory.",
+			"value": "todolist/todolist-jdbc"
+		},
+		{
+			"name": "DB_JNDI",
+			"displayName": "Database JNDI Name",
+			"description": "Database JNDI name used by application to resolve the datasource, e.g. jboss/datasources/postgresqlDS",
+			"value": "jboss/datasources/defaultDS"
+		},
+		{
+			"name": "DB_DATABASE",
+			"displayName": "Database Name",
+			"description": "Database name",
+			"value": "root",
+			"required": true
+		},
+		{
+			"name": "JWS_HTTPS_SECRET",
+			"displayName": "Secret Name",
+			"description": "The name of the secret containing the certificate files",
+			"value": "jws-app-secret",
+			"required": true
+		},
+		{
+			"name": "JWS_HTTPS_CERTIFICATE",
+			"displayName": "Certificate Name",
+			"description": "The name of the certificate file within the secret",
+			"value": "server.crt"
+		},
+		{
+			"name": "JWS_HTTPS_CERTIFICATE_KEY",
+			"displayName": "Certificate Key Name",
+			"description": "The name of the certificate key file within the secret",
+			"value": "server.key"
+		},
+		{
+			"name": "JWS_HTTPS_CERTIFICATE_PASSWORD",
+			"displayName": "Certificate Password",
+			"description": "The certificate password"
+		},
+		{
+			"name": "DB_MIN_POOL_SIZE",
+			"displayName": "Datasource Minimum Pool Size",
+			"description": "Sets xa-pool/min-pool-size for the configured datasource."
+		},
+		{
+			"name": "DB_MAX_POOL_SIZE",
+			"displayName": "Datasource Maximum Pool Size",
+			"description": "Sets xa-pool/max-pool-size for the configured datasource."
+		},
+		{
+			"name": "DB_TX_ISOLATION",
+			"displayName": "Datasource Transaction Isolation",
+			"description": "Sets transaction-isolation for the configured datasource."
+		},
+		{
+			"name": "POSTGRESQL_MAX_CONNECTIONS",
+			"displayName": "PostgreSQL Maximum number of connections",
+			"description": "The maximum number of client connections allowed. This also sets the maximum number of prepared transactions."
+		},
+		{
+			"name": "POSTGRESQL_SHARED_BUFFERS",
+			"displayName": "PostgreSQL Shared Buffers",
+			"description": "Configures how much memory is dedicated to PostgreSQL for caching data."
+		},
+		{
+			"name": "DB_USERNAME",
+			"displayName": "Database Username",
+			"description": "Database user name",
+			"generate": "expression",
+			"from": "user[a-zA-Z0-9]{3}",
+			"required": true
+		},
+		{
+			"name": "DB_PASSWORD",
+			"displayName": "Database Password",
+			"description": "Database user password",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "JWS_ADMIN_USERNAME",
+			"displayName": "JWS Admin Username",
+			"description": "JWS Admin User",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "JWS_ADMIN_PASSWORD",
+			"displayName": "JWS Admin Password",
+			"description": "JWS Admin Password",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "GITHUB_WEBHOOK_SECRET",
+			"displayName": "Github Webhook Secret",
+			"description": "GitHub trigger secret",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "GENERIC_WEBHOOK_SECRET",
+			"displayName": "Generic Webhook Secret",
+			"description": "Generic build trigger secret",
+			"generate": "expression",
+			"from": "[a-zA-Z0-9]{8}",
+			"required": true
+		},
+		{
+			"name": "IMAGE_STREAM_NAMESPACE",
+			"displayName": "ImageStream Namespace",
+			"description": "Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.",
+			"value": "openshift",
+			"required": true
+		},
+		{
+			"name": "MAVEN_MIRROR_URL",
+			"displayName": "Maven mirror URL",
+			"description": "Maven mirror to use for S2I builds"
+		},
+		{
+			"name": "ARTIFACT_DIR",
+			"description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied."
+		},
+		{
+			"name": "POSTGRESQL_IMAGE_STREAM_TAG",
+			"displayName": "PostgreSQL Image Stream Tag",
+			"description": "The tag to use for the \"postgresql\" image stream.  Typically, this aligns with the major.minor version of PostgreSQL.",
+			"value": "9.5",
+			"required": true
+		}
+	],
+	"labels": {
+		"jws54jdk8el7": "1.0",
+		"template": "jws54-openjdk8-tomcat9-rhel7-postgresql-s2i"
+	}
+}

--- a/official/webserver/templates/jws54-openjdk8-tomcat9-ubi8-basic-s2i.json
+++ b/official/webserver/templates/jws54-openjdk8-tomcat9-ubi8-basic-s2i.json
@@ -2,16 +2,16 @@
 	"kind": "Template",
 	"apiVersion": "v1",
 	"metadata": {
-		"name": "jws53-openjdk11-tomcat9-basic-s2i",
+		"name": "jws54-openjdk8-tomcat9-ubi8-basic-s2i",
 		"creationTimestamp": null,
 		"annotations": {
 			"description": "An example JBoss Web Server application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
 			"iconClass": "icon-rh-tomcat",
-			"openshift.io/display-name": "JBoss Web Server 5.3 Apache Tomcat 9 OpenJDK11 (no https)",
+			"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK8 on UBI8 (no https)",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
 			"tags": "tomcat,tomcat9,java,jboss",
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-web-server/",
-			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.3 Apache Tomcat 9 based application, including a build configuration, and an application deployment configuration.",
+			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.4 Apache Tomcat 9 based application, including a build configuration, and an application deployment configuration.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
 			"version": "1.0"
 		}
@@ -111,7 +111,7 @@
 						"forcePull": true,
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "jboss-webserver53-openjdk11-tomcat9-openshift:1.0",
+							"name": "jboss-webserver54-openjdk8-tomcat9-openshift-ubi8:1.0",
 							"namespace": "${IMAGE_STREAM_NAMESPACE}"
 						}
 					},
@@ -198,7 +198,7 @@
 										"command": [
 											"/bin/bash",
 											"-c",
-											"curl --noproxy '*' -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer\u0026att=stateName' |grep -iq 'stateName *= *STARTED'"
+											"curl --noproxy '*' -is 'http://localhost:8080/health' | grep -iq '\"status\": \"UP\"'"
 										]
 									}
 								}
@@ -310,7 +310,7 @@
 		}
 	],
 	"labels": {
-		"jws53": "1.0",
-		"template": "jws53-openjdk11-tomcat9-basic-s2i"
+		"jws54jdk8ubi8": "1.0",
+		"template": "jws54-openjdk8-tomcat9-ubi8-basic-s2i"
 	}
 }

--- a/official/webserver/templates/jws54-openjdk8-tomcat9-ubi8-https-s2i.json
+++ b/official/webserver/templates/jws54-openjdk8-tomcat9-ubi8-https-s2i.json
@@ -2,16 +2,16 @@
 	"kind": "Template",
 	"apiVersion": "v1",
 	"metadata": {
-		"name": "jws53-openjdk8-tomcat9-https-s2i",
+		"name": "jws54-openjdk8-tomcat9-ubi8-https-s2i",
 		"creationTimestamp": null,
 		"annotations": {
 			"description": "An example JBoss Web Server application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
 			"iconClass": "icon-rh-tomcat",
-			"openshift.io/display-name": "JBoss Web Server 5.3 Apache Tomcat 9 OpenJDK8 (with https)",
+			"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK8 on UBI8 (with https)",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
 			"tags": "tomcat,tomcat9,java,jboss,hidden",
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-web-server/",
-			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.3 Apache Tomcat 9 based application, including a build configuration, application deployment configuration, and secure communication using https.",
+			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.4 Apache Tomcat 9 based application, including a build configuration, application deployment configuration, and secure communication using https.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
 			"version": "1.0"
 		}
@@ -158,7 +158,7 @@
 						"forcePull": true,
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "jboss-webserver53-openjdk8-tomcat9-openshift:1.0",
+							"name": "jboss-webserver54-openjdk8-tomcat9-openshift-ubi8:1.0",
 							"namespace": "${IMAGE_STREAM_NAMESPACE}"
 						}
 					},
@@ -266,7 +266,7 @@
 										"command": [
 											"/bin/bash",
 											"-c",
-											"curl --noproxy '*' -s -u ${JWS_ADMIN_USERNAME}:${JWS_ADMIN_PASSWORD} 'http://localhost:8080/manager/jmxproxy/?get=Catalina%3Atype%3DServer\u0026att=stateName' |grep -iq 'stateName *= *STARTED'"
+											"curl --noproxy '*' -is 'http://localhost:8080/health' | grep -iq '\"status\": \"UP\"'"
 										]
 									}
 								},
@@ -422,7 +422,7 @@
 		}
 	],
 	"labels": {
-		"jws53": "1.0",
-		"template": "jws53-openjdk8-tomcat9-https-s2i"
+		"jws54jdk8ubi8": "1.0",
+		"template": "jws54-openjdk8-tomcat9-ubi8-https-s2i"
 	}
 }


### PR DESCRIPTION
This updates the RHEL7 imagestreams and templates for JWS 5.4 and also adds the UBI8 imagestreams and templates.
Removing outdated database templates for the time being.
CC @yselkowitz can you please review?