### PR TITLE
[KEYCLOAK-17575] Update RH-SSO templates & imagestreams to the latest 'v7.4.7.GA' release

### DIFF
--- a/official.yaml
+++ b/official.yaml
@@ -6,8 +6,8 @@ variables:
   rhsso72_zstream_version: v7.2.6.GA
   rhsso_tpcd_version: sso-cd-dev
   rhsso73_zstream_version: v7.3.8.GA-RHBZ-1813894-fix
-  rhsso74_openjdk_version: v7.4.6.GA
-  rhsso74_openj9_version: v7.4.6.GA
+  rhsso74_openjdk_version: v7.4.7.GA
+  rhsso74_openj9_version: v7.4.7.GA
   webserver_version: ose-v1.4.17
   webserver3_version: jws31-v1.4
   webserver5el7_version: jws54el7-v1.0

--- a/official/sso/imagestreams/sso74-openj9-openshift-rhel8.json
+++ b/official/sso/imagestreams/sso74-openj9-openshift-rhel8.json
@@ -8,7 +8,7 @@
 			"description": "Red Hat Single Sign-On 7.4 on OpenJ9",
 			"openshift.io/display-name": "Red Hat Single Sign-On 7.4 on OpenJ9",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
-			"version": "7.4.6.GA"
+			"version": "7.4.7.GA"
 		}
 	},
 	"spec": {

--- a/official/sso/imagestreams/sso74-openshift-rhel8.json
+++ b/official/sso/imagestreams/sso74-openshift-rhel8.json
@@ -8,7 +8,7 @@
 			"description": "Red Hat Single Sign-On 7.4 on OpenJDK",
 			"openshift.io/display-name": "Red Hat Single Sign-On 7.4 on OpenJDK",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
-			"version": "7.4.6.GA"
+			"version": "7.4.7.GA"
 		}
 	},
 	"spec": {

--- a/official/sso/templates/sso74-https.json
+++ b/official/sso/templates/sso74-https.json
@@ -13,7 +13,7 @@
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
 			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.4 on OpenJDK server based deployment, securing RH-SSO communication using passthrough TLS.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "7.4.6.GA"
+			"version": "7.4.7.GA"
 		}
 	},
 	"message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
@@ -539,7 +539,7 @@
 		}
 	],
 	"labels": {
-		"rhsso": "7.4.6.GA",
+		"rhsso": "7.4.7.GA",
 		"template": "sso74-https"
 	}
 }

--- a/official/sso/templates/sso74-ocp4-x509-https.json
+++ b/official/sso/templates/sso74-ocp4-x509-https.json
@@ -13,7 +13,7 @@
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
 			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.4 on OpenJDK server based deployment, securing RH-SSO communication using re-encrypt TLS.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "7.4.6.GA"
+			"version": "7.4.7.GA"
 		}
 	},
 	"message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
@@ -387,7 +387,7 @@
 		}
 	],
 	"labels": {
-		"rhsso": "7.4.6.GA",
+		"rhsso": "7.4.7.GA",
 		"template": "sso74-ocp4-x509-https"
 	}
 }

--- a/official/sso/templates/sso74-ocp4-x509-postgresql-persistent.json
+++ b/official/sso/templates/sso74-ocp4-x509-postgresql-persistent.json
@@ -13,7 +13,7 @@
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
 			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.4 on OpenJDK server based deployment, deployment configuration for PostgreSQL using persistence, and securing RH-SSO communication using re-encrypt TLS.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "7.4.6.GA"
+			"version": "7.4.7.GA"
 		}
 	},
 	"message": "A new persistent RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
@@ -635,7 +635,7 @@
 		}
 	],
 	"labels": {
-		"rhsso": "7.4.6.GA",
+		"rhsso": "7.4.7.GA",
 		"template": "sso74-ocp4-x509-postgresql-persistent"
 	}
 }

--- a/official/sso/templates/sso74-openj9-https.json
+++ b/official/sso/templates/sso74-openj9-https.json
@@ -13,7 +13,7 @@
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
 			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.4 on OpenJ9 server based deployment, securing RH-SSO communication using passthrough TLS.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "7.4.6.GA"
+			"version": "7.4.7.GA"
 		}
 	},
 	"message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
@@ -539,7 +539,7 @@
 		}
 	],
 	"labels": {
-		"rhsso": "7.4.6.GA",
+		"rhsso": "7.4.7.GA",
 		"template": "sso74-openj9-https"
 	}
 }

--- a/official/sso/templates/sso74-openj9-ocp4-x509-https.json
+++ b/official/sso/templates/sso74-openj9-ocp4-x509-https.json
@@ -13,7 +13,7 @@
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
 			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.4 on OpenJ9 server based deployment, securing RH-SSO communication using re-encrypt TLS.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "7.4.6.GA"
+			"version": "7.4.7.GA"
 		}
 	},
 	"message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
@@ -387,7 +387,7 @@
 		}
 	],
 	"labels": {
-		"rhsso": "7.4.6.GA",
+		"rhsso": "7.4.7.GA",
 		"template": "sso74-openj9-ocp4-x509-https"
 	}
 }

--- a/official/sso/templates/sso74-openj9-ocp4-x509-postgresql-persistent.json
+++ b/official/sso/templates/sso74-openj9-ocp4-x509-postgresql-persistent.json
@@ -13,7 +13,7 @@
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
 			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.4 on OpenJ9 server based deployment, deployment configuration for PostgreSQL using persistence, and securing RH-SSO communication using re-encrypt TLS.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "7.4.6.GA"
+			"version": "7.4.7.GA"
 		}
 	},
 	"message": "A new persistent RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
@@ -635,7 +635,7 @@
 		}
 	],
 	"labels": {
-		"rhsso": "7.4.6.GA",
+		"rhsso": "7.4.7.GA",
 		"template": "sso74-openj9-ocp4-x509-postgresql-persistent"
 	}
 }

--- a/official/sso/templates/sso74-openj9-postgresql-persistent.json
+++ b/official/sso/templates/sso74-openj9-postgresql-persistent.json
@@ -13,7 +13,7 @@
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
 			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.4 on OpenJ9 server based deployment, deployment configuration for PostgreSQL using persistence, and securing RH-SSO communication using passthrough TLS.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "7.4.6.GA"
+			"version": "7.4.7.GA"
 		}
 	},
 	"message": "A new persistent RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
@@ -788,7 +788,7 @@
 		}
 	],
 	"labels": {
-		"rhsso": "7.4.6.GA",
+		"rhsso": "7.4.7.GA",
 		"template": "sso74-openj9-postgresql-persistent"
 	}
 }

--- a/official/sso/templates/sso74-openj9-postgresql.json
+++ b/official/sso/templates/sso74-openj9-postgresql.json
@@ -13,7 +13,7 @@
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
 			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.4 on OpenJ9 server based deployment, deployment configuration for PostgreSQL using ephemeral (temporary) storage, and securing RH-SSO communication using passthrough TLS.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "7.4.6.GA"
+			"version": "7.4.7.GA"
 		}
 	},
 	"message": "A new RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
@@ -766,7 +766,7 @@
 		}
 	],
 	"labels": {
-		"rhsso": "7.4.6.GA",
+		"rhsso": "7.4.7.GA",
 		"template": "sso74-openj9-postgresql"
 	}
 }

--- a/official/sso/templates/sso74-postgresql-persistent.json
+++ b/official/sso/templates/sso74-postgresql-persistent.json
@@ -13,7 +13,7 @@
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
 			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.4 on OpenJDK server based deployment, deployment configuration for PostgreSQL using persistence, and securing RH-SSO communication using passthrough TLS.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "7.4.6.GA"
+			"version": "7.4.7.GA"
 		}
 	},
 	"message": "A new persistent RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
@@ -788,7 +788,7 @@
 		}
 	],
 	"labels": {
-		"rhsso": "7.4.6.GA",
+		"rhsso": "7.4.7.GA",
 		"template": "sso74-postgresql-persistent"
 	}
 }

--- a/official/sso/templates/sso74-postgresql.json
+++ b/official/sso/templates/sso74-postgresql.json
@@ -13,7 +13,7 @@
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
 			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.4 on OpenJDK server based deployment, deployment configuration for PostgreSQL using ephemeral (temporary) storage, and securing RH-SSO communication using passthrough TLS.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "7.4.6.GA"
+			"version": "7.4.7.GA"
 		}
 	},
 	"message": "A new RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
@@ -766,7 +766,7 @@
 		}
 	],
 	"labels": {
-		"rhsso": "7.4.6.GA",
+		"rhsso": "7.4.7.GA",
 		"template": "sso74-postgresql"
 	}
 }


### PR DESCRIPTION
<hr/>

    [KEYCLOAK-17575] Update templates & imagestream definitions for
    Red Hat Single Sign-On OpenShift images to the latest available
    'v7.4.7.GA' release
    
    Corresponding accompanied product advisory is RHEA-2021:2066
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>


See [RHEA-2021:2066](https://access.redhat.com/errata/RHEA-2021:2066) advisory for details

<hr/>

@adambkaplan @gabemontero PTAL (once got a chance)

Thanks,
Jan