### PR TITLE
Remove AMQ 6 samples from OCP 4

### DIFF
--- a/official.yaml
+++ b/official.yaml
@@ -527,20 +527,14 @@ data:
       - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{amq_version}/amq/amq63-basic.json
         docs: https://github.com/jboss-openshift/application-templates/blob/{amq_version}/docs/amq/amq63-basic.adoc
         tags:
-          - ocp
           - online-professional
       - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{amq_version}/amq/amq63-persistent-ssl.json
         docs: https://github.com/jboss-openshift/application-templates/blob/{amq_version}/docs/amq/amq63-persistent-ssl.adoc
-        tags:
-          - ocp
       - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{amq_version}/amq/amq63-persistent.json
         docs: https://github.com/jboss-openshift/application-templates/blob/{amq_version}/docs/amq/amq63-persistent.adoc
-        tags:
-          - ocp
       - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{amq_version}/amq/amq63-ssl.json
         docs: https://github.com/jboss-openshift/application-templates/blob/{amq_version}/docs/amq/amq63-ssl.adoc
         tags:
-          - ocp
           - online-professional
     imagestreams:
       - location: https://raw.githubusercontent.com/jboss-openshift/application-templates/{amq_version}/amq/amq63-image-stream.json
@@ -548,7 +542,6 @@ data:
         regex: jboss-amq
         suffix: rhel7
         tags:
-          - ocp
           - online-professional
   datagrid:
     templates:


### PR DESCRIPTION
AMQ 6 is only supported on OCP 3.11: https://access.redhat.com/articles/310613

This negates the need for https://github.com/jboss-openshift/application-templates/pull/501

/assign @fbm3307
