### PR TITLE
[RHSSO-2012] Update RH-SSO 7.5.X imagestream & templates definitions to 'v7.5.3.GA' release (tag)

### DIFF
--- a/official.yaml
+++ b/official.yaml
@@ -2,7 +2,7 @@ variables:
   django_version: 3.2.x
   openjdk_version: release
   amq_version: ose-v1.4.18
-  rhsso75_openjdk_version: v7.5.2.GA
+  rhsso75_openjdk_version: v7.5.3.GA
   rhsso76_openjdk_version: v7.6.0.GA
   webserver_version: ose-v1.4.17
   webserver3_version: jws31-v1.4

--- a/official/sso/imagestreams/postgresql13-for-sso75-openshift-rhel8.json
+++ b/official/sso/imagestreams/postgresql13-for-sso75-openshift-rhel8.json
@@ -1,0 +1,41 @@
+{
+	"kind": "ImageStream",
+	"apiVersion": "image.openshift.io/v1",
+	"metadata": {
+		"name": "postgresql13-for-sso75-openshift-rhel8",
+		"creationTimestamp": null,
+		"annotations": {
+			"openshift.io/display-name": "PostgreSQL"
+		}
+	},
+	"spec": {
+		"lookupPolicy": {
+			"local": false
+		},
+		"tags": [
+			{
+				"name": "13-el8",
+				"annotations": {
+					"description": "Provides a PostgreSQL 13 database on RHEL 8. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/postgresql-container/blob/master/README.md.",
+					"iconClass": "icon-postgresql",
+					"openshift.io/display-name": "PostgreSQL 13 (RHEL 8)",
+					"openshift.io/provider-display-name": "Red Hat, Inc.",
+					"tags": "database,postgresql",
+					"version": "13"
+				},
+				"from": {
+					"kind": "DockerImage",
+					"name": "registry.redhat.io/rhel8/postgresql-13:latest"
+				},
+				"generation": null,
+				"importPolicy": {},
+				"referencePolicy": {
+					"type": "Local"
+				}
+			}
+		]
+	},
+	"status": {
+		"dockerImageRepository": ""
+	}
+}

--- a/official/sso/imagestreams/sso75-openshift-rhel8.json
+++ b/official/sso/imagestreams/sso75-openshift-rhel8.json
@@ -8,7 +8,7 @@
 			"description": "Red Hat Single Sign-On 7.5 on OpenJDK",
 			"openshift.io/display-name": "Red Hat Single Sign-On 7.5 on OpenJDK",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
-			"version": "7.5.2.GA"
+			"version": "7.5.3.GA"
 		}
 	},
 	"spec": {

--- a/official/sso/templates/sso75-https.json
+++ b/official/sso/templates/sso75-https.json
@@ -13,7 +13,7 @@
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
 			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.5 on OpenJDK server based deployment, securing RH-SSO communication using passthrough TLS.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "7.5.2.GA"
+			"version": "7.5.3.GA"
 		}
 	},
 	"message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
@@ -539,7 +539,7 @@
 		}
 	],
 	"labels": {
-		"rhsso": "7.5.2.GA",
+		"rhsso": "7.5.3.GA",
 		"template": "sso75-https"
 	}
 }

--- a/official/sso/templates/sso75-ocp4-x509-https.json
+++ b/official/sso/templates/sso75-ocp4-x509-https.json
@@ -13,7 +13,7 @@
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
 			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.5 on OpenJDK server based deployment, securing RH-SSO communication using re-encrypt TLS.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "7.5.2.GA"
+			"version": "7.5.3.GA"
 		}
 	},
 	"message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
@@ -387,7 +387,7 @@
 		}
 	],
 	"labels": {
-		"rhsso": "7.5.2.GA",
+		"rhsso": "7.5.3.GA",
 		"template": "sso75-ocp4-x509-https"
 	}
 }

--- a/official/sso/templates/sso75-ocp4-x509-postgresql-persistent.json
+++ b/official/sso/templates/sso75-ocp4-x509-postgresql-persistent.json
@@ -13,7 +13,7 @@
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
 			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.5 on OpenJDK server based deployment, deployment configuration for PostgreSQL using persistence, and securing RH-SSO communication using re-encrypt TLS.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "7.5.2.GA"
+			"version": "7.5.3.GA"
 		}
 	},
 	"message": "A new persistent RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets.",
@@ -467,7 +467,7 @@
 							],
 							"from": {
 								"kind": "ImageStreamTag",
-								"name": "postgresql:${POSTGRESQL_IMAGE_STREAM_TAG}",
+								"name": "postgresql13-for-sso75-openshift-rhel8:${POSTGRESQL_IMAGE_STREAM_TAG}",
 								"namespace": "${IMAGE_STREAM_NAMESPACE}"
 							}
 						},
@@ -624,7 +624,7 @@
 			"name": "POSTGRESQL_IMAGE_STREAM_TAG",
 			"displayName": "PostgreSQL Image Stream Tag",
 			"description": "The tag to use for the \"postgresql\" image stream.  Typically, this aligns with the major.minor version of PostgreSQL.",
-			"value": "10",
+			"value": "13-el8",
 			"required": true
 		},
 		{
@@ -635,7 +635,7 @@
 		}
 	],
 	"labels": {
-		"rhsso": "7.5.2.GA",
+		"rhsso": "7.5.3.GA",
 		"template": "sso75-ocp4-x509-postgresql-persistent"
 	}
 }

--- a/official/sso/templates/sso75-postgresql-persistent.json
+++ b/official/sso/templates/sso75-postgresql-persistent.json
@@ -13,7 +13,7 @@
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
 			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.5 on OpenJDK server based deployment, deployment configuration for PostgreSQL using persistence, and securing RH-SSO communication using passthrough TLS.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "7.5.2.GA"
+			"version": "7.5.3.GA"
 		}
 	},
 	"message": "A new persistent RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
@@ -545,7 +545,7 @@
 							],
 							"from": {
 								"kind": "ImageStreamTag",
-								"name": "postgresql:${POSTGRESQL_IMAGE_STREAM_TAG}",
+								"name": "postgresql13-for-sso75-openshift-rhel8:${POSTGRESQL_IMAGE_STREAM_TAG}",
 								"namespace": "${IMAGE_STREAM_NAMESPACE}"
 							}
 						},
@@ -777,7 +777,7 @@
 			"name": "POSTGRESQL_IMAGE_STREAM_TAG",
 			"displayName": "PostgreSQL Image Stream Tag",
 			"description": "The tag to use for the \"postgresql\" image stream. Typically, this aligns with the major.minor version of PostgreSQL.",
-			"value": "10",
+			"value": "13-el8",
 			"required": true
 		},
 		{
@@ -788,7 +788,7 @@
 		}
 	],
 	"labels": {
-		"rhsso": "7.5.2.GA",
+		"rhsso": "7.5.3.GA",
 		"template": "sso75-postgresql-persistent"
 	}
 }

--- a/official/sso/templates/sso75-postgresql.json
+++ b/official/sso/templates/sso75-postgresql.json
@@ -13,7 +13,7 @@
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
 			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.5 on OpenJDK server based deployment, deployment configuration for PostgreSQL using ephemeral (temporary) storage, and securing RH-SSO communication using passthrough TLS.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "7.5.2.GA"
+			"version": "7.5.3.GA"
 		}
 	},
 	"message": "A new RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
@@ -550,7 +550,7 @@
 							],
 							"from": {
 								"kind": "ImageStreamTag",
-								"name": "postgresql:${POSTGRESQL_IMAGE_STREAM_TAG}",
+								"name": "postgresql13-for-sso75-openshift-rhel8:${POSTGRESQL_IMAGE_STREAM_TAG}",
 								"namespace": "${IMAGE_STREAM_NAMESPACE}"
 							}
 						},
@@ -755,7 +755,7 @@
 			"name": "POSTGRESQL_IMAGE_STREAM_TAG",
 			"displayName": "PostgreSQL Image Stream Tag",
 			"description": "The tag to use for the \"postgresql\" image stream. Typically, this aligns with the major.minor version of PostgreSQL.",
-			"value": "10",
+			"value": "13-el8",
 			"required": true
 		},
 		{
@@ -766,7 +766,7 @@
 		}
 	],
 	"labels": {
-		"rhsso": "7.5.2.GA",
+		"rhsso": "7.5.3.GA",
 		"template": "sso75-postgresql"
 	}
 }


### PR DESCRIPTION
    [RHSSO-2012] Update RH-SSO 7.5.X imagestream & templates definitions to
    the latest 'v7.5.3.GA' release (tag)
    
    Corresponding erratum is: RHEA-2022:6786
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Direct link to the erratum [RHEA-2022:6786](https://access.redhat.com/errata/RHEA-2022:6786)

@dperaza4dustbit @fbm3307 PTAL once got a chance

Thanks,
Jan
