### PR TITLE
Update imagestreams and templates for JWS 5.6.0

### DIFF
--- a/official.yaml
+++ b/official.yaml
@@ -13,8 +13,8 @@ variables:
   webserver_version: ose-v1.4.17
   webserver3_version: jws31-v1.4
   webserver5el7_version: jws54el7-v1.0
-  webserver5el8_version: jws54el8-v1.0
-  webserver5_openj9_version: jws54openj9ubi8-v1.0
+  webserver5el8_version: jws56el8-v5.6.0
+  webserver5_openj9_version: jws56el8-v5.6.0
   ips_ds_version: 6.4.12.GA
   rhdm_version: 7.11.1.GA
   rhpam_version: 7.11.1.GA
@@ -1300,13 +1300,7 @@ data:
         docs: https://github.com/jboss-openshift/application-templates/blob/{webserver_version}/docs/webserver/jws31-tomcat8-postgresql-s2i.adoc
       # List the JWS 5 RHEL7 templates below
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk8-tomcat9-rhel7-basic-s2i.json
-        tags:
-          - ocp
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk8-tomcat9-rhel7-https-s2i.json
-        tags:
-          - ocp
-          - online-starter
-          - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk8-tomcat9-rhel7-mongodb-persistent-s2i.json
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk8-tomcat9-rhel7-mongodb-s2i.json
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk8-tomcat9-rhel7-mysql-persistent-s2i.json
@@ -1314,13 +1308,7 @@ data:
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk8-tomcat9-rhel7-postgresql-persistent-s2i.json
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk8-tomcat9-rhel7-postgresql-s2i.json
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk11-tomcat9-rhel7-basic-s2i.json
-        tags:
-          - ocp
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk11-tomcat9-rhel7-https-s2i.json
-        tags:
-          - ocp
-          - online-starter
-          - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk11-tomcat9-rhel7-mongodb-persistent-s2i.json
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk11-tomcat9-rhel7-mongodb-s2i.json
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk11-tomcat9-rhel7-mysql-persistent-s2i.json
@@ -1328,29 +1316,29 @@ data:
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk11-tomcat9-rhel7-postgresql-persistent-s2i.json
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk11-tomcat9-rhel7-postgresql-s2i.json
       # List the JWS 5 UBI8 templates below
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el8_version}/templates/jws54-openjdk8-tomcat9-ubi8-basic-s2i.json
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el8_version}/templates/jws56-openjdk8-tomcat9-ubi8-basic-s2i.json
         tags:
           - ocp
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el8_version}/templates/jws54-openjdk8-tomcat9-ubi8-https-s2i.json
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el8_version}/templates/jws56-openjdk8-tomcat9-ubi8-https-s2i.json
         tags:
           - ocp
           - online-starter
           - online-professional
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el8_version}/templates/jws54-openjdk11-tomcat9-ubi8-basic-s2i.json
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el8_version}/templates/jws56-openjdk11-tomcat9-ubi8-basic-s2i.json
         tags:
           - ocp
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el8_version}/templates/jws54-openjdk11-tomcat9-ubi8-https-s2i.json
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el8_version}/templates/jws56-openjdk11-tomcat9-ubi8-https-s2i.json
         tags:
           - ocp
           - online-starter
           - online-professional
       # List templates for OpenJ9 images below
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5_openj9_version}/templates/jws54-openj9-tomcat9-ubi8-basic-s2i.json
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5_openj9_version}/templates/jws56-openj9-tomcat9-ubi8-basic-s2i.json
         tags:
           - ocp
           - arch_s390x
           - arch_ppc64le
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5_openj9_version}/templates/jws54-openj9-tomcat9-ubi8-https-s2i.json
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5_openj9_version}/templates/jws56-openj9-tomcat9-ubi8-https-s2i.json
         tags:
           - ocp
           - arch_s390x
@@ -1372,27 +1360,19 @@ data:
           - online-professional
       # List the JWS 5 imagestreams below
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk8-tomcat9-rhel7-image-stream.json
-        tags:
-          - ocp
-          - online-starter
-          - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el7_version}/templates/jws54-openjdk11-tomcat9-rhel7-image-stream.json
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el8_version}/templates/jws56-openjdk8-tomcat9-ubi8-image-stream.json
         tags:
           - ocp
           - online-starter
           - online-professional
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el8_version}/templates/jws54-openjdk8-tomcat9-ubi8-image-stream.json
-        tags:
-          - ocp
-          - online-starter
-          - online-professional
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el8_version}/templates/jws54-openjdk11-tomcat9-ubi8-image-stream.json
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5el8_version}/templates/jws56-openjdk11-tomcat9-ubi8-image-stream.json
         tags:
           - ocp
           - online-starter
           - online-professional
       # List imagestream for OpenJ9 images below
-      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5_openj9_version}/templates/jws54-openj9-tomcat9-ubi8-image-stream.json
+      - location: https://raw.githubusercontent.com/jboss-container-images/jboss-webserver-5-openshift-image/{webserver5_openj9_version}/templates/jws56-openj9-tomcat9-ubi8-image-stream.json
         tags:
           - ocp
           - arch_s390x

--- a/official/webserver/imagestreams/jboss-webserver56-openj9-tomcat9-openshift-ubi8.json
+++ b/official/webserver/imagestreams/jboss-webserver56-openj9-tomcat9-openshift-ubi8.json
@@ -1,13 +1,13 @@
 {
 	"kind": "ImageStream",
-	"apiVersion": "v1",
+	"apiVersion": "image.openshift.io/v1",
 	"metadata": {
-		"name": "jboss-webserver54-openjdk11-tomcat9-openshift-ubi8",
+		"name": "jboss-webserver56-openj9-tomcat9-openshift-ubi8",
 		"creationTimestamp": null,
 		"annotations": {
-			"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK11 on UBI8",
+			"openshift.io/display-name": "JBoss Web Server 5.6 Apache Tomcat 9 OpenJ9 JDK11",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
-			"version": "1.0"
+			"version": "5.6"
 		}
 	},
 	"spec": {
@@ -18,43 +18,47 @@
 			{
 				"name": "latest",
 				"annotations": {
-					"description": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK11 on UBI8 S2I images.",
+					"description": "JBoss Web Server 5.6 Apache Tomcat 9 OpenJ9 JDK11 on UBI8 S2I images.",
 					"iconClass": "icon-rh-tomcat",
-					"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK11 on UBI8",
+					"openshift.io/display-name": "JBoss Web Server 5.6 Apache Tomcat 9 OpenJ9 JDK11 on UBI8",
 					"sampleContextDir": "tomcat-websocket-chat",
 					"sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-					"supports": "tomcat9:5.4,tomcat:9,java:11",
+					"supports": "tomcat9:5.6,tomcat:9,java:11",
 					"tags": "builder,tomcat,tomcat9,java,jboss,hidden",
 					"version": "latest"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/jboss-webserver-5/webserver54-openjdk11-tomcat9-openshift-rhel8:latest"
+					"name": "registry.redhat.io/jboss-webserver-5/jws56-openj9-11-openshift-rhel8:latest"
 				},
 				"generation": null,
-				"importPolicy": {},
+				"importPolicy": {
+					"insecure": true
+				},
 				"referencePolicy": {
 					"type": "Local"
 				}
 			},
 			{
-				"name": "1.0",
+				"name": "5.6.0",
 				"annotations": {
-					"description": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK11 on UBI8 S2I images.",
+					"description": "JBoss Web Server 5.6 Apache Tomcat 9 OpenJ9 JDK11 on UBI8 S2I images.",
 					"iconClass": "icon-rh-tomcat",
-					"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK11 on UBI8",
+					"openshift.io/display-name": "JBoss Web Server 5.6 Apache Tomcat 9 OpenJ9 JDK11 on UBI8",
 					"sampleContextDir": "tomcat-websocket-chat",
 					"sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-					"supports": "tomcat9:5.4,tomcat:9,java:11",
+					"supports": "tomcat9:5.6,tomcat:9,java:11",
 					"tags": "builder,tomcat,tomcat9,java,jboss,hidden",
-					"version": "1.0"
+					"version": "1.2"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/jboss-webserver-5/webserver54-openjdk11-tomcat9-openshift-rhel8:1.0"
+					"name": "registry.redhat.io/jboss-webserver-5/jws56-openj9-11-openshift-rhel8:5.6.0"
 				},
 				"generation": null,
-				"importPolicy": {},
+				"importPolicy": {
+					"insecure": true
+				},
 				"referencePolicy": {
 					"type": "Local"
 				}

--- a/official/webserver/imagestreams/jboss-webserver56-openjdk11-tomcat9-openshift-ubi8.json
+++ b/official/webserver/imagestreams/jboss-webserver56-openjdk11-tomcat9-openshift-ubi8.json
@@ -1,13 +1,13 @@
 {
 	"kind": "ImageStream",
-	"apiVersion": "v1",
+	"apiVersion": "image.openshift.io/v1",
 	"metadata": {
-		"name": "jboss-webserver54-openj9-tomcat9-openshift-ubi8",
+		"name": "jboss-webserver56-openjdk11-tomcat9-openshift-ubi8",
 		"creationTimestamp": null,
 		"annotations": {
-			"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJ9 JDK11",
+			"openshift.io/display-name": "JBoss Web Server 5.6 Apache Tomcat 9 OpenJDK11 on UBI8",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
-			"version": "1.0"
+			"version": "5.6"
 		}
 	},
 	"spec": {
@@ -18,47 +18,43 @@
 			{
 				"name": "latest",
 				"annotations": {
-					"description": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJ9 JDK11 on UBI8 S2I images.",
+					"description": "JBoss Web Server 5.6 Apache Tomcat 9 OpenJDK11 on UBI8 S2I images.",
 					"iconClass": "icon-rh-tomcat",
-					"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJ9 JDK11 on UBI8",
+					"openshift.io/display-name": "JBoss Web Server 5.6 Apache Tomcat 9 OpenJDK11 on UBI8",
 					"sampleContextDir": "tomcat-websocket-chat",
 					"sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-					"supports": "tomcat9:5.4,tomcat:9,java:11",
+					"supports": "tomcat9:5.6,tomcat:9,java:11",
 					"tags": "builder,tomcat,tomcat9,java,jboss,hidden",
 					"version": "latest"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/jboss-webserver-5/webserver54-openj9-11-tomcat9-openshift-rhel8:latest"
+					"name": "registry.redhat.io/jboss-webserver-5/jws56-openjdk11-openshift-rhel8:latest"
 				},
 				"generation": null,
-				"importPolicy": {
-					"insecure": true
-				},
+				"importPolicy": {},
 				"referencePolicy": {
 					"type": "Local"
 				}
 			},
 			{
-				"name": "1.0",
+				"name": "5.6.0",
 				"annotations": {
-					"description": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJ9 JDK11 on UBI8 S2I images.",
+					"description": "JBoss Web Server 5.6 Apache Tomcat 9 OpenJDK11 on UBI8 S2I images.",
 					"iconClass": "icon-rh-tomcat",
-					"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJ9 JDK11 on UBI8",
+					"openshift.io/display-name": "JBoss Web Server 5.6 Apache Tomcat 9 OpenJDK11 on UBI8",
 					"sampleContextDir": "tomcat-websocket-chat",
 					"sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-					"supports": "tomcat9:5.4,tomcat:9,java:11",
+					"supports": "tomcat9:5.6,tomcat:9,java:11",
 					"tags": "builder,tomcat,tomcat9,java,jboss,hidden",
-					"version": "1.0"
+					"version": "1.2"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/jboss-webserver-5/webserver54-openj9-11-tomcat9-openshift-rhel8:1.0"
+					"name": "registry.redhat.io/jboss-webserver-5/jws56-openjdk11-openshift-rhel8:5.6.0"
 				},
 				"generation": null,
-				"importPolicy": {
-					"insecure": true
-				},
+				"importPolicy": {},
 				"referencePolicy": {
 					"type": "Local"
 				}

--- a/official/webserver/imagestreams/jboss-webserver56-openjdk8-tomcat9-openshift-ubi8.json
+++ b/official/webserver/imagestreams/jboss-webserver56-openjdk8-tomcat9-openshift-ubi8.json
@@ -1,13 +1,13 @@
 {
 	"kind": "ImageStream",
-	"apiVersion": "v1",
+	"apiVersion": "image.openshift.io/v1",
 	"metadata": {
-		"name": "jboss-webserver54-openjdk8-tomcat9-openshift-ubi8",
+		"name": "jboss-webserver56-openjdk8-tomcat9-openshift-ubi8",
 		"creationTimestamp": null,
 		"annotations": {
-			"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK8 on UBI8",
+			"openshift.io/display-name": "JBoss Web Server 5.6 Apache Tomcat 9 OpenJDK8 on UBI8",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
-			"version": "1.0"
+			"version": "5.6"
 		}
 	},
 	"spec": {
@@ -18,18 +18,18 @@
 			{
 				"name": "latest",
 				"annotations": {
-					"description": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK8 on UBI8 S2I images.",
+					"description": "JBoss Web Server 5.6 Apache Tomcat 9 OpenJDK8 on UBI8 S2I images.",
 					"iconClass": "icon-rh-tomcat",
-					"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK8 on UBI8",
+					"openshift.io/display-name": "JBoss Web Server 5.6 Apache Tomcat 9 OpenJDK8 on UBI8",
 					"sampleContextDir": "tomcat-websocket-chat",
 					"sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-					"supports": "tomcat9:5.4,tomcat:9,java:8",
+					"supports": "tomcat9:5.6,tomcat:9,java:8",
 					"tags": "builder,tomcat,tomcat9,java,jboss,hidden",
 					"version": "latest"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/jboss-webserver-5/webserver54-openjdk8-tomcat9-openshift-rhel8:latest"
+					"name": "registry.redhat.io/jboss-webserver-5/jws56-openjdk8-openshift-rhel8:latest"
 				},
 				"generation": null,
 				"importPolicy": {},
@@ -38,20 +38,20 @@
 				}
 			},
 			{
-				"name": "1.0",
+				"name": "5.6.0",
 				"annotations": {
-					"description": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK8 on UBI8 S2I images.",
+					"description": "JBoss Web Server 5.6 Apache Tomcat 9 OpenJDK8 on UBI8 S2I images.",
 					"iconClass": "icon-rh-tomcat",
-					"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK8 on UBI8",
+					"openshift.io/display-name": "JBoss Web Server 5.6 Apache Tomcat 9 OpenJDK8 on UBI8",
 					"sampleContextDir": "tomcat-websocket-chat",
 					"sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-					"supports": "tomcat9:5.4,tomcat:9,java:8",
+					"supports": "tomcat9:5.6,tomcat:9,java:8",
 					"tags": "builder,tomcat,tomcat9,java,jboss,hidden",
-					"version": "1.0"
+					"version": "1.2"
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/jboss-webserver-5/webserver54-openjdk8-tomcat9-openshift-rhel8:1.0"
+					"name": "registry.redhat.io/jboss-webserver-5/jws56-openjdk8-openshift-rhel8:5.6.0"
 				},
 				"generation": null,
 				"importPolicy": {},

--- a/official/webserver/templates/jws56-openj9-tomcat9-ubi8-basic-s2i.json
+++ b/official/webserver/templates/jws56-openj9-tomcat9-ubi8-basic-s2i.json
@@ -1,22 +1,22 @@
 {
 	"kind": "Template",
-	"apiVersion": "v1",
+	"apiVersion": "template.openshift.io/v1",
 	"metadata": {
-		"name": "jws54-openjdk11-tomcat9-ubi8-https-s2i",
+		"name": "jws56-openj9-tomcat9-ubi8-basic-s2i",
 		"creationTimestamp": null,
 		"annotations": {
 			"description": "An example JBoss Web Server application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
 			"iconClass": "icon-rh-tomcat",
-			"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK11 on UBI8 (with https)",
+			"openshift.io/display-name": "JBoss Web Server 5.6 Apache Tomcat 9 OpenJ9 JDK11 on UBI8 (no https)",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
-			"tags": "tomcat,tomcat9,java,jboss,hidden",
+			"tags": "tomcat,tomcat9,java,jboss",
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-web-server/",
-			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.4 Apache Tomcat 9 based application, including a build configuration, application deployment configuration, and secure communication using https.",
+			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.6 Apache Tomcat 9 OpenJ9 JDK11 based application, including a build configuration, and an application deployment configuration.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "1.0"
+			"version": "5.6"
 		}
 	},
-	"message": "A new JWS application for Apache Tomcat 9 has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}. Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
+	"message": "A new JWS application for Apache Tomcat 9 has been created in your project.",
 	"objects": [
 		{
 			"apiVersion": "v1",
@@ -43,31 +43,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
-			"kind": "Service",
-			"metadata": {
-				"annotations": {
-					"description": "The web server's https port."
-				},
-				"labels": {
-					"application": "${APPLICATION_NAME}"
-				},
-				"name": "secure-${APPLICATION_NAME}"
-			},
-			"spec": {
-				"ports": [
-					{
-						"port": 8443,
-						"targetPort": 8443
-					}
-				],
-				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
-				}
-			}
-		},
-		{
-			"apiVersion": "v1",
+			"apiVersion": "route.openshift.io/v1",
 			"id": "${APPLICATION_NAME}-http",
 			"kind": "Route",
 			"metadata": {
@@ -87,30 +63,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
-			"id": "${APPLICATION_NAME}-https",
-			"kind": "Route",
-			"metadata": {
-				"annotations": {
-					"description": "Route for application's https service."
-				},
-				"labels": {
-					"application": "${APPLICATION_NAME}"
-				},
-				"name": "secure-${APPLICATION_NAME}"
-			},
-			"spec": {
-				"host": "${HOSTNAME_HTTPS}",
-				"tls": {
-					"termination": "passthrough"
-				},
-				"to": {
-					"name": "secure-${APPLICATION_NAME}"
-				}
-			}
-		},
-		{
-			"apiVersion": "v1",
+			"apiVersion": "image.openshift.io/v1",
 			"kind": "ImageStream",
 			"metadata": {
 				"labels": {
@@ -120,7 +73,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "build.openshift.io/v1",
 			"kind": "BuildConfig",
 			"metadata": {
 				"labels": {
@@ -158,7 +111,7 @@
 						"forcePull": true,
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "jboss-webserver54-openjdk11-tomcat9-openshift-ubi8:1.0",
+							"name": "jboss-webserver56-openj9-tomcat9-openshift-ubi8:5.6.0",
 							"namespace": "${IMAGE_STREAM_NAMESPACE}"
 						}
 					},
@@ -188,7 +141,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "apps.openshift.io/v1",
 			"kind": "DeploymentConfig",
 			"metadata": {
 				"labels": {
@@ -215,32 +168,6 @@
 					"spec": {
 						"containers": [
 							{
-								"env": [
-									{
-										"name": "JWS_HTTPS_CERTIFICATE_DIR",
-										"value": "/etc/jws-secret-volume"
-									},
-									{
-										"name": "JWS_HTTPS_CERTIFICATE",
-										"value": "${JWS_HTTPS_CERTIFICATE}"
-									},
-									{
-										"name": "JWS_HTTPS_CERTIFICATE_KEY",
-										"value": "${JWS_HTTPS_CERTIFICATE_KEY}"
-									},
-									{
-										"name": "JWS_HTTPS_CERTIFICATE_PASSWORD",
-										"value": "${JWS_HTTPS_CERTIFICATE_PASSWORD}"
-									},
-									{
-										"name": "JWS_ADMIN_USERNAME",
-										"value": "${JWS_ADMIN_USERNAME}"
-									},
-									{
-										"name": "JWS_ADMIN_PASSWORD",
-										"value": "${JWS_ADMIN_PASSWORD}"
-									}
-								],
 								"image": "${APPLICATION_NAME}",
 								"imagePullPolicy": "Always",
 								"name": "${APPLICATION_NAME}",
@@ -254,11 +181,6 @@
 										"containerPort": 8080,
 										"name": "http",
 										"protocol": "TCP"
-									},
-									{
-										"containerPort": 8443,
-										"name": "https",
-										"protocol": "TCP"
 									}
 								],
 								"readinessProbe": {
@@ -269,25 +191,10 @@
 											"curl --noproxy '*' -is 'http://localhost:8080/health' | grep -iq '\"status\": \"UP\"'"
 										]
 									}
-								},
-								"volumeMounts": [
-									{
-										"mountPath": "/etc/jws-secret-volume",
-										"name": "jws-certificate-volume",
-										"readOnly": true
-									}
-								]
-							}
-						],
-						"terminationGracePeriodSeconds": 60,
-						"volumes": [
-							{
-								"name": "jws-certificate-volume",
-								"secret": {
-									"secretName": "${JWS_HTTPS_SECRET}"
 								}
 							}
-						]
+						],
+						"terminationGracePeriodSeconds": 60
 					}
 				},
 				"triggers": [
@@ -325,11 +232,6 @@
 			"description": "Custom hostname for http service route.  Leave blank for default hostname, e.g.: \u003capplication-name\u003e-\u003cproject\u003e.\u003cdefault-domain-suffix\u003e"
 		},
 		{
-			"name": "HOSTNAME_HTTPS",
-			"displayName": "Custom https Route Hostname",
-			"description": "Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-\u003capplication-name\u003e-\u003cproject\u003e.\u003cdefault-domain-suffix\u003e"
-		},
-		{
 			"name": "SOURCE_REPOSITORY_URL",
 			"displayName": "Git Repository URL",
 			"description": "Git source URI for application",
@@ -347,46 +249,6 @@
 			"displayName": "Context Directory",
 			"description": "Path within Git project to build; empty for root project directory.",
 			"value": "tomcat-websocket-chat"
-		},
-		{
-			"name": "JWS_HTTPS_SECRET",
-			"displayName": "Secret Name",
-			"description": "The name of the secret containing the certificate files",
-			"value": "jws-app-secret",
-			"required": true
-		},
-		{
-			"name": "JWS_HTTPS_CERTIFICATE",
-			"displayName": "Certificate Name",
-			"description": "The name of the certificate file within the secret",
-			"value": "server.crt"
-		},
-		{
-			"name": "JWS_HTTPS_CERTIFICATE_KEY",
-			"displayName": "Certificate Key Name",
-			"description": "The name of the certificate key file within the secret",
-			"value": "server.key"
-		},
-		{
-			"name": "JWS_HTTPS_CERTIFICATE_PASSWORD",
-			"displayName": "Certificate Password",
-			"description": "The certificate password"
-		},
-		{
-			"name": "JWS_ADMIN_USERNAME",
-			"displayName": "JWS Admin Username",
-			"description": "JWS Admin User",
-			"generate": "expression",
-			"from": "[a-zA-Z0-9]{8}",
-			"required": true
-		},
-		{
-			"name": "JWS_ADMIN_PASSWORD",
-			"displayName": "JWS Admin Password",
-			"description": "JWS Admin Password",
-			"generate": "expression",
-			"from": "[a-zA-Z0-9]{8}",
-			"required": true
 		},
 		{
 			"name": "GITHUB_WEBHOOK_SECRET",
@@ -422,7 +284,7 @@
 		}
 	],
 	"labels": {
-		"jws54jdk11ubi8": "1.0",
-		"template": "jws54-openjdk11-tomcat9-ubi8-https-s2i"
+		"jws56openj9ubi8": "5.6.0",
+		"template": "jws56-openj9-tomcat9-ubi8-basic-s2i"
 	}
 }

--- a/official/webserver/templates/jws56-openj9-tomcat9-ubi8-https-s2i.json
+++ b/official/webserver/templates/jws56-openj9-tomcat9-ubi8-https-s2i.json
@@ -1,22 +1,22 @@
 {
 	"kind": "Template",
-	"apiVersion": "v1",
+	"apiVersion": "template.openshift.io/v1",
 	"metadata": {
-		"name": "jws54-openj9-tomcat9-ubi8-https-s2i",
+		"name": "jws56-openj9-tomcat9-ubi8-https-s2i",
 		"creationTimestamp": null,
 		"annotations": {
 			"description": "An example JBoss Web Server application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
 			"iconClass": "icon-rh-tomcat",
-			"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJ9 JDK11 on UBI8 (with https)",
+			"openshift.io/display-name": "JBoss Web Server 5.6 Apache Tomcat 9 OpenJ9 JDK11 on UBI8 (with https)",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
 			"tags": "tomcat,tomcat9,java,jboss,hidden",
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-web-server/",
-			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.4 Apache Tomcat 9 OpenJ9 JDK11 based application, including a build configuration, application deployment configuration, and secure communication using https.",
+			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.6 Apache Tomcat 9 OpenJ9 JDK11 based application, including a build configuration, application deployment configuration, and secure communication using https.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "1.0"
+			"version": "5.6"
 		}
 	},
-	"message": "A new JWS application for Apache Tomcat 9 has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}. Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
+	"message": "A new JWS application for Apache Tomcat 9 has been created in your project. Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
 	"objects": [
 		{
 			"apiVersion": "v1",
@@ -67,7 +67,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "route.openshift.io/v1",
 			"id": "${APPLICATION_NAME}-http",
 			"kind": "Route",
 			"metadata": {
@@ -87,7 +87,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "route.openshift.io/v1",
 			"id": "${APPLICATION_NAME}-https",
 			"kind": "Route",
 			"metadata": {
@@ -110,7 +110,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "image.openshift.io/v1",
 			"kind": "ImageStream",
 			"metadata": {
 				"labels": {
@@ -120,7 +120,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "build.openshift.io/v1",
 			"kind": "BuildConfig",
 			"metadata": {
 				"labels": {
@@ -158,7 +158,7 @@
 						"forcePull": true,
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "jboss-webserver54-openj9-tomcat9-openshift-ubi8:1.0",
+							"name": "jboss-webserver56-openj9-tomcat9-openshift-ubi8:5.6.0",
 							"namespace": "${IMAGE_STREAM_NAMESPACE}"
 						}
 					},
@@ -188,7 +188,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "apps.openshift.io/v1",
 			"kind": "DeploymentConfig",
 			"metadata": {
 				"labels": {
@@ -231,14 +231,6 @@
 									{
 										"name": "JWS_HTTPS_CERTIFICATE_PASSWORD",
 										"value": "${JWS_HTTPS_CERTIFICATE_PASSWORD}"
-									},
-									{
-										"name": "JWS_ADMIN_USERNAME",
-										"value": "${JWS_ADMIN_USERNAME}"
-									},
-									{
-										"name": "JWS_ADMIN_PASSWORD",
-										"value": "${JWS_ADMIN_PASSWORD}"
 									}
 								],
 								"image": "${APPLICATION_NAME}",
@@ -373,22 +365,6 @@
 			"description": "The certificate password"
 		},
 		{
-			"name": "JWS_ADMIN_USERNAME",
-			"displayName": "JWS Admin Username",
-			"description": "JWS Admin User",
-			"generate": "expression",
-			"from": "[a-zA-Z0-9]{8}",
-			"required": true
-		},
-		{
-			"name": "JWS_ADMIN_PASSWORD",
-			"displayName": "JWS Admin Password",
-			"description": "JWS Admin Password",
-			"generate": "expression",
-			"from": "[a-zA-Z0-9]{8}",
-			"required": true
-		},
-		{
 			"name": "GITHUB_WEBHOOK_SECRET",
 			"displayName": "Github Webhook Secret",
 			"description": "GitHub trigger secret",
@@ -422,7 +398,7 @@
 		}
 	],
 	"labels": {
-		"jws54openj9ubi8": "1.0",
-		"template": "jws54-openj9-tomcat9-ubi8-https-s2i"
+		"jws56openj9ubi8": "5.6.0",
+		"template": "jws56-openj9-tomcat9-ubi8-https-s2i"
 	}
 }

--- a/official/webserver/templates/jws56-openjdk11-tomcat9-ubi8-basic-s2i.json
+++ b/official/webserver/templates/jws56-openjdk11-tomcat9-ubi8-basic-s2i.json
@@ -1,22 +1,22 @@
 {
 	"kind": "Template",
-	"apiVersion": "v1",
+	"apiVersion": "template.openshift.io/v1",
 	"metadata": {
-		"name": "jws54-openj9-tomcat9-ubi8-basic-s2i",
+		"name": "jws56-openjdk11-tomcat9-ubi8-basic-s2i",
 		"creationTimestamp": null,
 		"annotations": {
 			"description": "An example JBoss Web Server application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
 			"iconClass": "icon-rh-tomcat",
-			"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJ9 JDK11 on UBI8 (no https)",
+			"openshift.io/display-name": "JBoss Web Server 5.6 Apache Tomcat 9 OpenJDK11 on UBI8 (no https)",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
 			"tags": "tomcat,tomcat9,java,jboss",
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-web-server/",
-			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.4 Apache Tomcat 9 OpenJ9 JDK11 based application, including a build configuration, and an application deployment configuration.",
+			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.6 Apache Tomcat 9 based application, including a build configuration, and an application deployment configuration.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "1.0"
+			"version": "5.6"
 		}
 	},
-	"message": "A new JWS application for Apache Tomcat 9 has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}.",
+	"message": "A new JWS application for Apache Tomcat 9 has been created in your project.",
 	"objects": [
 		{
 			"apiVersion": "v1",
@@ -43,7 +43,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "route.openshift.io/v1",
 			"id": "${APPLICATION_NAME}-http",
 			"kind": "Route",
 			"metadata": {
@@ -63,7 +63,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "image.openshift.io/v1",
 			"kind": "ImageStream",
 			"metadata": {
 				"labels": {
@@ -73,7 +73,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "build.openshift.io/v1",
 			"kind": "BuildConfig",
 			"metadata": {
 				"labels": {
@@ -111,7 +111,7 @@
 						"forcePull": true,
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "jboss-webserver54-openj9-tomcat9-openshift-ubi8:1.0",
+							"name": "jboss-webserver56-openjdk11-tomcat9-openshift-ubi8:5.6.0",
 							"namespace": "${IMAGE_STREAM_NAMESPACE}"
 						}
 					},
@@ -141,7 +141,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "apps.openshift.io/v1",
 			"kind": "DeploymentConfig",
 			"metadata": {
 				"labels": {
@@ -168,16 +168,6 @@
 					"spec": {
 						"containers": [
 							{
-								"env": [
-									{
-										"name": "JWS_ADMIN_USERNAME",
-										"value": "${JWS_ADMIN_USERNAME}"
-									},
-									{
-										"name": "JWS_ADMIN_PASSWORD",
-										"value": "${JWS_ADMIN_PASSWORD}"
-									}
-								],
 								"image": "${APPLICATION_NAME}",
 								"imagePullPolicy": "Always",
 								"name": "${APPLICATION_NAME}",
@@ -261,22 +251,6 @@
 			"value": "tomcat-websocket-chat"
 		},
 		{
-			"name": "JWS_ADMIN_USERNAME",
-			"displayName": "JWS Admin Username",
-			"description": "JWS Admin User",
-			"generate": "expression",
-			"from": "[a-zA-Z0-9]{8}",
-			"required": true
-		},
-		{
-			"name": "JWS_ADMIN_PASSWORD",
-			"displayName": "JWS Admin Password",
-			"description": "JWS Admin Password",
-			"generate": "expression",
-			"from": "[a-zA-Z0-9]{8}",
-			"required": true
-		},
-		{
 			"name": "GITHUB_WEBHOOK_SECRET",
 			"displayName": "Github Webhook Secret",
 			"description": "GitHub trigger secret",
@@ -310,7 +284,7 @@
 		}
 	],
 	"labels": {
-		"jws54openj9ubi8": "1.0",
-		"template": "jws54-openj9-tomcat9-ubi8-basic-s2i"
+		"jws56jdk11ubi8": "5.6.0",
+		"template": "jws56-openjdk11-tomcat9-ubi8-basic-s2i"
 	}
 }

--- a/official/webserver/templates/jws56-openjdk11-tomcat9-ubi8-https-s2i.json
+++ b/official/webserver/templates/jws56-openjdk11-tomcat9-ubi8-https-s2i.json
@@ -1,22 +1,22 @@
 {
 	"kind": "Template",
-	"apiVersion": "v1",
+	"apiVersion": "template.openshift.io/v1",
 	"metadata": {
-		"name": "jws54-openjdk8-tomcat9-ubi8-basic-s2i",
+		"name": "jws56-openjdk11-tomcat9-ubi8-https-s2i",
 		"creationTimestamp": null,
 		"annotations": {
 			"description": "An example JBoss Web Server application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
 			"iconClass": "icon-rh-tomcat",
-			"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK8 on UBI8 (no https)",
+			"openshift.io/display-name": "JBoss Web Server 5.6 Apache Tomcat 9 OpenJDK11 on UBI8 (with https)",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
-			"tags": "tomcat,tomcat9,java,jboss",
+			"tags": "tomcat,tomcat9,java,jboss,hidden",
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-web-server/",
-			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.4 Apache Tomcat 9 based application, including a build configuration, and an application deployment configuration.",
+			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.6 Apache Tomcat 9 based application, including a build configuration, application deployment configuration, and secure communication using https.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "1.0"
+			"version": "5.6"
 		}
 	},
-	"message": "A new JWS application for Apache Tomcat 9 has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}.",
+	"message": "A new JWS application for Apache Tomcat 9 has been created in your project. Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
 	"objects": [
 		{
 			"apiVersion": "v1",
@@ -44,6 +44,30 @@
 		},
 		{
 			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"description": "The web server's https port."
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "secure-${APPLICATION_NAME}"
+			},
+			"spec": {
+				"ports": [
+					{
+						"port": 8443,
+						"targetPort": 8443
+					}
+				],
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "route.openshift.io/v1",
 			"id": "${APPLICATION_NAME}-http",
 			"kind": "Route",
 			"metadata": {
@@ -63,7 +87,30 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "route.openshift.io/v1",
+			"id": "${APPLICATION_NAME}-https",
+			"kind": "Route",
+			"metadata": {
+				"annotations": {
+					"description": "Route for application's https service."
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "secure-${APPLICATION_NAME}"
+			},
+			"spec": {
+				"host": "${HOSTNAME_HTTPS}",
+				"tls": {
+					"termination": "passthrough"
+				},
+				"to": {
+					"name": "secure-${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "image.openshift.io/v1",
 			"kind": "ImageStream",
 			"metadata": {
 				"labels": {
@@ -73,7 +120,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "build.openshift.io/v1",
 			"kind": "BuildConfig",
 			"metadata": {
 				"labels": {
@@ -111,7 +158,7 @@
 						"forcePull": true,
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "jboss-webserver54-openjdk8-tomcat9-openshift-ubi8:1.0",
+							"name": "jboss-webserver56-openjdk11-tomcat9-openshift-ubi8:5.6.0",
 							"namespace": "${IMAGE_STREAM_NAMESPACE}"
 						}
 					},
@@ -141,7 +188,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "apps.openshift.io/v1",
 			"kind": "DeploymentConfig",
 			"metadata": {
 				"labels": {
@@ -170,12 +217,20 @@
 							{
 								"env": [
 									{
-										"name": "JWS_ADMIN_USERNAME",
-										"value": "${JWS_ADMIN_USERNAME}"
+										"name": "JWS_HTTPS_CERTIFICATE_DIR",
+										"value": "/etc/jws-secret-volume"
 									},
 									{
-										"name": "JWS_ADMIN_PASSWORD",
-										"value": "${JWS_ADMIN_PASSWORD}"
+										"name": "JWS_HTTPS_CERTIFICATE",
+										"value": "${JWS_HTTPS_CERTIFICATE}"
+									},
+									{
+										"name": "JWS_HTTPS_CERTIFICATE_KEY",
+										"value": "${JWS_HTTPS_CERTIFICATE_KEY}"
+									},
+									{
+										"name": "JWS_HTTPS_CERTIFICATE_PASSWORD",
+										"value": "${JWS_HTTPS_CERTIFICATE_PASSWORD}"
 									}
 								],
 								"image": "${APPLICATION_NAME}",
@@ -191,6 +246,11 @@
 										"containerPort": 8080,
 										"name": "http",
 										"protocol": "TCP"
+									},
+									{
+										"containerPort": 8443,
+										"name": "https",
+										"protocol": "TCP"
 									}
 								],
 								"readinessProbe": {
@@ -201,10 +261,25 @@
 											"curl --noproxy '*' -is 'http://localhost:8080/health' | grep -iq '\"status\": \"UP\"'"
 										]
 									}
-								}
+								},
+								"volumeMounts": [
+									{
+										"mountPath": "/etc/jws-secret-volume",
+										"name": "jws-certificate-volume",
+										"readOnly": true
+									}
+								]
 							}
 						],
-						"terminationGracePeriodSeconds": 60
+						"terminationGracePeriodSeconds": 60,
+						"volumes": [
+							{
+								"name": "jws-certificate-volume",
+								"secret": {
+									"secretName": "${JWS_HTTPS_SECRET}"
+								}
+							}
+						]
 					}
 				},
 				"triggers": [
@@ -242,6 +317,11 @@
 			"description": "Custom hostname for http service route.  Leave blank for default hostname, e.g.: \u003capplication-name\u003e-\u003cproject\u003e.\u003cdefault-domain-suffix\u003e"
 		},
 		{
+			"name": "HOSTNAME_HTTPS",
+			"displayName": "Custom https Route Hostname",
+			"description": "Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-\u003capplication-name\u003e-\u003cproject\u003e.\u003cdefault-domain-suffix\u003e"
+		},
+		{
 			"name": "SOURCE_REPOSITORY_URL",
 			"displayName": "Git Repository URL",
 			"description": "Git source URI for application",
@@ -261,20 +341,28 @@
 			"value": "tomcat-websocket-chat"
 		},
 		{
-			"name": "JWS_ADMIN_USERNAME",
-			"displayName": "JWS Admin Username",
-			"description": "JWS Admin User",
-			"generate": "expression",
-			"from": "[a-zA-Z0-9]{8}",
+			"name": "JWS_HTTPS_SECRET",
+			"displayName": "Secret Name",
+			"description": "The name of the secret containing the certificate files",
+			"value": "jws-app-secret",
 			"required": true
 		},
 		{
-			"name": "JWS_ADMIN_PASSWORD",
-			"displayName": "JWS Admin Password",
-			"description": "JWS Admin Password",
-			"generate": "expression",
-			"from": "[a-zA-Z0-9]{8}",
-			"required": true
+			"name": "JWS_HTTPS_CERTIFICATE",
+			"displayName": "Certificate Name",
+			"description": "The name of the certificate file within the secret",
+			"value": "server.crt"
+		},
+		{
+			"name": "JWS_HTTPS_CERTIFICATE_KEY",
+			"displayName": "Certificate Key Name",
+			"description": "The name of the certificate key file within the secret",
+			"value": "server.key"
+		},
+		{
+			"name": "JWS_HTTPS_CERTIFICATE_PASSWORD",
+			"displayName": "Certificate Password",
+			"description": "The certificate password"
 		},
 		{
 			"name": "GITHUB_WEBHOOK_SECRET",
@@ -310,7 +398,7 @@
 		}
 	],
 	"labels": {
-		"jws54jdk8ubi8": "1.0",
-		"template": "jws54-openjdk8-tomcat9-ubi8-basic-s2i"
+		"jws56jdk11ubi8": "5.6.0",
+		"template": "jws56-openjdk11-tomcat9-ubi8-https-s2i"
 	}
 }

--- a/official/webserver/templates/jws56-openjdk8-tomcat9-ubi8-basic-s2i.json
+++ b/official/webserver/templates/jws56-openjdk8-tomcat9-ubi8-basic-s2i.json
@@ -1,22 +1,22 @@
 {
 	"kind": "Template",
-	"apiVersion": "v1",
+	"apiVersion": "template.openshift.io/v1",
 	"metadata": {
-		"name": "jws54-openjdk8-tomcat9-ubi8-https-s2i",
+		"name": "jws56-openjdk8-tomcat9-ubi8-basic-s2i",
 		"creationTimestamp": null,
 		"annotations": {
 			"description": "An example JBoss Web Server application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
 			"iconClass": "icon-rh-tomcat",
-			"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK8 on UBI8 (with https)",
+			"openshift.io/display-name": "JBoss Web Server 5.6 Apache Tomcat 9 OpenJDK8 on UBI8 (no https)",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
-			"tags": "tomcat,tomcat9,java,jboss,hidden",
+			"tags": "tomcat,tomcat9,java,jboss",
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-web-server/",
-			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.4 Apache Tomcat 9 based application, including a build configuration, application deployment configuration, and secure communication using https.",
+			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.5 Apache Tomcat 9 based application, including a build configuration, and an application deployment configuration.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "1.0"
+			"version": "5.6"
 		}
 	},
-	"message": "A new JWS application for Apache Tomcat 9 has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}. Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
+	"message": "A new JWS application for Apache Tomcat 9 has been created in your project.",
 	"objects": [
 		{
 			"apiVersion": "v1",
@@ -43,31 +43,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
-			"kind": "Service",
-			"metadata": {
-				"annotations": {
-					"description": "The web server's https port."
-				},
-				"labels": {
-					"application": "${APPLICATION_NAME}"
-				},
-				"name": "secure-${APPLICATION_NAME}"
-			},
-			"spec": {
-				"ports": [
-					{
-						"port": 8443,
-						"targetPort": 8443
-					}
-				],
-				"selector": {
-					"deploymentConfig": "${APPLICATION_NAME}"
-				}
-			}
-		},
-		{
-			"apiVersion": "v1",
+			"apiVersion": "route.openshift.io/v1",
 			"id": "${APPLICATION_NAME}-http",
 			"kind": "Route",
 			"metadata": {
@@ -87,30 +63,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
-			"id": "${APPLICATION_NAME}-https",
-			"kind": "Route",
-			"metadata": {
-				"annotations": {
-					"description": "Route for application's https service."
-				},
-				"labels": {
-					"application": "${APPLICATION_NAME}"
-				},
-				"name": "secure-${APPLICATION_NAME}"
-			},
-			"spec": {
-				"host": "${HOSTNAME_HTTPS}",
-				"tls": {
-					"termination": "passthrough"
-				},
-				"to": {
-					"name": "secure-${APPLICATION_NAME}"
-				}
-			}
-		},
-		{
-			"apiVersion": "v1",
+			"apiVersion": "image.openshift.io/v1",
 			"kind": "ImageStream",
 			"metadata": {
 				"labels": {
@@ -120,7 +73,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "build.openshift.io/v1",
 			"kind": "BuildConfig",
 			"metadata": {
 				"labels": {
@@ -158,7 +111,7 @@
 						"forcePull": true,
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "jboss-webserver54-openjdk8-tomcat9-openshift-ubi8:1.0",
+							"name": "jboss-webserver56-openjdk8-tomcat9-openshift-ubi8:5.6.0",
 							"namespace": "${IMAGE_STREAM_NAMESPACE}"
 						}
 					},
@@ -188,7 +141,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "apps.openshift.io/v1",
 			"kind": "DeploymentConfig",
 			"metadata": {
 				"labels": {
@@ -215,32 +168,6 @@
 					"spec": {
 						"containers": [
 							{
-								"env": [
-									{
-										"name": "JWS_HTTPS_CERTIFICATE_DIR",
-										"value": "/etc/jws-secret-volume"
-									},
-									{
-										"name": "JWS_HTTPS_CERTIFICATE",
-										"value": "${JWS_HTTPS_CERTIFICATE}"
-									},
-									{
-										"name": "JWS_HTTPS_CERTIFICATE_KEY",
-										"value": "${JWS_HTTPS_CERTIFICATE_KEY}"
-									},
-									{
-										"name": "JWS_HTTPS_CERTIFICATE_PASSWORD",
-										"value": "${JWS_HTTPS_CERTIFICATE_PASSWORD}"
-									},
-									{
-										"name": "JWS_ADMIN_USERNAME",
-										"value": "${JWS_ADMIN_USERNAME}"
-									},
-									{
-										"name": "JWS_ADMIN_PASSWORD",
-										"value": "${JWS_ADMIN_PASSWORD}"
-									}
-								],
 								"image": "${APPLICATION_NAME}",
 								"imagePullPolicy": "Always",
 								"name": "${APPLICATION_NAME}",
@@ -254,11 +181,6 @@
 										"containerPort": 8080,
 										"name": "http",
 										"protocol": "TCP"
-									},
-									{
-										"containerPort": 8443,
-										"name": "https",
-										"protocol": "TCP"
 									}
 								],
 								"readinessProbe": {
@@ -269,25 +191,10 @@
 											"curl --noproxy '*' -is 'http://localhost:8080/health' | grep -iq '\"status\": \"UP\"'"
 										]
 									}
-								},
-								"volumeMounts": [
-									{
-										"mountPath": "/etc/jws-secret-volume",
-										"name": "jws-certificate-volume",
-										"readOnly": true
-									}
-								]
-							}
-						],
-						"terminationGracePeriodSeconds": 60,
-						"volumes": [
-							{
-								"name": "jws-certificate-volume",
-								"secret": {
-									"secretName": "${JWS_HTTPS_SECRET}"
 								}
 							}
-						]
+						],
+						"terminationGracePeriodSeconds": 60
 					}
 				},
 				"triggers": [
@@ -325,11 +232,6 @@
 			"description": "Custom hostname for http service route.  Leave blank for default hostname, e.g.: \u003capplication-name\u003e-\u003cproject\u003e.\u003cdefault-domain-suffix\u003e"
 		},
 		{
-			"name": "HOSTNAME_HTTPS",
-			"displayName": "Custom https Route Hostname",
-			"description": "Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-\u003capplication-name\u003e-\u003cproject\u003e.\u003cdefault-domain-suffix\u003e"
-		},
-		{
 			"name": "SOURCE_REPOSITORY_URL",
 			"displayName": "Git Repository URL",
 			"description": "Git source URI for application",
@@ -347,46 +249,6 @@
 			"displayName": "Context Directory",
 			"description": "Path within Git project to build; empty for root project directory.",
 			"value": "tomcat-websocket-chat"
-		},
-		{
-			"name": "JWS_HTTPS_SECRET",
-			"displayName": "Secret Name",
-			"description": "The name of the secret containing the certificate files",
-			"value": "jws-app-secret",
-			"required": true
-		},
-		{
-			"name": "JWS_HTTPS_CERTIFICATE",
-			"displayName": "Certificate Name",
-			"description": "The name of the certificate file within the secret",
-			"value": "server.crt"
-		},
-		{
-			"name": "JWS_HTTPS_CERTIFICATE_KEY",
-			"displayName": "Certificate Key Name",
-			"description": "The name of the certificate key file within the secret",
-			"value": "server.key"
-		},
-		{
-			"name": "JWS_HTTPS_CERTIFICATE_PASSWORD",
-			"displayName": "Certificate Password",
-			"description": "The certificate password"
-		},
-		{
-			"name": "JWS_ADMIN_USERNAME",
-			"displayName": "JWS Admin Username",
-			"description": "JWS Admin User",
-			"generate": "expression",
-			"from": "[a-zA-Z0-9]{8}",
-			"required": true
-		},
-		{
-			"name": "JWS_ADMIN_PASSWORD",
-			"displayName": "JWS Admin Password",
-			"description": "JWS Admin Password",
-			"generate": "expression",
-			"from": "[a-zA-Z0-9]{8}",
-			"required": true
 		},
 		{
 			"name": "GITHUB_WEBHOOK_SECRET",
@@ -422,7 +284,7 @@
 		}
 	],
 	"labels": {
-		"jws54jdk8ubi8": "1.0",
-		"template": "jws54-openjdk8-tomcat9-ubi8-https-s2i"
+		"jws56jdk8ubi8": "5.6.0",
+		"template": "jws56-openjdk8-tomcat9-ubi8-basic-s2i"
 	}
 }

--- a/official/webserver/templates/jws56-openjdk8-tomcat9-ubi8-https-s2i.json
+++ b/official/webserver/templates/jws56-openjdk8-tomcat9-ubi8-https-s2i.json
@@ -1,22 +1,22 @@
 {
 	"kind": "Template",
-	"apiVersion": "v1",
+	"apiVersion": "template.openshift.io/v1",
 	"metadata": {
-		"name": "jws54-openjdk11-tomcat9-ubi8-basic-s2i",
+		"name": "jws56-openjdk8-tomcat9-ubi8-https-s2i",
 		"creationTimestamp": null,
 		"annotations": {
 			"description": "An example JBoss Web Server application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
 			"iconClass": "icon-rh-tomcat",
-			"openshift.io/display-name": "JBoss Web Server 5.4 Apache Tomcat 9 OpenJDK11 on UBI8 (no https)",
+			"openshift.io/display-name": "JBoss Web Server 5.6 Apache Tomcat 9 OpenJDK8 on UBI8 (with https)",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
-			"tags": "tomcat,tomcat9,java,jboss",
+			"tags": "tomcat,tomcat9,java,jboss,hidden",
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-web-server/",
-			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.4 Apache Tomcat 9 based application, including a build configuration, and an application deployment configuration.",
+			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Web Server 5.6 Apache Tomcat 9 based application, including a build configuration, application deployment configuration, and secure communication using https.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "1.0"
+			"version": "5.6"
 		}
 	},
-	"message": "A new JWS application for Apache Tomcat 9 has been created in your project. The username/password for administering your JWS is ${JWS_ADMIN_USERNAME}/${JWS_ADMIN_PASSWORD}.",
+	"message": "A new JWS application for Apache Tomcat 9 has been created in your project. Please be sure to create the secret named \"${JWS_HTTPS_SECRET}\" containing the ${JWS_HTTPS_CERTIFICATE} file used for serving secure content.",
 	"objects": [
 		{
 			"apiVersion": "v1",
@@ -44,6 +44,30 @@
 		},
 		{
 			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"description": "The web server's https port."
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "secure-${APPLICATION_NAME}"
+			},
+			"spec": {
+				"ports": [
+					{
+						"port": 8443,
+						"targetPort": 8443
+					}
+				],
+				"selector": {
+					"deploymentConfig": "${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "route.openshift.io/v1",
 			"id": "${APPLICATION_NAME}-http",
 			"kind": "Route",
 			"metadata": {
@@ -63,7 +87,30 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "route.openshift.io/v1",
+			"id": "${APPLICATION_NAME}-https",
+			"kind": "Route",
+			"metadata": {
+				"annotations": {
+					"description": "Route for application's https service."
+				},
+				"labels": {
+					"application": "${APPLICATION_NAME}"
+				},
+				"name": "secure-${APPLICATION_NAME}"
+			},
+			"spec": {
+				"host": "${HOSTNAME_HTTPS}",
+				"tls": {
+					"termination": "passthrough"
+				},
+				"to": {
+					"name": "secure-${APPLICATION_NAME}"
+				}
+			}
+		},
+		{
+			"apiVersion": "image.openshift.io/v1",
 			"kind": "ImageStream",
 			"metadata": {
 				"labels": {
@@ -73,7 +120,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "build.openshift.io/v1",
 			"kind": "BuildConfig",
 			"metadata": {
 				"labels": {
@@ -111,7 +158,7 @@
 						"forcePull": true,
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "jboss-webserver54-openjdk11-tomcat9-openshift-ubi8:1.0",
+							"name": "jboss-webserver56-openjdk8-tomcat9-openshift-ubi8:5.6.0",
 							"namespace": "${IMAGE_STREAM_NAMESPACE}"
 						}
 					},
@@ -141,7 +188,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "apps.openshift.io/v1",
 			"kind": "DeploymentConfig",
 			"metadata": {
 				"labels": {
@@ -170,12 +217,20 @@
 							{
 								"env": [
 									{
-										"name": "JWS_ADMIN_USERNAME",
-										"value": "${JWS_ADMIN_USERNAME}"
+										"name": "JWS_HTTPS_CERTIFICATE_DIR",
+										"value": "/etc/jws-secret-volume"
 									},
 									{
-										"name": "JWS_ADMIN_PASSWORD",
-										"value": "${JWS_ADMIN_PASSWORD}"
+										"name": "JWS_HTTPS_CERTIFICATE",
+										"value": "${JWS_HTTPS_CERTIFICATE}"
+									},
+									{
+										"name": "JWS_HTTPS_CERTIFICATE_KEY",
+										"value": "${JWS_HTTPS_CERTIFICATE_KEY}"
+									},
+									{
+										"name": "JWS_HTTPS_CERTIFICATE_PASSWORD",
+										"value": "${JWS_HTTPS_CERTIFICATE_PASSWORD}"
 									}
 								],
 								"image": "${APPLICATION_NAME}",
@@ -191,6 +246,11 @@
 										"containerPort": 8080,
 										"name": "http",
 										"protocol": "TCP"
+									},
+									{
+										"containerPort": 8443,
+										"name": "https",
+										"protocol": "TCP"
 									}
 								],
 								"readinessProbe": {
@@ -201,10 +261,25 @@
 											"curl --noproxy '*' -is 'http://localhost:8080/health' | grep -iq '\"status\": \"UP\"'"
 										]
 									}
-								}
+								},
+								"volumeMounts": [
+									{
+										"mountPath": "/etc/jws-secret-volume",
+										"name": "jws-certificate-volume",
+										"readOnly": true
+									}
+								]
 							}
 						],
-						"terminationGracePeriodSeconds": 60
+						"terminationGracePeriodSeconds": 60,
+						"volumes": [
+							{
+								"name": "jws-certificate-volume",
+								"secret": {
+									"secretName": "${JWS_HTTPS_SECRET}"
+								}
+							}
+						]
 					}
 				},
 				"triggers": [
@@ -242,6 +317,11 @@
 			"description": "Custom hostname for http service route.  Leave blank for default hostname, e.g.: \u003capplication-name\u003e-\u003cproject\u003e.\u003cdefault-domain-suffix\u003e"
 		},
 		{
+			"name": "HOSTNAME_HTTPS",
+			"displayName": "Custom https Route Hostname",
+			"description": "Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-\u003capplication-name\u003e-\u003cproject\u003e.\u003cdefault-domain-suffix\u003e"
+		},
+		{
 			"name": "SOURCE_REPOSITORY_URL",
 			"displayName": "Git Repository URL",
 			"description": "Git source URI for application",
@@ -261,20 +341,28 @@
 			"value": "tomcat-websocket-chat"
 		},
 		{
-			"name": "JWS_ADMIN_USERNAME",
-			"displayName": "JWS Admin Username",
-			"description": "JWS Admin User",
-			"generate": "expression",
-			"from": "[a-zA-Z0-9]{8}",
+			"name": "JWS_HTTPS_SECRET",
+			"displayName": "Secret Name",
+			"description": "The name of the secret containing the certificate files",
+			"value": "jws-app-secret",
 			"required": true
 		},
 		{
-			"name": "JWS_ADMIN_PASSWORD",
-			"displayName": "JWS Admin Password",
-			"description": "JWS Admin Password",
-			"generate": "expression",
-			"from": "[a-zA-Z0-9]{8}",
-			"required": true
+			"name": "JWS_HTTPS_CERTIFICATE",
+			"displayName": "Certificate Name",
+			"description": "The name of the certificate file within the secret",
+			"value": "server.crt"
+		},
+		{
+			"name": "JWS_HTTPS_CERTIFICATE_KEY",
+			"displayName": "Certificate Key Name",
+			"description": "The name of the certificate key file within the secret",
+			"value": "server.key"
+		},
+		{
+			"name": "JWS_HTTPS_CERTIFICATE_PASSWORD",
+			"displayName": "Certificate Password",
+			"description": "The certificate password"
 		},
 		{
 			"name": "GITHUB_WEBHOOK_SECRET",
@@ -310,7 +398,7 @@
 		}
 	],
 	"labels": {
-		"jws54jdk11ubi8": "1.0",
-		"template": "jws54-openjdk11-tomcat9-ubi8-basic-s2i"
+		"jws56jdk8ubi8": "5.6.0",
+		"template": "jws56-openjdk8-tomcat9-ubi8-https-s2i"
 	}
 }


### PR DESCRIPTION
This PR introduces the JWS 5.6.0 templates and imagestreams for OpenJDK8 and OpenJDK11.

References:

- https://access.redhat.com/errata/RHEA-2021:4862
- https://access.redhat.com/errata/RHEA-2021:4865