### PR TITLE
Drop Fuse Apicurito and Console samples from OCP 4

### DIFF
--- a/official.yaml
+++ b/official.yaml
@@ -974,24 +974,21 @@ data:
       - location: https://raw.githubusercontent.com/jboss-fuse/application-templates/GA/fis-console-namespace-template.json
         docs: https://access.redhat.com/documentation/en-us/red_hat_fuse/{fuse_version}/html/managing_fuse/
         tags:
-          - ocp
           - online-professional
       - location: https://raw.githubusercontent.com/jboss-fuse/application-templates/GA/fuse-apicurito.yml
         docs: https://access.redhat.com/documentation/en-us/red_hat_fuse/{fuse_version}/html/designing_apis_with_apicurito/
         tags:
-          - ocp
           - online-professional
     imagestreams:
       - location: https://raw.githubusercontent.com/jboss-fuse/application-templates/GA/fis-image-streams.json
         docs: https://access.redhat.com/documentation/en-us/red_hat_fuse/{fuse_version}/html/fuse_on_openshift_guide/
-        regex: '^(apicurito|fuse)'
+        regex: 'fuse7-(eap|java|karaf)'
         suffix: rhel7
         tags:
           - ocp
-          - online-professional
       - location: https://raw.githubusercontent.com/jboss-fuse/application-templates/GA/fis-image-streams.json
         docs: https://access.redhat.com/documentation/en-us/red_hat_fuse/{fuse_version}/html/fuse_on_openshift_guide/
-        regex: '^fis'
+        regex: '^[^j]'
         suffix: rhel7
         tags:
           - online-professional


### PR DESCRIPTION
Their respective operators are the supported install methods on OCP 4; the imagestreams and templates are only used on OCP 3.  Fuse Online samples remain for OCP 4, as they are still used for building images.

Marking this as draft pending confirmation from the Fuse team.

/cc @cunningt @tadayosi
