### PR TITLE
Add .NET imagestreams for aarch64 and s390x

### DIFF
--- a/official.yaml
+++ b/official.yaml
@@ -1446,6 +1446,19 @@ data:
           - ocp
           - online-starter
           - online-professional
+          - arch_x86_64
+      - location: https://raw.githubusercontent.com/redhat-developer/s2i-dotnetcore/master/dotnet_imagestreams_aarch64.json
+        docs: https://github.com/redhat-developer/s2i-dotnetcore/blob/master/README.md
+        suffix: rhel-aarch64
+        tags:
+          - ocp
+          - arch_aarch64
+      - location: https://raw.githubusercontent.com/redhat-developer/s2i-dotnetcore/master/dotnet_imagestreams_s390x.json
+        docs: https://github.com/redhat-developer/s2i-dotnetcore/blob/master/README.md
+        suffix: rhel-s390x
+        tags:
+          - ocp
+          - arch_s390x
   3scale:
     templates:
       - location: https://raw.githubusercontent.com/3scale/3scale-amp-openshift-templates/{rhamp_version}/apicast-gateway/library/apicast.yml

--- a/official/dotnet/imagestreams/dotnet-rhel-aarch64.json
+++ b/official/dotnet/imagestreams/dotnet-rhel-aarch64.json
@@ -1,0 +1,89 @@
+{
+	"kind": "ImageStream",
+	"apiVersion": "v1",
+	"metadata": {
+		"name": "dotnet",
+		"creationTimestamp": null,
+		"annotations": {
+			"openshift.io/display-name": ".NET"
+		}
+	},
+	"spec": {
+		"lookupPolicy": {
+			"local": false
+		},
+		"tags": [
+			{
+				"name": "latest",
+				"annotations": {
+					"description": "Build and run .NET applications. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/build/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET available on OpenShift, including major versions updates.",
+					"iconClass": "icon-dotnet",
+					"openshift.io/display-name": ".NET (Latest)",
+					"sampleContextDir": "app",
+					"sampleRef": "dotnet-6.0",
+					"sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
+					"supports": "dotnet",
+					"tags": "builder,.net,dotnet,dotnetcore,hidden"
+				},
+				"from": {
+					"kind": "ImageStreamTag",
+					"name": "6.0-ubi8"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "6.0-ubi8",
+				"annotations": {
+					"description": "Build and run .NET 6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/build/README.md.",
+					"iconClass": "icon-dotnet",
+					"openshift.io/display-name": ".NET 6 (UBI 8)",
+					"sampleContextDir": "app",
+					"sampleRef": "dotnet-6.0",
+					"sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
+					"supports": "dotnet:6.0,dotnet",
+					"tags": "builder,.net,dotnet,dotnetcore,dotnet60",
+					"version": "6.0"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.access.redhat.com/ubi8/dotnet-60:6.0"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "6.0",
+				"annotations": {
+					"description": "Build and run .NET 6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/build/README.md.",
+					"iconClass": "icon-dotnet",
+					"openshift.io/display-name": ".NET 6 (UBI 8)",
+					"sampleContextDir": "app",
+					"sampleRef": "dotnetcore-6.0",
+					"sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
+					"supports": "dotnet:6.0,dotnet",
+					"tags": "builder,.net,dotnet,dotnetcore,dotnet60,hidden",
+					"version": "6.0"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.access.redhat.com/ubi8/dotnet-60:6.0"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			}
+		]
+	},
+	"status": {
+		"dockerImageRepository": ""
+	}
+}

--- a/official/dotnet/imagestreams/dotnet-rhel-s390x.json
+++ b/official/dotnet/imagestreams/dotnet-rhel-s390x.json
@@ -1,0 +1,89 @@
+{
+	"kind": "ImageStream",
+	"apiVersion": "v1",
+	"metadata": {
+		"name": "dotnet",
+		"creationTimestamp": null,
+		"annotations": {
+			"openshift.io/display-name": ".NET"
+		}
+	},
+	"spec": {
+		"lookupPolicy": {
+			"local": false
+		},
+		"tags": [
+			{
+				"name": "latest",
+				"annotations": {
+					"description": "Build and run .NET applications. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/build/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET available on OpenShift, including major versions updates.",
+					"iconClass": "icon-dotnet",
+					"openshift.io/display-name": ".NET (Latest)",
+					"sampleContextDir": "app",
+					"sampleRef": "dotnet-6.0",
+					"sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
+					"supports": "dotnet",
+					"tags": "builder,.net,dotnet,dotnetcore,hidden"
+				},
+				"from": {
+					"kind": "ImageStreamTag",
+					"name": "6.0-ubi8"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "6.0-ubi8",
+				"annotations": {
+					"description": "Build and run .NET 6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/build/README.md.",
+					"iconClass": "icon-dotnet",
+					"openshift.io/display-name": ".NET 6 (UBI 8)",
+					"sampleContextDir": "app",
+					"sampleRef": "dotnet-6.0",
+					"sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
+					"supports": "dotnet:6.0,dotnet",
+					"tags": "builder,.net,dotnet,dotnetcore,dotnet60",
+					"version": "6.0"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.access.redhat.com/ubi8/dotnet-60:6.0"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "6.0",
+				"annotations": {
+					"description": "Build and run .NET 6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/build/README.md.",
+					"iconClass": "icon-dotnet",
+					"openshift.io/display-name": ".NET 6 (UBI 8)",
+					"sampleContextDir": "app",
+					"sampleRef": "dotnetcore-6.0",
+					"sampleRepo": "https://github.com/redhat-developer/s2i-dotnetcore-ex",
+					"supports": "dotnet:6.0,dotnet",
+					"tags": "builder,.net,dotnet,dotnetcore,dotnet60,hidden",
+					"version": "6.0"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.access.redhat.com/ubi8/dotnet-60:6.0"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			}
+		]
+	},
+	"status": {
+		"dockerImageRepository": ""
+	}
+}

--- a/official/dotnet/imagestreams/dotnet-runtime-rhel-aarch64.json
+++ b/official/dotnet/imagestreams/dotnet-runtime-rhel-aarch64.json
@@ -1,0 +1,80 @@
+{
+	"kind": "ImageStream",
+	"apiVersion": "v1",
+	"metadata": {
+		"name": "dotnet-runtime",
+		"creationTimestamp": null,
+		"annotations": {
+			"openshift.io/display-name": ".NET Core Runtime"
+		}
+	},
+	"spec": {
+		"lookupPolicy": {
+			"local": false
+		},
+		"tags": [
+			{
+				"name": "latest",
+				"annotations": {
+					"description": "Run .NET applications. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/runtime/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core Runtime available on OpenShift, including major versions updates.",
+					"iconClass": "icon-dotnet",
+					"openshift.io/display-name": ".NET Runtime (Latest)",
+					"supports": "dotnet-runtime",
+					"tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden"
+				},
+				"from": {
+					"kind": "ImageStreamTag",
+					"name": "6.0-ubi8"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "6.0-ubi8",
+				"annotations": {
+					"description": "Run .NET 6 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/runtime/README.md.",
+					"iconClass": "icon-dotnet",
+					"openshift.io/display-name": ".NET 6 Runtime (UBI 8)",
+					"supports": "dotnet-runtime",
+					"tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
+					"version": "6.0"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.access.redhat.com/ubi8/dotnet-60-runtime:6.0"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "6.0",
+				"annotations": {
+					"description": "Run .NET 6 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/runtime/README.md.",
+					"iconClass": "icon-dotnet",
+					"openshift.io/display-name": ".NET 6 Runtime (UBI 8)",
+					"supports": "dotnet-runtime",
+					"tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
+					"version": "6.0"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.access.redhat.com/ubi8/dotnet-60-runtime:6.0"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			}
+		]
+	},
+	"status": {
+		"dockerImageRepository": ""
+	}
+}

--- a/official/dotnet/imagestreams/dotnet-runtime-rhel-s390x.json
+++ b/official/dotnet/imagestreams/dotnet-runtime-rhel-s390x.json
@@ -1,0 +1,80 @@
+{
+	"kind": "ImageStream",
+	"apiVersion": "v1",
+	"metadata": {
+		"name": "dotnet-runtime",
+		"creationTimestamp": null,
+		"annotations": {
+			"openshift.io/display-name": ".NET Core Runtime"
+		}
+	},
+	"spec": {
+		"lookupPolicy": {
+			"local": false
+		},
+		"tags": [
+			{
+				"name": "latest",
+				"annotations": {
+					"description": "Run .NET applications. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/runtime/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of .NET Core Runtime available on OpenShift, including major versions updates.",
+					"iconClass": "icon-dotnet",
+					"openshift.io/display-name": ".NET Runtime (Latest)",
+					"supports": "dotnet-runtime",
+					"tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden"
+				},
+				"from": {
+					"kind": "ImageStreamTag",
+					"name": "6.0-ubi8"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "6.0-ubi8",
+				"annotations": {
+					"description": "Run .NET 6 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/runtime/README.md.",
+					"iconClass": "icon-dotnet",
+					"openshift.io/display-name": ".NET 6 Runtime (UBI 8)",
+					"supports": "dotnet-runtime",
+					"tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime",
+					"version": "6.0"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.access.redhat.com/ubi8/dotnet-60-runtime:6.0"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			},
+			{
+				"name": "6.0",
+				"annotations": {
+					"description": "Run .NET 6 applications on UBI 8. For more information about using this image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/6.0/runtime/README.md.",
+					"iconClass": "icon-dotnet",
+					"openshift.io/display-name": ".NET 6 Runtime (UBI 8)",
+					"supports": "dotnet-runtime",
+					"tags": "runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime,hidden",
+					"version": "6.0"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.access.redhat.com/ubi8/dotnet-60-runtime:6.0"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			}
+		]
+	},
+	"status": {
+		"dockerImageRepository": ""
+	}
+}


### PR DESCRIPTION
Only the latest .NET 6 is available for these arches however, so separate files are needed.

/cc @tmds
