### PR TITLE
Update openliberty URLs

### DIFF
--- a/community.yaml
+++ b/community.yaml
@@ -201,8 +201,8 @@ data:
           - okd
   openliberty:
     imagestreams:
-      - location: https://raw.githubusercontent.com/OpenLiberty/open-liberty-s2i/master/imagestreams/openliberty-ubi-min.json
-        docs: https://github.com/OpenLiberty/open-liberty-s2i/blob/master/README.md
+      - location: https://raw.githubusercontent.com/OpenLiberty/open-liberty-s2i/main/imagestreams/openliberty-ubi-min.json
+        docs: https://github.com/OpenLiberty/open-liberty-s2i/blob/main/README.md
         tags:
           - okd
           - online-professional


### PR DESCRIPTION
This will have no current effect on library, but future updates to openliberty's imagestream will not propogate without this.

/assign @fbm3307
