### PR TITLE
Remove 3scale templates from OCP4

### DIFF
--- a/official.yaml
+++ b/official.yaml
@@ -1270,13 +1270,11 @@ data:
       - location: https://raw.githubusercontent.com/3scale/3scale-amp-openshift-templates/{rhamp_version}/apicast-gateway/library/apicast.yml
         docs: https://access.redhat.com/documentation/en-us/red_hat_3scale/2.saas/html/deployment_options/apicast-openshift
         tags:
-          - ocp
           - online-professional
     imagestreams:
       - location: https://raw.githubusercontent.com/3scale/3scale-amp-openshift-templates/{rhamp_version}/3scale-image-streams.yml
         docs: https://access.redhat.com/documentation/en-us/red_hat_3scale/2.saas/html/deployment_options/apicast-openshift
         tags:
-          - ocp
           - online-professional
   golang:
     imagestreams:


### PR DESCRIPTION
The 3scale and apicast operators are the only supported installation option on OCP4.

https://github.com/3scale/3scale-amp-openshift-templates/pull/69#issuecomment-1128513554

/cc @eguzki
