### PR TITLE
RHSSO-2511 Update RH-SSO templates & image-streams to '7.6.4.GA' release/tag

### DIFF
--- a/official.yaml
+++ b/official.yaml
@@ -3,7 +3,7 @@ variables:
   openjdk_version: release
   amq_version: ose-v1.4.18
   rhsso75_tag: v7.5.3.GA
-  rhsso76_tag: v7.6.3.GA
+  rhsso76_tag: v7.6.4.GA
   webserver5el8_version: jws57el8-v5.7.3
   datagrid_version: 7.3-v1.9
   rhamp_version: master

--- a/official/sso/imagestreams/sso76-openshift-rhel8.json
+++ b/official/sso/imagestreams/sso76-openshift-rhel8.json
@@ -8,7 +8,7 @@
 			"description": "Red Hat Single Sign-On 7.6 on OpenJDK",
 			"openshift.io/display-name": "Red Hat Single Sign-On 7.6 on OpenJDK",
 			"openshift.io/provider-display-name": "Red Hat, Inc.",
-			"version": "7.6.3.GA"
+			"version": "7.6.4.GA"
 		}
 	},
 	"spec": {

--- a/official/sso/templates/sso76-ocp4-https.json
+++ b/official/sso/templates/sso76-ocp4-https.json
@@ -13,7 +13,7 @@
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
 			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.6 on OpenJDK server based deployment, securing RH-SSO communication using passthrough TLS. It is intended to be used solely on OpenShift 4.X versions. For OpenShift 3.X variant of this template refer to the 'sso76-ocp3-https' one.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "7.6.3.GA"
+			"version": "7.6.4.GA"
 		}
 	},
 	"message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests. To enable also dual-network clusters that support both IPv4 and IPv6 address families, all services defined by this template are configured having the 'spec.ipFamilyPolicy' field set to 'PreferDualStack' by default.",
@@ -553,7 +553,7 @@
 		}
 	],
 	"labels": {
-		"rhsso": "7.6.3.GA",
+		"rhsso": "7.6.4.GA",
 		"template": "sso76-ocp4-https"
 	}
 }

--- a/official/sso/templates/sso76-ocp4-postgresql-persistent.json
+++ b/official/sso/templates/sso76-ocp4-postgresql-persistent.json
@@ -13,7 +13,7 @@
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
 			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.6 on OpenJDK server based deployment, deployment configuration for PostgreSQL using persistence, and securing RH-SSO communication using passthrough TLS. It is intended to be used solely on OpenShift 4.X versions. For OpenShift 3.X variant of this template refer to the 'sso76-ocp3-postgresql-persistent' one.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "7.6.3.GA"
+			"version": "7.6.4.GA"
 		}
 	},
 	"message": "A new persistent RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests. To enable also dual-network clusters that support both IPv4 and IPv6 address families, all services defined by this template are configured having the 'spec.ipFamilyPolicy' field set to 'PreferDualStack' by default.",
@@ -803,7 +803,7 @@
 		}
 	],
 	"labels": {
-		"rhsso": "7.6.3.GA",
+		"rhsso": "7.6.4.GA",
 		"template": "sso76-ocp4-postgresql-persistent"
 	}
 }

--- a/official/sso/templates/sso76-ocp4-postgresql.json
+++ b/official/sso/templates/sso76-ocp4-postgresql.json
@@ -13,7 +13,7 @@
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
 			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.6 on OpenJDK server based deployment, deployment configuration for PostgreSQL using ephemeral (temporary) storage, and securing RH-SSO communication using passthrough TLS. It is intended to be used solely on OpenShift 4.X versions. For OpenShift 3.X variant of this template refer to the 'sso76-ocp3-postgresql' one.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "7.6.3.GA"
+			"version": "7.6.4.GA"
 		}
 	},
 	"message": "A new RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications; \"${SSO_TRUSTSTORE_SECRET}\" containing the ${SSO_TRUSTSTORE} file used for securing RH-SSO requests. To enable also dual-network clusters that support both IPv4 and IPv6 address families, all services defined by this template are configured having the 'spec.ipFamilyPolicy' field set to 'PreferDualStack' by default.",
@@ -781,7 +781,7 @@
 		}
 	],
 	"labels": {
-		"rhsso": "7.6.3.GA",
+		"rhsso": "7.6.4.GA",
 		"template": "sso76-ocp4-postgresql"
 	}
 }

--- a/official/sso/templates/sso76-ocp4-x509-https.json
+++ b/official/sso/templates/sso76-ocp4-x509-https.json
@@ -13,7 +13,7 @@
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
 			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.6 on OpenJDK server based deployment, securing RH-SSO communication using re-encrypt TLS. It is intended to be used solely on OpenShift 4.X versions. For OpenShift 3.X variant of this template refer to the 'sso76-ocp3-x509-https' one.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "7.6.3.GA"
+			"version": "7.6.4.GA"
 		}
 	},
 	"message": "A new RH-SSO service has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets by using a CA bundle that is automatically injected into any configMap annotated with 'service.beta.openshift.io/inject-cabundle=true' annotation. Refer to: https://github.com/openshift/openshift-docs/blob/enterprise-4.1/release_notes/ocp-4-1-release-notes.adoc#service-ca-bundle-changes for additional details about this CA bundle. To enable also dual-network clusters that support both IPv4 and IPv6 address families, all services defined by this template are configured having the 'spec.ipFamilyPolicy' field set to 'PreferDualStack' by default.",
@@ -400,7 +400,7 @@
 		}
 	],
 	"labels": {
-		"rhsso": "7.6.3.GA",
+		"rhsso": "7.6.4.GA",
 		"template": "sso76-ocp4-x509-https"
 	}
 }

--- a/official/sso/templates/sso76-ocp4-x509-postgresql-persistent.json
+++ b/official/sso/templates/sso76-ocp4-x509-postgresql-persistent.json
@@ -13,7 +13,7 @@
 			"template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
 			"template.openshift.io/long-description": "This template defines resources needed to develop Red Hat Single Sign-On 7.6 on OpenJDK server based deployment, deployment configuration for PostgreSQL using persistence, and securing RH-SSO communication using re-encrypt TLS. It is intended to be used solely on OpenShift 4.X versions. For OpenShift 3.X variant of this template refer to the 'sso76-ocp3-x509-postgresql-persistent' one.",
 			"template.openshift.io/support-url": "https://access.redhat.com",
-			"version": "7.6.3.GA"
+			"version": "7.6.4.GA"
 		}
 	},
 	"message": "A new persistent RH-SSO service (using PostgreSQL) has been created in your project. The admin username/password for accessing the master realm via the RH-SSO console is ${SSO_ADMIN_USERNAME}/${SSO_ADMIN_PASSWORD}. The username/password for accessing the PostgreSQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. The HTTPS keystore used for serving secure content, the JGroups keystore used for securing JGroups communications, and server truststore used for securing RH-SSO requests were automatically created via OpenShift's service serving x509 certificate secrets by using a CA bundle that is automatically injected into any configMap annotated with 'service.beta.openshift.io/inject-cabundle=true' annotation. Refer to: https://github.com/openshift/openshift-docs/blob/enterprise-4.1/release_notes/ocp-4-1-release-notes.adoc#service-ca-bundle-changes for additional details about this CA bundle. To enable also dual-network clusters that support both IPv4 and IPv6 address families, all services defined by this template are configured having the 'spec.ipFamilyPolicy' field set to 'PreferDualStack' by default.",
@@ -649,7 +649,7 @@
 		}
 	],
 	"labels": {
-		"rhsso": "7.6.3.GA",
+		"rhsso": "7.6.4.GA",
 		"template": "sso76-ocp4-x509-postgresql-persistent"
 	}
 }


### PR DESCRIPTION
[RHSSO-2511](https://issues.redhat.com//browse/RHSSO-2511) Update RH-SSO templates & image-streams to '7.6.4.GA' release/tag
Relevant erratum is RHSA-2023:3888
