### PR TITLE
[RHSSO-2296] Update RH-SSO imagestream & template definitions to v7.6.2.GA tag / release

### DIFF
--- a/official.yaml
+++ b/official.yaml
@@ -3,7 +3,7 @@ variables:
   openjdk_version: release
   amq_version: ose-v1.4.18
   rhsso75_tag: v7.5.3.GA
-  rhsso76_tag: v7.6.1.GA
+  rhsso76_tag: v7.6.2.GA
   webserver_version: ose-v1.4.17
   webserver3_version: jws31-v1.4
   webserver5el8_version: jws56el8-v5.6.2

--- a/official/sso/imagestreams/sso76-openshift-rhel8.json
+++ b/official/sso/imagestreams/sso76-openshift-rhel8.json
@@ -8,7 +8,7 @@
 			"description": "Red Hat Single Sign-On 7.6 on OpenJDK",
 			"openshift.io/display-name": "Red Hat Single Sign-On 7.6 on OpenJDK",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
-			"version": "7.6.1.GA"
+			"version": "7.6.2.GA"
 		}
 	},
 	"spec": {

--- a/official/sso/templates/sso76-https.json
+++ b/official/sso/templates/sso76-https.json
@@ -13,7 +13,7 @@
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
 			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.6 on OpenJDK server based deployment, securing RH-SSO communication using passthrough TLS.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "7.6.1.GA"
+			"version": "7.6.2.GA"
 		}
 	},
 	"message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
@@ -333,6 +333,11 @@
 										"mountPath": "/etc/sso-secret-volume",
 										"name": "sso-truststore-volume",
 										"readOnly": true
+									},
+									{
+										"mountPath": "/mnt/rh-sso",
+										"name": "sso-probe-netrc-volume",
+										"readOnly": false
 									}
 								]
 							}
@@ -356,6 +361,12 @@
 								"secret": {
 									"secretName": "${SSO_TRUSTSTORE_SECRET}"
 								}
+							},
+							{
+								"emptyDir": {
+									"medium": "Memory"
+								},
+								"name": "sso-probe-netrc-volume"
 							}
 						]
 					}
@@ -539,7 +550,7 @@
 		}
 	],
 	"labels": {
-		"rhsso": "7.6.1.GA",
+		"rhsso": "7.6.2.GA",
 		"template": "sso76-https"
 	}
 }

--- a/official/sso/templates/sso76-ocp3-x509-https.json
+++ b/official/sso/templates/sso76-ocp3-x509-https.json
@@ -13,7 +13,7 @@
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
 			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.6 on OpenJDK server based deployment, securing RH-SSO communication using re-encrypt TLS. It is intended to be used solely on OpenShift 3.X versions. For OpenShift 4.X variant of this template refer to 'sso76-ocp4-x509-https' one.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "7.6.1.GA"
+			"version": "7.6.2.GA"
 		}
 	},
 	"message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets using the service-serving CA bundle from '/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt'. Refer to: https://github.com/openshift/openshift-docs/blob/enterprise-4.1/release_notes/ocp-4-1-release-notes.adoc#service-ca-bundle-changes for additional details about this CA bundle.",
@@ -237,6 +237,11 @@
 										"mountPath": "/etc/x509/jgroups",
 										"name": "sso-x509-jgroups-volume",
 										"readOnly": true
+									},
+									{
+										"mountPath": "/mnt/rh-sso",
+										"name": "sso-probe-netrc-volume",
+										"readOnly": false
 									}
 								]
 							}
@@ -254,6 +259,12 @@
 								"secret": {
 									"secretName": "sso-x509-jgroups-secret"
 								}
+							},
+							{
+								"emptyDir": {
+									"medium": "Memory"
+								},
+								"name": "sso-probe-netrc-volume"
 							}
 						]
 					}
@@ -362,7 +373,7 @@
 		}
 	],
 	"labels": {
-		"rhsso": "7.6.1.GA",
+		"rhsso": "7.6.2.GA",
 		"template": "sso76-ocp3-x509-https"
 	}
 }

--- a/official/sso/templates/sso76-ocp3-x509-postgresql-persistent.json
+++ b/official/sso/templates/sso76-ocp3-x509-postgresql-persistent.json
@@ -13,7 +13,7 @@
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
 			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.6 on OpenJDK server based deployment, deployment configuration for PostgreSQL using persistence and encrypted database connection, and securing RH-SSO communication using re-encrypt TLS. It is intended to be used solely on OpenShift 3.X versions. For OpenShift 4.X variant of this template refer to 'sso76-ocp4-x509-postgresql-persistent' one.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "7.6.1.GA"
+			"version": "7.6.2.GA"
 		}
 	},
 	"message": "A new persistent RH-SSO service (using SSL/TLS secured PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, the server truststore used for securing RH-SSO requests, and SSL/TLS certificate \u0026 private key used to run PostgreSQL server with SSL/TLS support were automatically created via OpenShift's service serving x509 certificate secrets using the service-serving CA bundle from '/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt'. Refer to: https://github.com/openshift/openshift-docs/blob/enterprise-4.1/release_notes/ocp-4-1-release-notes.adoc#service-ca-bundle-changes for additional details about this CA bundle.",
@@ -368,6 +368,11 @@
 										"mountPath": "/etc/x509/jgroups",
 										"name": "sso-x509-jgroups-volume",
 										"readOnly": true
+									},
+									{
+										"mountPath": "/mnt/rh-sso",
+										"name": "sso-probe-netrc-volume",
+										"readOnly": false
 									}
 								]
 							}
@@ -385,6 +390,12 @@
 								"secret": {
 									"secretName": "sso-x509-jgroups-secret"
 								}
+							},
+							{
+								"emptyDir": {
+									"medium": "Memory"
+								},
+								"name": "sso-probe-netrc-volume"
 							}
 						]
 					}
@@ -720,7 +731,7 @@
 		}
 	],
 	"labels": {
-		"rhsso": "7.6.1.GA",
+		"rhsso": "7.6.2.GA",
 		"template": "sso76-ocp3-x509-postgresql-persistent"
 	}
 }

--- a/official/sso/templates/sso76-ocp4-x509-https.json
+++ b/official/sso/templates/sso76-ocp4-x509-https.json
@@ -13,7 +13,7 @@
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
 			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.6 on OpenJDK server based deployment, securing RH-SSO communication using re-encrypt TLS. It is intended to be used solely on OpenShift 4.X versions. For OpenShift 3.X variant of this template refer to 'sso76-ocp3-x509-https' one.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "7.6.1.GA"
+			"version": "7.6.2.GA"
 		}
 	},
 	"message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets by using a CA bundle that is automatically injected into any configMap annotated with 'service.beta.openshift.io/inject-cabundle=true' annotation. Refer to: https://github.com/openshift/openshift-docs/blob/enterprise-4.1/release_notes/ocp-4-1-release-notes.adoc#service-ca-bundle-changes for additional details about this CA bundle.",
@@ -256,6 +256,11 @@
 										"mountPath": "/var/run/configmaps/service-ca",
 										"name": "service-ca",
 										"readOnly": true
+									},
+									{
+										"mountPath": "/mnt/rh-sso",
+										"name": "sso-probe-netrc-volume",
+										"readOnly": false
 									}
 								]
 							}
@@ -279,6 +284,12 @@
 									"name": "${APPLICATION_NAME}-service-ca"
 								},
 								"name": "service-ca"
+							},
+							{
+								"emptyDir": {
+									"medium": "Memory"
+								},
+								"name": "sso-probe-netrc-volume"
 							}
 						]
 					}
@@ -387,7 +398,7 @@
 		}
 	],
 	"labels": {
-		"rhsso": "7.6.1.GA",
+		"rhsso": "7.6.2.GA",
 		"template": "sso76-ocp4-x509-https"
 	}
 }

--- a/official/sso/templates/sso76-ocp4-x509-postgresql-persistent.json
+++ b/official/sso/templates/sso76-ocp4-x509-postgresql-persistent.json
@@ -13,7 +13,7 @@
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
 			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.6 on OpenJDK server based deployment, deployment configuration for PostgreSQL using persistence, and securing RH-SSO communication using re-encrypt TLS. It is intended to be used solely on OpenShift 4.X versions. For OpenShift 3.X variant of this template refer to 'sso76-ocp3-x509-postgresql-persistent' one.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "7.6.1.GA"
+			"version": "7.6.2.GA"
 		}
 	},
 	"message": "A new persistent RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets by using a CA bundle that is automatically injected into any configMap annotated with 'service.beta.openshift.io/inject-cabundle=true' annotation. Refer to: https://github.com/openshift/openshift-docs/blob/enterprise-4.1/release_notes/ocp-4-1-release-notes.adoc#service-ca-bundle-changes for additional details about this CA bundle.",
@@ -305,6 +305,11 @@
 										"mountPath": "/var/run/configmaps/service-ca",
 										"name": "service-ca",
 										"readOnly": true
+									},
+									{
+										"mountPath": "/mnt/rh-sso",
+										"name": "sso-probe-netrc-volume",
+										"readOnly": false
 									}
 								]
 							}
@@ -328,6 +333,12 @@
 									"name": "${APPLICATION_NAME}-service-ca"
 								},
 								"name": "service-ca"
+							},
+							{
+								"emptyDir": {
+									"medium": "Memory"
+								},
+								"name": "sso-probe-netrc-volume"
 							}
 						]
 					}
@@ -635,7 +646,7 @@
 		}
 	],
 	"labels": {
-		"rhsso": "7.6.1.GA",
+		"rhsso": "7.6.2.GA",
 		"template": "sso76-ocp4-x509-postgresql-persistent"
 	}
 }

--- a/official/sso/templates/sso76-postgresql-persistent.json
+++ b/official/sso/templates/sso76-postgresql-persistent.json
@@ -13,7 +13,7 @@
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
 			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.6 on OpenJDK server based deployment, deployment configuration for PostgreSQL using persistence, and securing RH-SSO communication using passthrough TLS.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "7.6.1.GA"
+			"version": "7.6.2.GA"
 		}
 	},
 	"message": "A new persistent RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
@@ -383,6 +383,11 @@
 										"mountPath": "/etc/sso-secret-volume",
 										"name": "sso-truststore-volume",
 										"readOnly": true
+									},
+									{
+										"mountPath": "/mnt/rh-sso",
+										"name": "sso-probe-netrc-volume",
+										"readOnly": false
 									}
 								]
 							}
@@ -406,6 +411,12 @@
 								"secret": {
 									"secretName": "${SSO_TRUSTSTORE_SECRET}"
 								}
+							},
+							{
+								"emptyDir": {
+									"medium": "Memory"
+								},
+								"name": "sso-probe-netrc-volume"
 							}
 						]
 					}
@@ -788,7 +799,7 @@
 		}
 	],
 	"labels": {
-		"rhsso": "7.6.1.GA",
+		"rhsso": "7.6.2.GA",
 		"template": "sso76-postgresql-persistent"
 	}
 }

--- a/official/sso/templates/sso76-postgresql.json
+++ b/official/sso/templates/sso76-postgresql.json
@@ -13,7 +13,7 @@
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
 			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.6 on OpenJDK server based deployment, deployment configuration for PostgreSQL using ephemeral (temporary) storage, and securing RH-SSO communication using passthrough TLS.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "7.6.1.GA"
+			"version": "7.6.2.GA"
 		}
 	},
 	"message": "A new RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests.",
@@ -390,6 +390,11 @@
 										"mountPath": "/etc/sso-secret-volume",
 										"name": "sso-truststore-volume",
 										"readOnly": true
+									},
+									{
+										"mountPath": "/mnt/rh-sso",
+										"name": "sso-probe-netrc-volume",
+										"readOnly": false
 									}
 								]
 							}
@@ -413,6 +418,12 @@
 								"secret": {
 									"secretName": "${SSO_TRUSTSTORE_SECRET}"
 								}
+							},
+							{
+								"emptyDir": {
+									"medium": "Memory"
+								},
+								"name": "sso-probe-netrc-volume"
 							}
 						]
 					}
@@ -766,7 +777,7 @@
 		}
 	],
 	"labels": {
-		"rhsso": "7.6.1.GA",
+		"rhsso": "7.6.2.GA",
 		"template": "sso76-postgresql"
 	}
 }


### PR DESCRIPTION

Corresponding erratum is: [RHSA-2023:1047](https://access.redhat.com/errata/RHSA-2023:1047)

@fbm3307 PTAL once got a chance

Thanks,
Jan