### PR TITLE
community: replace some docker.io images with quay.io

### DIFF
--- a/arch/x86_64/community/mariadb/imagestreams/mariadb-centos.json
+++ b/arch/x86_64/community/mariadb/imagestreams/mariadb-centos.json
@@ -64,7 +64,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "docker.io/centos/mariadb-103-centos7:latest"
+					"name": "quay.io/centos7/mariadb-103-centos7:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -84,7 +84,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "docker.io/centos/mariadb-103-centos7:latest"
+					"name": "quay.io/centos7/mariadb-103-centos7:latest"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/arch/x86_64/community/nginx/imagestreams/nginx-centos.json
+++ b/arch/x86_64/community/nginx/imagestreams/nginx-centos.json
@@ -92,7 +92,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "docker.io/centos/nginx-116-centos7:latest"
+					"name": "quay.io/centos7/nginx-116-centos7:latest"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/arch/x86_64/community/php/imagestreams/php-centos.json
+++ b/arch/x86_64/community/php/imagestreams/php-centos.json
@@ -114,7 +114,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "docker.io/centos/php-73-centos7:latest"
+					"name": "quay.io/centos7/php-73-centos7:latest"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/arch/x86_64/community/python/imagestreams/python-centos.json
+++ b/arch/x86_64/community/python/imagestreams/python-centos.json
@@ -158,7 +158,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "docker.io/centos/python-27-centos7:latest"
+					"name": "quay.io/centos7/python-27-centos7:latest"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/arch/x86_64/community/redis/imagestreams/redis-centos.json
+++ b/arch/x86_64/community/redis/imagestreams/redis-centos.json
@@ -64,7 +64,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "docker.io/centos/redis-5-centos7:latest"
+					"name": "quay.io/centos7/redis-5-centos7:latest"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/community/mariadb/imagestreams/mariadb-centos.json
+++ b/community/mariadb/imagestreams/mariadb-centos.json
@@ -64,7 +64,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "docker.io/centos/mariadb-103-centos7:latest"
+					"name": "quay.io/centos7/mariadb-103-centos7:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -84,7 +84,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "docker.io/centos/mariadb-103-centos7:latest"
+					"name": "quay.io/centos7/mariadb-103-centos7:latest"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/community/nginx/imagestreams/nginx-centos.json
+++ b/community/nginx/imagestreams/nginx-centos.json
@@ -92,7 +92,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "docker.io/centos/nginx-116-centos7:latest"
+					"name": "quay.io/centos7/nginx-116-centos7:latest"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/community/php/imagestreams/php-centos.json
+++ b/community/php/imagestreams/php-centos.json
@@ -114,7 +114,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "docker.io/centos/php-73-centos7:latest"
+					"name": "quay.io/centos7/php-73-centos7:latest"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/community/python/imagestreams/python-centos.json
+++ b/community/python/imagestreams/python-centos.json
@@ -158,7 +158,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "docker.io/centos/python-27-centos7:latest"
+					"name": "quay.io/centos7/python-27-centos7:latest"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/community/redis/imagestreams/redis-centos.json
+++ b/community/redis/imagestreams/redis-centos.json
@@ -64,7 +64,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "docker.io/centos/redis-5-centos7:latest"
+					"name": "quay.io/centos7/redis-5-centos7:latest"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/operator/okd-x86_64/community/mariadb/imagestreams/mariadb-centos.json
+++ b/operator/okd-x86_64/community/mariadb/imagestreams/mariadb-centos.json
@@ -64,7 +64,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "docker.io/centos/mariadb-103-centos7:latest"
+					"name": "quay.io/centos7/mariadb-103-centos7:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -84,7 +84,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "docker.io/centos/mariadb-103-centos7:latest"
+					"name": "quay.io/centos7/mariadb-103-centos7:latest"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/operator/okd-x86_64/community/nginx/imagestreams/nginx-centos.json
+++ b/operator/okd-x86_64/community/nginx/imagestreams/nginx-centos.json
@@ -92,7 +92,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "docker.io/centos/nginx-116-centos7:latest"
+					"name": "quay.io/centos7/nginx-116-centos7:latest"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/operator/okd-x86_64/community/php/imagestreams/php-centos.json
+++ b/operator/okd-x86_64/community/php/imagestreams/php-centos.json
@@ -114,7 +114,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "docker.io/centos/php-73-centos7:latest"
+					"name": "quay.io/centos7/php-73-centos7:latest"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/operator/okd-x86_64/community/python/imagestreams/python-centos.json
+++ b/operator/okd-x86_64/community/python/imagestreams/python-centos.json
@@ -158,7 +158,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "docker.io/centos/python-27-centos7:latest"
+					"name": "quay.io/centos7/python-27-centos7:latest"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/operator/okd-x86_64/community/redis/imagestreams/redis-centos.json
+++ b/operator/okd-x86_64/community/redis/imagestreams/redis-centos.json
@@ -64,7 +64,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "docker.io/centos/redis-5-centos7:latest"
+					"name": "quay.io/centos7/redis-5-centos7:latest"
 				},
 				"generation": null,
 				"importPolicy": {},


### PR DESCRIPTION
This would ensure OKD clusters are hitting docker.io less often. Centos8 images are not yet mirrored to quay