### PR TITLE
Remove tags from mongodb imagestream and nodejs-mongodb template

### DIFF
--- a/community.yaml
+++ b/community.yaml
@@ -158,8 +158,6 @@ data:
         docs: https://github.com/sclorg/mongodb-container/blob/master/README.md
         regex: mongodb
         suffix: centos7
-        tags:
-          - okd
   mysql:
     imagestreams:
       - location: https://raw.githubusercontent.com/sclorg/mysql-container/master/imagestreams/mysql-centos.json

--- a/official.yaml
+++ b/official.yaml
@@ -114,12 +114,6 @@ data:
         docs: https://github.com/sclorg/nodejs-ex/blob/master/README.md
       - location: https://raw.githubusercontent.com/sclorg/nodejs-ex/master/openshift/templates/nodejs-mongodb.json
         docs: https://github.com/sclorg/nodejs-ex/blob/master/README.md
-        tags:
-          - okd
-          - ocp
-          - arch_ppc64le
-          - arch_s390x
-          - arch_x86_64
       - location: https://raw.githubusercontent.com/nodeshift-starters/nodejs-rest-http-crud/master/.openshift/postgresql-template.json
         docs: https://github.com/nodeshift-starters/nodejs-rest-http-crud/blob/master/README.md
         tags:
@@ -422,13 +416,6 @@ data:
         docs: https://github.com/sclorg/mongodb-container/blob/master/README.md
         regex: mongodb
         suffix: rhel7
-        tags:
-          - ocp
-          - online-starter
-          - online-professional
-          - arch_ppc64le
-          - arch_s390x
-          - arch_x86_64
   mysql:
     templates:
       - location: https://raw.githubusercontent.com/sclorg/mysql-container/master/examples/mysql-ephemeral-template.json


### PR DESCRIPTION
The mongodb imagestream and all dependent thereon was deprecated or
removed in 4.6, with only the minimum required to support the testsuites
remaining.  With the tests no longer dependent on mongodb, now the rest
can be removed.
