### PR TITLE
Use django 3.2.x branch

### DIFF
--- a/official.yaml
+++ b/official.yaml
@@ -1,4 +1,5 @@
 variables:
+  django_version: 3.2.x
   xpaas_version: ose-v1.4.8-1
   openjdk_version: release
   amq_version: ose-v1.4.18
@@ -85,10 +86,10 @@ data:
           - arch_aarch64
   django:
     templates:
-      - location: https://raw.githubusercontent.com/sclorg/django-ex/master/openshift/templates/django.json
-        docs: https://github.com/sclorg/django-ex/blob/master/README.md
-      - location: https://raw.githubusercontent.com/sclorg/django-ex/master/openshift/templates/django-postgresql.json
-        docs: https://github.com/sclorg/django-ex/blob/master/README.md
+      - location: https://raw.githubusercontent.com/sclorg/django-ex/{django_version}/openshift/templates/django.json
+        docs: https://github.com/sclorg/django-ex/blob/{django_version}/README.md
+      - location: https://raw.githubusercontent.com/sclorg/django-ex/{django_version}/openshift/templates/django-postgresql.json
+        docs: https://github.com/sclorg/django-ex/blob/{django_version}/README.md
         tags:
           - okd
           - ocp
@@ -96,8 +97,8 @@ data:
           - arch_ppc64le
           - arch_s390x
           - arch_x86_64
-      - location: https://raw.githubusercontent.com/sclorg/django-ex/master/openshift/templates/django-postgresql-persistent.json
-        docs: https://github.com/sclorg/django-ex/blob/master/README.md
+      - location: https://raw.githubusercontent.com/sclorg/django-ex/{django_version}/openshift/templates/django-postgresql-persistent.json
+        docs: https://github.com/sclorg/django-ex/blob/{django_version}/README.md
         tags:
           - okd
           - ocp

--- a/official/django/templates/django-example.json
+++ b/official/django/templates/django-example.json
@@ -1,6 +1,6 @@
 {
 	"kind": "Template",
-	"apiVersion": "v1",
+	"apiVersion": "template.openshift.io/v1",
 	"metadata": {
 		"name": "django-example",
 		"creationTimestamp": null,
@@ -51,7 +51,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "route.openshift.io/v1",
 			"kind": "Route",
 			"metadata": {
 				"name": "${NAME}"
@@ -65,7 +65,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "image.openshift.io/v1",
 			"kind": "ImageStream",
 			"metadata": {
 				"annotations": {
@@ -75,7 +75,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "build.openshift.io/v1",
 			"kind": "BuildConfig",
 			"metadata": {
 				"annotations": {
@@ -135,7 +135,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "apps.openshift.io/v1",
 			"kind": "DeploymentConfig",
 			"metadata": {
 				"annotations": {
@@ -248,8 +248,8 @@
 		{
 			"name": "PYTHON_VERSION",
 			"displayName": "Version of Python Image",
-			"description": "Version of Python image to be used (3.6-ubi8, 3.8-ubi7, 3.8-ubi8, or latest).",
-			"value": "3.8-ubi8",
+			"description": "Version of Python image to be used (3.6-ubi8, 3.8-ubi8, 3.9-ubi8, or latest).",
+			"value": "3.9-ubi8",
 			"required": true
 		},
 		{

--- a/official/django/templates/django-psql-example.json
+++ b/official/django/templates/django-psql-example.json
@@ -1,6 +1,6 @@
 {
 	"kind": "Template",
-	"apiVersion": "v1",
+	"apiVersion": "template.openshift.io/v1",
 	"metadata": {
 		"name": "django-psql-example",
 		"creationTimestamp": null,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "route.openshift.io/v1",
 			"kind": "Route",
 			"metadata": {
 				"name": "${NAME}"
@@ -68,7 +68,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "image.openshift.io/v1",
 			"kind": "ImageStream",
 			"metadata": {
 				"annotations": {
@@ -78,7 +78,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "build.openshift.io/v1",
 			"kind": "BuildConfig",
 			"metadata": {
 				"annotations": {
@@ -138,7 +138,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "apps.openshift.io/v1",
 			"kind": "DeploymentConfig",
 			"metadata": {
 				"annotations": {
@@ -285,7 +285,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "apps.openshift.io/v1",
 			"kind": "DeploymentConfig",
 			"metadata": {
 				"annotations": {
@@ -423,8 +423,8 @@
 		{
 			"name": "PYTHON_VERSION",
 			"displayName": "Version of Python Image",
-			"description": "Version of Python image to be used (3.6-ubi8, 3.8-ubi7, 3.8-ubi8, or latest).",
-			"value": "3.8-ubi8",
+			"description": "Version of Python image to be used (3.6-ubi8, 3.8-ubi8, 3.9-ubi8, or latest).",
+			"value": "3.9-ubi8",
 			"required": true
 		},
 		{

--- a/official/django/templates/django-psql-persistent.json
+++ b/official/django/templates/django-psql-persistent.json
@@ -1,6 +1,6 @@
 {
 	"kind": "Template",
-	"apiVersion": "v1",
+	"apiVersion": "template.openshift.io/v1",
 	"metadata": {
 		"name": "django-psql-persistent",
 		"creationTimestamp": null,
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "route.openshift.io/v1",
 			"kind": "Route",
 			"metadata": {
 				"name": "${NAME}"
@@ -68,7 +68,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "image.openshift.io/v1",
 			"kind": "ImageStream",
 			"metadata": {
 				"annotations": {
@@ -78,7 +78,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "build.openshift.io/v1",
 			"kind": "BuildConfig",
 			"metadata": {
 				"annotations": {
@@ -138,7 +138,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "apps.openshift.io/v1",
 			"kind": "DeploymentConfig",
 			"metadata": {
 				"annotations": {
@@ -302,7 +302,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "apps.openshift.io/v1",
 			"kind": "DeploymentConfig",
 			"metadata": {
 				"annotations": {
@@ -442,8 +442,8 @@
 		{
 			"name": "PYTHON_VERSION",
 			"displayName": "Version of Python Image",
-			"description": "Version of Python image to be used (3.6-ubi8, 3.8-ubi7, 3.8-ubi8, or latest).",
-			"value": "3.8-ubi8",
+			"description": "Version of Python image to be used (3.6-ubi8, 3.8-ubi8, 3.9-ubi8, or latest).",
+			"value": "3.9-ubi8",
 			"required": true
 		},
 		{


### PR DESCRIPTION
master is for the deprecated 1.11 LTS branch. 3.2 was updated in https://github.com/sclorg/django-ex/pull/190﻿
