### PR TITLE
Update template location 

### DIFF
--- a/official.yaml
+++ b/official.yaml
@@ -1091,8 +1091,8 @@ data:
           - arch_aarch64
   semeru:
     templates:
-      - location: https://raw.githubusercontent.com/ibm-redhat-mw-PE/openjdk-semeru-transition/main/openjdk-to-semeru-transition.json
-        docs: https://github.com/ibm-redhat-mw-PE/openjdk-semeru-transition/blob/main/README.md
+      - location: https://raw.githubusercontent.com/jboss-container-images/openjdk-semeru-transition/main/openjdk-to-semeru-transition.json
+        docs: https://github.com/jboss-container-images/openjdk-semeru-transition/blob/main/README.md
         tags:
           - ocp
           - arch_s390x


### PR DESCRIPTION
Updating the template location to the official JBoss repository maintained by Red Hat for the latest OpenJDK Semeru transition template. 