### PR TITLE
Remove RHDM/RHPAM templates from OCP

### DIFF
--- a/official.yaml
+++ b/official.yaml
@@ -655,12 +655,9 @@ data:
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-decisionserver-6-openshift-image/{ips_ds_version}/templates/decisionserver64-amq-s2i.json
         docs: https://github.com/jboss-container-images/jboss-decisionserver-6-openshift-image/blob/{ips_ds_version}/templates/docs/decisionserver64-amq-s2i.adoc
         tags:
-          - ocp
           - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-decisionserver-6-openshift-image/{ips_ds_version}/templates/decisionserver64-basic-s2i.json
         docs: https://github.com/jboss-container-images/jboss-decisionserver-6-openshift-image/blob/{ips_ds_version}/templates/docs/decisionserver64-basic-s2i.adoc
-        tags:
-          - ocp
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-decisionserver-6-openshift-image/{ips_ds_version}/templates/decisionserver64-https-s2i.json
         docs: https://github.com/jboss-container-images/jboss-decisionserver-6-openshift-image/blob/{ips_ds_version}/templates/docs/decisionserver64-https-s2i.adoc
     imagestreams:
@@ -669,7 +666,6 @@ data:
         regex: jboss-decisionserver
         suffix: rhel7
         tags:
-          - ocp
           - online-professional
   eap:
     templates:
@@ -805,51 +801,40 @@ data:
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-processserver-6-openshift-image/{ips_ds_version}/templates/processserver64-amq-mysql-persistent-s2i.json
         docs: https://github.com/jboss-container-images/jboss-processserver-6-openshift-image/blob/{ips_ds_version}/templates/docs/processserver64-amq-mysql-persistent-s2i.adoc
         tags:
-          - ocp
           - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-processserver-6-openshift-image/{ips_ds_version}/templates/processserver64-amq-mysql-s2i.json
         docs: https://github.com/jboss-container-images/jboss-processserver-6-openshift-image/blob/{ips_ds_version}/templates/docs/processserver64-amq-mysql-s2i.adoc
         tags:
-          - ocp
           - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-processserver-6-openshift-image/{ips_ds_version}/templates/processserver64-amq-postgresql-persistent-s2i.json
         docs: https://github.com/jboss-container-images/jboss-processserver-6-openshift-image/blob/{ips_ds_version}/templates/docs/processserver64-amq-postgresql-persistent-s2i.adoc
         tags:
-          - ocp
           - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-processserver-6-openshift-image/{ips_ds_version}/templates/processserver64-amq-postgresql-s2i.json
         docs: https://github.com/jboss-container-images/jboss-processserver-6-openshift-image/blob/{ips_ds_version}/templates/docs/processserver64-amq-postgresql-s2i.adoc
         tags:
-          - ocp
           - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-processserver-6-openshift-image/{ips_ds_version}/templates/processserver64-basic-s2i.json
         docs: https://github.com/jboss-container-images/jboss-processserver-6-openshift-image/blob/{ips_ds_version}/templates/docs/processserver64-basic-s2i.adoc
         tags:
-          - ocp
           - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-processserver-6-openshift-image/{ips_ds_version}/templates/processserver64-mysql-persistent-s2i.json
         docs: https://github.com/jboss-container-images/jboss-processserver-6-openshift-image/blob/{ips_ds_version}/templates/docs/processserver64-mysql-persistent-s2i.adoc
         tags:
-          - ocp
           - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-processserver-6-openshift-image/{ips_ds_version}/templates/processserver64-mysql-s2i.json
         docs: https://github.com/jboss-container-images/jboss-processserver-6-openshift-image/blob/{ips_ds_version}/templates/docs/processserver64-mysql-s2i.adoc
         tags:
-          - ocp
           - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-processserver-6-openshift-image/{ips_ds_version}/templates/processserver64-postgresql-persistent-s2i.json
         docs: https://github.com/jboss-container-images/jboss-processserver-6-openshift-image/blob/{ips_ds_version}/templates/docs/processserver64-postgresql-persistent-s2i.adoc
         tags:
-          - ocp
           - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-processserver-6-openshift-image/{ips_ds_version}/templates/processserver64-externaldb-s2i.json
         docs: https://github.com/jboss-container-images/jboss-processserver-6-openshift-image/blob/{ips_ds_version}/templates/docs/processserver64-externaldb-s2i.adoc
-        tags:
-          - ocp
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-processserver-6-openshift-image/{ips_ds_version}/templates/processserver64-postgresql-s2i.json
-        docs:
-          https://github.com/jboss-container-images/jboss-processserver-6-openshift-image/blob/{ips_ds_version}/templates/docs/processserver64-postgresql-s2i.adoc
-          - ocp
+        docs: https://github.com/jboss-container-images/jboss-processserver-6-openshift-image/blob/{ips_ds_version}/templates/docs/processserver64-postgresql-s2i.adoc
+        tags:
           - online-professional
     imagestreams:
       - location: https://raw.githubusercontent.com/jboss-container-images/jboss-processserver-6-openshift-image/{ips_ds_version}/templates/processserver64-image-stream.json
@@ -857,121 +842,98 @@ data:
         regex: jboss-processserver
         suffix: rhel7
         tags:
-          - ocp
           - online-professional
   rhdm:
     templates:
       - location: https://raw.githubusercontent.com/jboss-container-images/rhdm-7-openshift-image/{rhdm_version}/templates/rhdm712-authoring-ha.yaml
         docs: https://github.com/jboss-container-images/rhdm-7-openshift-image/blob/{rhdm_version}/templates/docs/rhdm712-authoring-ha.adoc
         tags:
-          - ocp
           - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/rhdm-7-openshift-image/{rhdm_version}/templates/rhdm712-authoring.yaml
         docs: https://github.com/jboss-container-images/rhdm-7-openshift-image/blob/{rhdm_version}/templates/docs/rhdm712-authoring.adoc
         tags:
-          - ocp
           - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/rhdm-7-openshift-image/{rhdm_version}/templates/rhdm712-kieserver.yaml
         docs: https://github.com/jboss-container-images/rhdm-7-openshift-image/blob/{rhdm_version}/templates/docs/rhdm712-kieserver.adoc
         tags:
-          - ocp
           - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/rhdm-7-openshift-image/{rhdm_version}/templates/rhdm712-prod-immutable-kieserver-amq.yaml
         docs: https://github.com/jboss-container-images/rhdm-7-openshift-image/blob/{rhdm_version}/templates/docs/rhdm712-prod-immutable-kieserver-amq.adoc
         tags:
-          - ocp
           - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/rhdm-7-openshift-image/{rhdm_version}/templates/rhdm712-prod-immutable-kieserver.yaml
         docs: https://github.com/jboss-container-images/rhdm-7-openshift-image/blob/{rhdm_version}/templates/docs/rhdm712-prod-immutable-kieserver.adoc
         tags:
-          - ocp
           - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/rhdm-7-openshift-image/{rhdm_version}/templates/rhdm712-trial-ephemeral.yaml
         docs: https://github.com/jboss-container-images/rhdm-7-openshift-image/blob/{rhdm_version}/templates/docs/rhdm712-trial-ephemeral.adoc
         tags:
-          - ocp
           - online-professional
     imagestreams:
       - location: https://raw.githubusercontent.com/jboss-container-images/rhdm-7-openshift-image/{rhdm_version}/rhdm712-image-streams.yaml
         docs: https://access.redhat.com/documentation/en-us/red_hat_decision_manager/7.12/html/deploying_red_hat_decision_manager_on_red_hat_openshift_container_platform/index
         regex: rhdm-decisioncentral-rhel8
         tags:
-          - ocp
           - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/rhdm-7-openshift-image/{rhdm_version}/rhdm712-image-streams.yaml
         docs: https://access.redhat.com/documentation/en-us/red_hat_decision_manager/7.12/html/deploying_red_hat_decision_manager_on_red_hat_openshift_container_platform/index
         regex: rhdm-kieserver-rhel8
         tags:
-          - ocp
           - online-professional
   rhpam:
     templates:
       - location: https://raw.githubusercontent.com/jboss-container-images/rhpam-7-openshift-image/{rhpam_version}/templates/rhpam712-authoring-ha.yaml
         docs: https://github.com/jboss-container-images/rhpam-7-openshift-image/blob/{rhpam_version}/templates/docs/rhpam712-authoring-ha.adoc
         tags:
-          - ocp
           - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/rhpam-7-openshift-image/{rhpam_version}/templates/rhpam712-authoring.yaml
         docs: https://github.com/jboss-container-images/rhpam-7-openshift-image/blob/{rhpam_version}/templates/docs/rhpam712-authoring.adoc
         tags:
-          - ocp
           - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/rhpam-7-openshift-image/{rhpam_version}/templates/rhpam712-kieserver-externaldb.yaml
         docs: https://github.com/jboss-container-images/rhpam-7-openshift-image/blob/{rhpam_version}/templates/docs/rhpam712-kieserver-externaldb.adoc
-        tags:
-          - ocp
       - location: https://raw.githubusercontent.com/jboss-container-images/rhpam-7-openshift-image/{rhpam_version}/templates/rhpam712-kieserver-mysql.yaml
         docs: https://github.com/jboss-container-images/rhpam-7-openshift-image/blob/{rhpam_version}/templates/docs/rhpam712-kieserver-mysql.adoc
         tags:
-          - ocp
           - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/rhpam-7-openshift-image/{rhpam_version}/templates/rhpam712-kieserver-postgresql.yaml
         docs: https://github.com/jboss-container-images/rhpam-7-openshift-image/blob/{rhpam_version}/templates/docs/rhpam712-kieserver-postgresql.adoc
         tags:
-          - ocp
           - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/rhpam-7-openshift-image/{rhpam_version}/templates/rhpam712-managed.yaml
         docs: https://github.com/jboss-container-images/rhpam-7-openshift-image/blob/{rhpam_version}/templates/docs/rhpam712-managed.adoc
         tags:
-          - ocp
           - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/rhpam-7-openshift-image/{rhpam_version}/templates/rhpam712-prod-immutable-kieserver-amq.yaml
         docs: https://github.com/jboss-container-images/rhpam-7-openshift-image/blob/{rhpam_version}/templates/docs/rhpam712-prod-immutable-kieserver-amq.adoc
         tags:
-          - ocp
           - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/rhpam-7-openshift-image/{rhpam_version}/templates/rhpam712-prod-immutable-kieserver.yaml
         docs: https://github.com/jboss-container-images/rhpam-7-openshift-image/blob/{rhpam_version}/templates/docs/rhpam712-prod-immutable-kieserver.adoc
         tags:
-          - ocp
           - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/rhpam-7-openshift-image/{rhpam_version}/templates/rhpam712-prod-immutable-monitor.yaml
         docs: https://github.com/jboss-container-images/rhpam-7-openshift-image/blob/{rhpam_version}/templates/docs/rhpam712-prod-immutable-monitor.adoc
         tags:
-          - ocp
           - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/rhpam-7-openshift-image/{rhpam_version}/templates/rhpam712-prod.yaml
         docs: https://github.com/jboss-container-images/rhpam-7-openshift-image/blob/{rhpam_version}/templates/docs/rhpam712-prod.adoc
         tags:
-          - ocp
           - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/rhpam-7-openshift-image/{rhpam_version}/templates/rhpam712-trial-ephemeral.yaml
         docs: https://github.com/jboss-container-images/rhpam-7-openshift-image/blob/{rhpam_version}/templates/docs/rhpam712-trial-ephemeral.adoc
         tags:
-          - ocp
           - online-professional
     imagestreams:
       - location: https://raw.githubusercontent.com/jboss-container-images/rhpam-7-openshift-image/{rhpam_version}/rhpam712-image-streams.yaml
         docs: https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.12/html/deploying_red_hat_process_automation_manager_on_red_hat_openshift_container_platform/index
         regex: rhpam-businesscentral-rhel8|rhpam-businesscentral-monitoring-rhel8|rhpam-smartrouter-rhel8
         tags:
-          - ocp
           - online-professional
       - location: https://raw.githubusercontent.com/jboss-container-images/rhpam-7-openshift-image/{rhpam_version}/rhpam712-image-streams.yaml
         docs: https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.12/html/deploying_red_hat_process_automation_manager_on_red_hat_openshift_container_platform/index
         regex: rhpam-kieserver-rhel8
         tags:
-          - ocp
           - online-professional
   sso:
     templates:


### PR DESCRIPTION
The operator is now the only supported installation method on OCP 4.

https://github.com/jboss-container-images/rhdm-7-openshift-image/pull/480#issuecomment-1124824387
https://github.com/jboss-container-images/rhpam-7-openshift-image/pull/623#issuecomment-1124823954
