### PR TITLE
Remove jenkins maven and nodejs imagestreams

### DIFF
--- a/community.yaml
+++ b/community.yaml
@@ -127,18 +127,6 @@ data:
         suffix: centos
         tags:
           - okd
-      - location: https://raw.githubusercontent.com/openshift/jenkins/master/openshift/imagestreams/jenkins-agent-maven-okd.json
-        docs: https://github.com/openshift/origin/blob/master/examples/jenkins/README.md
-        regex: jenkins-agent-maven
-        suffix: ubi
-        tags:
-          - okd
-      - location: https://raw.githubusercontent.com/openshift/jenkins/master/openshift/imagestreams/jenkins-agent-nodejs-okd.json
-        docs: https://github.com/openshift/origin/blob/master/examples/jenkins/README.md
-        regex: jenkins-agent-nodejs
-        suffix: ubi
-        tags:
-          - okd
   mariadb:
     imagestreams:
       - location: https://raw.githubusercontent.com/sclorg/mariadb-container/master/imagestreams/mariadb-centos.json

--- a/official.yaml
+++ b/official.yaml
@@ -290,28 +290,6 @@ data:
           - arch_ppc64le
           - arch_s390x
           - arch_x86_64
-      - location: https://raw.githubusercontent.com/openshift/jenkins/master/openshift/imagestreams/jenkins-agent-maven-ocp.json
-        docs: https://github.com/openshift/origin/blob/master/examples/jenkins/README.md
-        regex: jenkins-agent-maven
-        suffix: rhel
-        tags:
-          - ocp
-          - online-professional
-          - arch_aarch64
-          - arch_ppc64le
-          - arch_s390x
-          - arch_x86_64
-      - location: https://raw.githubusercontent.com/openshift/jenkins/master/openshift/imagestreams/jenkins-agent-nodejs-ocp.json
-        docs: https://github.com/openshift/origin/blob/master/examples/jenkins/README.md
-        regex: jenkins-agent-nodejs
-        suffix: rhel
-        tags:
-          - ocp
-          - online-professional
-          - arch_aarch64
-          - arch_ppc64le
-          - arch_s390x
-          - arch_x86_64
   httpd:
     imagestreams:
       - location: https://raw.githubusercontent.com/sclorg/httpd-container/master/imagestreams/httpd-rhel.json


### PR DESCRIPTION
Remove the Jenkins maven and nodejs imagestreams from the library as they are deprecated.

Ref PR: https://github.com/openshift/jenkins/pull/1660